### PR TITLE
#4 Set batch size as a parameter in createFromFileBatchAsync

### DIFF
--- a/music-commons-api/src/main/kotlin/net/transgressoft/commons/music/audio/AudioLibrary.kt
+++ b/music-commons-api/src/main/kotlin/net/transgressoft/commons/music/audio/AudioLibrary.kt
@@ -117,7 +117,11 @@ interface AudioLibrary<I: ReactiveAudioItem<I>, AC: ReactiveArtistCatalog<AC, I>
     /**
      * Creates audio items asynchronously from a batch of file paths using the specified dispatcher.
      *
-     * The files are processed in batches of 500 for optimal performance.
+     * +     * The files are processed in batches of [batchSize] (default: 500).
+     * +     *
+     * +     * `@param` audioItemPaths File paths to process
+     * +     * `@param` dispatcher Dispatcher used for coroutine execution
+     * +     * `@param` batchSize Number of files per chunk; must be greater than 0
      */
     fun createFromFileBatchAsync(audioItemPaths: Collection<Path>, dispatcher: CoroutineDispatcher, batchSize: Int = 500): CompletableFuture<List<I>> {
         require(batchSize > 0) { "Batch size must be greater than 0" }

--- a/music-commons-api/src/main/kotlin/net/transgressoft/commons/music/audio/AudioLibrary.kt
+++ b/music-commons-api/src/main/kotlin/net/transgressoft/commons/music/audio/AudioLibrary.kt
@@ -119,8 +119,8 @@ interface AudioLibrary<I: ReactiveAudioItem<I>, AC: ReactiveArtistCatalog<AC, I>
      *
      * The files are processed in batches of 500 for optimal performance.
      */
-    fun createFromFileBatchAsync(audioItemPaths: Collection<Path>, dispatcher: CoroutineDispatcher): CompletableFuture<List<I>> {
-        val batchSize = 500 // TODO #4 Parameterize this magic constant for customization
+    fun createFromFileBatchAsync(audioItemPaths: Collection<Path>, dispatcher: CoroutineDispatcher, batchSize: Int = 500): CompletableFuture<List<I>> {
+        require(batchSize > 0) { "Batch size must be greater than 0" }
         return CoroutineScope(dispatcher).future {
             audioItemPaths.chunked(batchSize).map { batch ->
                 async {


### PR DESCRIPTION
Made the batch size configurable by introducing it as a method parameter with a default value of 500. Added input validation to ensure the batch size is greater than 0, improving flexibility and robustness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Audio library batch processing now accepts a configurable batch size (defaults to 500 items per batch).

* **Improvements**
  * Added validation to ensure the provided batch size is a positive number and the processing uses the supplied size for chunking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->