### PR TITLE
#18 Reduce code duplication across core and FX modules

### DIFF
--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/AudioItemMetadataUtils.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/AudioItemMetadataUtils.kt
@@ -1,0 +1,302 @@
+/******************************************************************************
+ * Copyright (C) 2025  Octavio Calleya Garcia                                 *
+ *                                                                            *
+ * This program is free software: you can redistribute it and/or modify       *
+ * it under the terms of the GNU General Public License as published by       *
+ * the Free Software Foundation, either version 3 of the License, or          *
+ * (at your option) any later version.                                        *
+ *                                                                            *
+ * This program is distributed in the hope that it will be useful,            *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
+ * GNU General Public License for more details.                               *
+ *                                                                            *
+ * You should have received a copy of the GNU General Public License          *
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.     *
+ ******************************************************************************/
+
+package net.transgressoft.commons.music.audio
+
+import net.transgressoft.commons.music.AudioUtils
+import net.transgressoft.commons.music.audio.AudioFileType.FLAC
+import net.transgressoft.commons.music.audio.AudioFileType.MP3
+import net.transgressoft.commons.music.audio.AudioFileType.WAV
+import com.neovisionaries.i18n.CountryCode
+import mu.KLogger
+import org.jaudiotagger.audio.AudioFileIO
+import org.jaudiotagger.audio.AudioHeader
+import org.jaudiotagger.audio.wav.WavOptions
+import org.jaudiotagger.tag.FieldKey
+import org.jaudiotagger.tag.Tag
+import org.jaudiotagger.tag.TagOptionSingleton
+import org.jaudiotagger.tag.flac.FlacTag
+import org.jaudiotagger.tag.id3.ID3v24Tag
+import org.jaudiotagger.tag.images.Artwork
+import org.jaudiotagger.tag.images.ArtworkFactory
+import org.jaudiotagger.tag.mp4.Mp4Tag
+import org.jaudiotagger.tag.wav.WavInfoTag
+import org.jaudiotagger.tag.wav.WavTag
+import java.io.IOException
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardOpenOption
+import java.time.Duration
+
+/**
+ * Holds all metadata extracted from an audio file, using only plain Kotlin/Java types.
+ *
+ * Returned by [AudioItemMetadataUtils.readMetadata] so that audio item implementations
+ * never need to depend on JAudioTagger types directly.
+ */
+data class AudioFileMetadata(
+    val bitRate: Int,
+    val duration: Duration,
+    val encoder: String?,
+    val encoding: String?,
+    val title: String,
+    val artist: Artist,
+    val album: Album,
+    val genre: Genre,
+    val comments: String?,
+    val trackNumber: Short?,
+    val discNumber: Short?,
+    val bpm: Float?,
+    val coverBytes: ByteArray?
+)
+
+/**
+ * Shared utility object centralizing all JAudioTagger metadata read and write operations.
+ *
+ * Isolates JAudioTagger-dependent code from [net.transgressoft.commons.music.audio.MutableAudioItem]
+ * and [net.transgressoft.commons.fx.music.audio.FXAudioItem], creating a clean seam for future
+ * library replacement. Both audio item implementations delegate metadata operations to this object
+ * rather than depending on JAudioTagger types.
+ *
+ * The public API consists of [readMetadata], [readCoverBytes], and [writeMetadataToFile].
+ * All JAudioTagger type references are confined to this object.
+ */
+object AudioItemMetadataUtils {
+
+    /**
+     * Reads all metadata from the audio file at [path] and returns it as an [AudioFileMetadata]
+     * value object containing only plain Kotlin/Java types.
+     *
+     * @param path path to the audio file
+     * @param extension file extension used to determine compilation flag parsing (m4a vs others)
+     */
+    fun readMetadata(path: Path, extension: String): AudioFileMetadata {
+        val audioFile = AudioFileIO.read(path.toFile())
+        val header = audioFile.audioHeader
+        val tag = audioFile.tag
+        return AudioFileMetadata(
+            bitRate = parseBitRate(header),
+            duration = Duration.ofSeconds(header.trackLength.toLong()),
+            encoder = getFieldIfExisting(tag, FieldKey.ENCODER),
+            encoding = header.encodingType,
+            title = getFieldIfExisting(tag, FieldKey.TITLE) ?: "",
+            artist = parseArtist(tag),
+            album = parseAlbum(tag, extension),
+            genre = getFieldIfExisting(tag, FieldKey.GENRE)?.let { Genre.parseGenre(it) } ?: Genre.UNDEFINED,
+            comments = getFieldIfExisting(tag, FieldKey.COMMENT)?.takeIf { it.isNotEmpty() },
+            trackNumber = parseOptionalShort(getFieldIfExisting(tag, FieldKey.TRACK)),
+            discNumber = parseOptionalShort(getFieldIfExisting(tag, FieldKey.DISC_NO)),
+            bpm = parseOptionalBpm(getFieldIfExisting(tag, FieldKey.BPM)),
+            coverBytes = parseCoverBytes(tag)
+        )
+    }
+
+    /**
+     * Reads the cover image bytes from the audio file at [path], or returns `null` if the file
+     * has no artwork or cannot be read.
+     */
+    fun readCoverBytes(path: Path): ByteArray? {
+        val file = path.toFile()
+        if (!file.exists() || !file.canRead()) return null
+        return parseCoverBytes(AudioFileIO.read(file).tag)
+    }
+
+    /**
+     * Writes metadata to the audio file at [path], creating the appropriate tag format and
+     * committing changes to disk.
+     *
+     * @param logger caller's logger for artwork error reporting
+     * @param fileName caller's file name for temp file naming during artwork creation
+     */
+    fun writeMetadataToFile(
+        path: Path,
+        title: String,
+        album: Album,
+        artist: Artist,
+        genre: Genre,
+        comments: String?,
+        trackNumber: Short?,
+        discNumber: Short?,
+        bpm: Float?,
+        encoder: String?,
+        coverImageBytes: ByteArray?,
+        fileName: String,
+        logger: KLogger
+    ) {
+        val audio = AudioFileIO.read(path.toFile())
+        createTag(
+            audio.audioHeader.format, title, album, artist, genre,
+            comments, trackNumber, discNumber, bpm, encoder,
+            coverImageBytes, fileName, logger
+        ).let {
+            audio.tag = it
+        }
+        audio.commit()
+    }
+
+    private fun getFieldIfExisting(tag: Tag, fieldKey: FieldKey): String? =
+        tag.hasField(fieldKey).takeIf { it }.run { tag.getFirst(fieldKey) }
+
+    private fun parseArtist(tag: Tag): Artist =
+        getFieldIfExisting(tag, FieldKey.ARTIST)?.let { artistName ->
+            val country =
+                getFieldIfExisting(tag, FieldKey.COUNTRY)?.let { _country ->
+                    if (_country.isNotEmpty()) CountryCode.valueOf(_country)
+                    else CountryCode.UNDEFINED
+                } ?: CountryCode.UNDEFINED
+            ImmutableArtist.of(AudioUtils.beautifyArtistName(artistName), country)
+        } ?: ImmutableArtist.UNKNOWN
+
+    private fun parseAlbum(tag: Tag, extension: String): ImmutableAlbum =
+        getFieldIfExisting(tag, FieldKey.ALBUM).let { albumName ->
+            return if (albumName == null) {
+                ImmutableAlbum.UNKNOWN
+            } else {
+                val albumArtistName = getFieldIfExisting(tag, FieldKey.ALBUM_ARTIST) ?: ""
+                val isCompilation =
+                    getFieldIfExisting(tag, FieldKey.IS_COMPILATION)?.let {
+                        if ("m4a" == extension) "1" == tag.getFirst(FieldKey.IS_COMPILATION)
+                        else "true" == tag.getFirst(FieldKey.IS_COMPILATION)
+                    } ?: false
+                val year = getFieldIfExisting(tag, FieldKey.YEAR)?.toShortOrNull()?.takeIf { it > 0 }
+                val label = getFieldIfExisting(tag, FieldKey.GROUPING)?.let { ImmutableLabel.of(it) } as Label
+                ImmutableAlbum(albumName, ImmutableArtist.of(AudioUtils.beautifyArtistName(albumArtistName)), isCompilation, year, label)
+            }
+        }
+
+    private fun parseBitRate(audioHeader: AudioHeader): Int {
+        val bitRate = audioHeader.bitRate
+        return if ("~" == bitRate.substring(0, 1)) {
+            bitRate.substring(1).toInt()
+        } else {
+            bitRate.toInt()
+        }
+    }
+
+    private fun parseCoverBytes(tag: Tag): ByteArray? = tag.artworkList.isNotEmpty().takeIf { it }?.let { tag.firstArtwork.binaryData }
+
+    private fun parseOptionalShort(value: String?): Short? =
+        value?.takeUnless { it.isEmpty().and(it == "0") }?.toShortOrNull()?.takeIf { it > 0 }
+
+    private fun parseOptionalBpm(value: String?): Float? =
+        value?.takeUnless { it.isEmpty().and(it == "0") }?.toFloatOrNull()?.takeIf { it > 0 }
+
+    private fun createTag(
+        format: String,
+        title: String,
+        album: Album,
+        artist: Artist,
+        genre: Genre,
+        comments: String?,
+        trackNumber: Short?,
+        discNumber: Short?,
+        bpm: Float?,
+        encoder: String?,
+        coverImageBytes: ByteArray?,
+        fileName: String,
+        logger: KLogger
+    ): Tag =
+        when {
+            format.startsWith(WAV.extension, ignoreCase = true) -> {
+                val wavTag = WavTag(WavOptions.READ_ID3_ONLY)
+                wavTag.iD3Tag = ID3v24Tag()
+                wavTag.infoTag = WavInfoTag()
+                wavTag
+            }
+
+            format.startsWith(MP3.extension, ignoreCase = true) -> {
+                TagOptionSingleton.getInstance().isWriteMp3GenresAsText = true
+                val tag: Tag = ID3v24Tag()
+                tag.artworkList.clear()
+                tag
+            }
+
+            format.startsWith(FLAC.extension, ignoreCase = true) -> {
+                val tag: Tag = FlacTag()
+                tag.artworkList.clear()
+                tag
+            }
+
+            format.startsWith("Aac", ignoreCase = true) -> {
+                TagOptionSingleton.getInstance().isWriteMp4GenresAsText = true
+                val tag: Tag = Mp4Tag()
+                tag.artworkList.clear()
+                tag
+            }
+
+            else -> {
+                WavInfoTag()
+            }
+        }.also {
+            setTrackFieldsToTag(it, title, album, artist, genre, comments, trackNumber, discNumber, bpm, encoder, coverImageBytes, fileName, logger)
+        }
+
+    private fun setTrackFieldsToTag(
+        tag: Tag,
+        title: String,
+        album: Album,
+        artist: Artist,
+        genre: Genre,
+        comments: String?,
+        trackNumber: Short?,
+        discNumber: Short?,
+        bpm: Float?,
+        encoder: String?,
+        coverImageBytes: ByteArray?,
+        fileName: String,
+        logger: KLogger
+    ) {
+        tag.setField(FieldKey.TITLE, title)
+        tag.setField(FieldKey.ALBUM, album.name)
+        tag.setField(FieldKey.ALBUM_ARTIST, album.albumArtist.name)
+        tag.setField(FieldKey.ARTIST, artist.name)
+        tag.setField(FieldKey.GENRE, genre.capitalize())
+        tag.setField(FieldKey.COUNTRY, artist.countryCode.name)
+        comments?.let { tag.setField(FieldKey.COMMENT, it) }
+        trackNumber?.let { tag.setField(FieldKey.TRACK, it.toString()) }
+        album.year?.let { tag.setField(FieldKey.YEAR, it.toString()) }
+        tag.setField(FieldKey.ENCODER, encoder)
+        tag.setField(FieldKey.GROUPING, album.label.name)
+        discNumber?.let { tag.setField(FieldKey.DISC_NO, it.toString()) }
+        tag.setField(FieldKey.IS_COMPILATION, album.isCompilation.toString())
+        bpm?.let {
+            if (tag is Mp4Tag) {
+                tag.setField(FieldKey.BPM, it.toInt().toString())
+            } else {
+                tag.setField(FieldKey.BPM, it.toString())
+            }
+        }
+        coverImageBytes?.let {
+            tag.deleteArtworkField()
+            tag.addField(createArtwork(it, fileName, logger))
+        }
+    }
+
+    private fun createArtwork(coverBytes: ByteArray, fileName: String, logger: KLogger): Artwork {
+        val tempCover: Path
+        try {
+            tempCover = Files.createTempFile("tempCover_$fileName", ".tmp")
+            Files.write(tempCover, coverBytes, StandardOpenOption.CREATE)
+            tempCover.toFile().deleteOnExit()
+            return ArtworkFactory.createArtworkFromFile(tempCover.toFile())
+        } catch (exception: IOException) {
+            val errorText = "Error creating artwork of $fileName"
+            logger.error(errorText, exception)
+            throw AudioItemManipulationException(errorText, exception)
+        }
+    }
+}

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/AudioItemSerializer.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/AudioItemSerializer.kt
@@ -54,64 +54,110 @@ val AudioItemMapSerializer: KSerializer<Map<Int, AudioItem>> = MapSerializer(Int
  * fields including artist, album, and label information. Creates [MutableAudioItem]
  * instances during deserialization to enable metadata modification.
  */
-internal object AudioItemSerializer: AudioItemSerializerBase<AudioItem>() {
+internal object AudioItemSerializer : AudioItemSerializerBase<AudioItem>() {
 
-    override fun createInstance(propertiesList: List<Any?>): AudioItem =
+    override fun constructEntity(
+        path: Path,
+        id: Int,
+        title: String,
+        duration: Duration,
+        bitRate: Int,
+        artist: Artist,
+        album: Album,
+        genre: Genre,
+        comments: String?,
+        trackNumber: Short?,
+        discNumber: Short?,
+        bpm: Float?,
+        encoder: String?,
+        encoding: String?,
+        dateOfCreation: LocalDateTime,
+        lastDateModified: LocalDateTime,
+        playCount: Short
+    ): AudioItem =
         MutableAudioItem(
-            // path
-            propertiesList[0] as Path,
-            // id
-            propertiesList[1] as Int,
-            // title
-            propertiesList[2] as String,
-            // duration
-            propertiesList[3] as Duration,
-            // bitRate
-            propertiesList[4] as Int,
-            // artist name and artist country code
-            ImmutableArtist.of(propertiesList[5] as String, CountryCode.getByCode(propertiesList[6] as String)),
-            ImmutableAlbum(
-                // album name
-                propertiesList[7] as String,
-                // album artist name
-                ImmutableArtist.of(propertiesList[8] as String),
-                // album isCompilation
-                propertiesList[9] as Boolean,
-                // album year
-                propertiesList[10] as Short?,
-                // album label name
-                ImmutableLabel.of(propertiesList[11] as String)
-            ),
-            // genre
-            Genre.parseGenre(propertiesList[12] as String),
-            // comments
-            propertiesList[13] as String?,
-            // trackNumber
-            propertiesList[14] as Short?,
-            // discNumber
-            propertiesList[15] as Short?,
-            // bpm
-            propertiesList[16] as Float?,
-            // encoder
-            propertiesList[17] as String?,
-            // encoding
-            propertiesList[18] as String?,
-            // dateOfCreation
-            propertiesList[19] as LocalDateTime,
-            // lastDateModified
-            propertiesList[20] as LocalDateTime,
-            // playCount
-            propertiesList[21] as Short
+            path, id, title, duration, bitRate, artist, album, genre,
+            comments, trackNumber, discNumber, bpm, encoder, encoding,
+            dateOfCreation, lastDateModified, playCount
         )
 }
 
-abstract class AudioItemSerializerBase<I: ReactiveAudioItem<I>>: LirpEntityPolymorphicSerializer<I> {
+abstract class AudioItemSerializerBase<I : ReactiveAudioItem<I>> : LirpEntityPolymorphicSerializer<I> {
 
     override val descriptor: SerialDescriptor =
         buildClassSerialDescriptor("AudioItem") {
             element<String>("id")
             element<String>("path")
         }
+
+    /**
+     * Constructs a concrete audio item instance from deserialized properties.
+     *
+     * @param path audio file path
+     * @param id entity identifier
+     * @param title track title
+     * @param duration track duration
+     * @param bitRate audio bitrate in kbps
+     * @param artist track artist
+     * @param album track album
+     * @param genre track genre
+     * @param comments optional comments
+     * @param trackNumber optional track number
+     * @param discNumber optional disc number
+     * @param bpm optional beats per minute
+     * @param encoder optional encoder name
+     * @param encoding optional encoding type
+     * @param dateOfCreation creation timestamp
+     * @param lastDateModified last modification timestamp
+     * @param playCount number of times played
+     */
+    protected abstract fun constructEntity(
+        path: Path,
+        id: Int,
+        title: String,
+        duration: Duration,
+        bitRate: Int,
+        artist: Artist,
+        album: Album,
+        genre: Genre,
+        comments: String?,
+        trackNumber: Short?,
+        discNumber: Short?,
+        bpm: Float?,
+        encoder: String?,
+        encoding: String?,
+        dateOfCreation: LocalDateTime,
+        lastDateModified: LocalDateTime,
+        playCount: Short
+    ): I
+
+    override fun createInstance(propertiesList: List<Any?>): I =
+        constructEntity(
+            path = propertiesList[0] as Path,
+            id = propertiesList[1] as Int,
+            title = propertiesList[2] as String,
+            duration = propertiesList[3] as Duration,
+            bitRate = propertiesList[4] as Int,
+            artist = ImmutableArtist.of(propertiesList[5] as String, CountryCode.getByCode(propertiesList[6] as String)),
+            album =
+                ImmutableAlbum(
+                    propertiesList[7] as String,
+                    ImmutableArtist.of(propertiesList[8] as String),
+                    propertiesList[9] as Boolean,
+                    propertiesList[10] as Short?,
+                    ImmutableLabel.of(propertiesList[11] as String)
+                ),
+            genre = Genre.parseGenre(propertiesList[12] as String),
+            comments = propertiesList[13] as String?,
+            trackNumber = propertiesList[14] as Short?,
+            discNumber = propertiesList[15] as Short?,
+            bpm = propertiesList[16] as Float?,
+            encoder = propertiesList[17] as String?,
+            encoding = propertiesList[18] as String?,
+            dateOfCreation = propertiesList[19] as LocalDateTime,
+            lastDateModified = propertiesList[20] as LocalDateTime,
+            playCount = propertiesList[21] as Short
+        )
 
     override fun getPropertiesList(decoder: Decoder): List<Any?> {
         val propertiesList = mutableListOf<Any?>()

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/MutableAudioItem.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/MutableAudioItem.kt
@@ -17,31 +17,15 @@
 
 package net.transgressoft.commons.music.audio
 
-import net.transgressoft.commons.music.AudioUtils
 import net.transgressoft.commons.music.AudioUtils.audioItemTrackDiscNumberComparator
-import net.transgressoft.commons.music.audio.AudioFileType.FLAC
-import net.transgressoft.commons.music.audio.AudioFileType.MP3
-import net.transgressoft.commons.music.audio.AudioFileType.WAV
+import net.transgressoft.commons.music.AudioUtils.getArtistsNamesInvolved
+import net.transgressoft.commons.music.audio.AudioItemMetadataUtils.readCoverBytes
+import net.transgressoft.commons.music.audio.AudioItemMetadataUtils.readMetadata
+import net.transgressoft.commons.music.audio.AudioItemMetadataUtils.writeMetadataToFile
 import net.transgressoft.lirp.entity.ReactiveEntityBase
-import com.neovisionaries.i18n.CountryCode
 import mu.KotlinLogging
-import org.jaudiotagger.audio.AudioFileIO
-import org.jaudiotagger.audio.AudioHeader
-import org.jaudiotagger.audio.wav.WavOptions
-import org.jaudiotagger.tag.FieldKey
-import org.jaudiotagger.tag.Tag
-import org.jaudiotagger.tag.TagOptionSingleton
-import org.jaudiotagger.tag.flac.FlacTag
-import org.jaudiotagger.tag.id3.ID3v24Tag
-import org.jaudiotagger.tag.images.Artwork
-import org.jaudiotagger.tag.images.ArtworkFactory
-import org.jaudiotagger.tag.mp4.Mp4Tag
-import org.jaudiotagger.tag.wav.WavInfoTag
-import org.jaudiotagger.tag.wav.WavTag
-import java.io.IOException
 import java.nio.file.Files
 import java.nio.file.Path
-import java.nio.file.StandardOpenOption
 import java.time.Duration
 import java.time.LocalDateTime
 import java.util.Objects
@@ -77,6 +61,7 @@ interface AudioItem : ReactiveAudioItem<AudioItem> {
  *
  * The implementation automatically extracts metadata from the file on construction and
  * lazily caches immutable properties like duration and bitrate for performance.
+ * All JAudioTagger operations are delegated to [AudioItemMetadataUtils].
  *
  * @see <a href=https://www.jthink.net/jaudiotagger/>JAudioTagger website</a>
  */
@@ -142,13 +127,7 @@ internal class MutableAudioItem(
     }
 
     @Transient
-    private val audioFile = AudioFileIO.read(path.toFile())
-
-    @Transient
-    private val audioHeader = audioFile.audioHeader
-
-    @Transient
-    private val tag: Tag = audioFile.tag
+    private val metadata = readMetadata(path, path.extension)
 
     init {
         require(Files.exists(path)) { "File '${path.toAbsolutePath()}' does not exist" }
@@ -156,22 +135,22 @@ internal class MutableAudioItem(
 
     /** Immutable properties */
 
-    private var _bitRate: Int = getBitRate(audioHeader)
+    private var _bitRate: Int = metadata.bitRate
 
     @Serializable
     override val bitRate: Int = _bitRate
 
-    private var _duration: Duration = Duration.ofSeconds(audioHeader.trackLength.toLong())
+    private var _duration: Duration = metadata.duration
 
     @Serializable
     override val duration: Duration = _duration
 
-    private var _encoder: String? = getFieldIfExisting(tag, FieldKey.ENCODER)?.takeIf { it.isNotEmpty() }
+    private var _encoder: String? = metadata.encoder?.takeIf { it.isNotEmpty() }
 
     @Serializable
     override val encoder: String? = _encoder
 
-    private var _encoding: String? = audioHeader.encodingType.takeIf { it.isNotEmpty() }
+    private var _encoding: String? = metadata.encoding?.takeIf { it.isNotEmpty() }
 
     @Serializable
     override val encoding: String? = _encoding
@@ -202,7 +181,7 @@ internal class MutableAudioItem(
     }
 
     override val artistsInvolved
-        get() = AudioUtils.getArtistsNamesInvolved(title, artist.name, album.albumArtist.name).map { ImmutableArtist.of(it) }.toSet()
+        get() = getArtistsNamesInvolved(title, artist.name, album.albumArtist.name).map { ImmutableArtist.of(it) }.toSet()
 
     override val length by lazy {
         path.toFile().length()
@@ -220,106 +199,59 @@ internal class MutableAudioItem(
     /** Mutable properties */
 
     @Serializable
-    override var title: String = getFieldIfExisting(tag, FieldKey.TITLE) ?: ""
+    override var title: String = metadata.title
         set(value) {
             if (!suppressEvents) mutateAndPublish { field = value } else field = value
         }
 
     @Serializable
-    override var artist: Artist = readArtist(tag)
+    override var artist: Artist = metadata.artist
         set(value) {
             if (!suppressEvents) mutateAndPublish { field = value } else field = value
         }
 
     @Serializable
-    override var genre: Genre = getFieldIfExisting(tag, FieldKey.GENRE)?.let { Genre.parseGenre(it) } ?: Genre.UNDEFINED
+    override var genre: Genre = metadata.genre
         set(value) {
             if (!suppressEvents) mutateAndPublish { field = value } else field = value
         }
 
     @Serializable
-    override var comments: String? = getFieldIfExisting(tag, FieldKey.COMMENT)?.takeIf { it.isNotEmpty() }
+    override var comments: String? = metadata.comments
         set(value) {
             if (!suppressEvents) mutateAndPublish { field = value } else field = value
         }
 
     @Serializable
-    override var trackNumber: Short? = getFieldIfExisting(tag, FieldKey.TRACK)?.takeUnless { it.isEmpty().and(it == "0") }?.toShortOrNull()?.takeIf { it > 0 }
+    override var trackNumber: Short? = metadata.trackNumber
         set(value) {
             if (!suppressEvents) mutateAndPublish { field = value } else field = value
         }
 
     @Serializable
-    override var discNumber: Short? = getFieldIfExisting(tag, FieldKey.DISC_NO)?.takeUnless { it.isEmpty().and(it == "0") }?.toShortOrNull()?.takeIf { it > 0 }
+    override var discNumber: Short? = metadata.discNumber
         set(value) {
             if (!suppressEvents) mutateAndPublish { field = value } else field = value
         }
 
     @Serializable
-    override var bpm: Float? = getFieldIfExisting(tag, FieldKey.BPM)?.takeUnless { it.isEmpty().and(it == "0") }?.toFloatOrNull()?.takeIf { it > 0 }
+    override var bpm: Float? = metadata.bpm
         set(value) {
             if (!suppressEvents) mutateAndPublish { field = value } else field = value
         }
 
     @Serializable
-    override var album: Album = readAlbum(tag, path.extension)
+    override var album: Album = metadata.album
         set(value) {
             if (!suppressEvents) mutateAndPublish { field = value } else field = value
         }
 
     @Transient
-    override var coverImageBytes: ByteArray? = getCoverBytes(tag)
-        get() = field ?: getCoverBytes()
+    override var coverImageBytes: ByteArray? = metadata.coverBytes
+        get() = field ?: readCoverBytes(path)
         set(value) {
             if (!suppressEvents) mutateAndPublish { field = value } else field = value
         }
-
-    private fun getFieldIfExisting(tag: Tag, fieldKey: FieldKey): String? = tag.hasField(fieldKey).takeIf { it }.run { tag.getFirst(fieldKey) }
-
-    private fun readArtist(tag: Tag): Artist =
-        getFieldIfExisting(tag, FieldKey.ARTIST)?.let { artistName ->
-            val country =
-                getFieldIfExisting(tag, FieldKey.COUNTRY)?.let { _country ->
-                    if (_country.isNotEmpty()) CountryCode.valueOf(_country)
-                    else CountryCode.UNDEFINED
-                } ?: CountryCode.UNDEFINED
-            ImmutableArtist.of(AudioUtils.beautifyArtistName(artistName), country)
-        } ?: ImmutableArtist.UNKNOWN
-
-    private fun readAlbum(tag: Tag, extension: String): ImmutableAlbum =
-        getFieldIfExisting(tag, FieldKey.ALBUM).let { albumName ->
-            return if (albumName == null) {
-                ImmutableAlbum.UNKNOWN
-            } else {
-                val albumArtistName = getFieldIfExisting(tag, FieldKey.ALBUM_ARTIST) ?: ""
-                val isCompilation =
-                    getFieldIfExisting(tag, FieldKey.IS_COMPILATION)?.let {
-                        if ("m4a" == extension) "1" == tag.getFirst(FieldKey.IS_COMPILATION)
-                        else "true" == tag.getFirst(FieldKey.IS_COMPILATION)
-                    } ?: false
-                val year = getFieldIfExisting(tag, FieldKey.YEAR)?.toShortOrNull()?.takeIf { it > 0 }
-                val label = getFieldIfExisting(tag, FieldKey.GROUPING)?.let { ImmutableLabel.of(it) } as Label
-                ImmutableAlbum(albumName, ImmutableArtist.of(AudioUtils.beautifyArtistName(albumArtistName)), isCompilation, year, label)
-            }
-        }
-
-    private fun getBitRate(audioHeader: AudioHeader): Int {
-        val bitRate = audioHeader.bitRate
-        return if ("~" == bitRate.substring(0, 1)) {
-            bitRate.substring(1).toInt()
-        } else {
-            bitRate.toInt()
-        }
-    }
-
-    private fun getCoverBytes(): ByteArray? =
-        path.toFile().let {
-            if (it.exists() && it.canRead())
-                getCoverBytes(AudioFileIO.read(it).tag)
-            else null
-        }
-
-    private fun getCoverBytes(tag: Tag): ByteArray? = tag.artworkList.isNotEmpty().takeIf { it }?.let { tag.firstArtwork.binaryData }
 
     /**
      * Asynchronously writes the current metadata back to the audio file.
@@ -331,92 +263,13 @@ internal class MutableAudioItem(
     override fun writeMetadata(): Job =
         ioScope.launch {
             logger.debug { "Writing metadata of $this to file '${path.toAbsolutePath()}'" }
-            val audioFile = path.toFile()
-            val audio = AudioFileIO.read(audioFile)
-            createTag(audio.audioHeader.format).let {
-                audio.tag = it
-            }
-
-            audio.commit()
+            writeMetadataToFile(
+                path, title, album, artist, genre,
+                comments, trackNumber, discNumber, bpm, encoder,
+                coverImageBytes, fileName, logger
+            )
             logger.debug { "Metadata of $this successfully written to file" }
         }
-
-    private fun createTag(format: String): Tag =
-        when {
-            format.startsWith(WAV.extension, ignoreCase = true) -> {
-                val wavTag = WavTag(WavOptions.READ_ID3_ONLY)
-                wavTag.iD3Tag = ID3v24Tag()
-                wavTag.infoTag = WavInfoTag()
-                wavTag
-            }
-
-            format.startsWith(MP3.extension, ignoreCase = true) -> {
-                TagOptionSingleton.getInstance().isWriteMp3GenresAsText = true
-                val tag: Tag = ID3v24Tag()
-                tag.artworkList.clear()
-                tag
-            }
-
-            format.startsWith(FLAC.extension, ignoreCase = true) -> {
-                val tag: Tag = FlacTag()
-                tag.artworkList.clear()
-                tag
-            }
-
-            format.startsWith("Aac", ignoreCase = true) -> {
-                TagOptionSingleton.getInstance().isWriteMp4GenresAsText = true
-                val tag: Tag = Mp4Tag()
-                tag.artworkList.clear()
-                tag
-            }
-
-            else -> {
-                WavInfoTag()
-            }
-        }.also {
-            setTrackFieldsToTag(it)
-        }
-
-    private fun setTrackFieldsToTag(tag: Tag) {
-        tag.setField(FieldKey.TITLE, title)
-        tag.setField(FieldKey.ALBUM, album.name)
-        tag.setField(FieldKey.ALBUM_ARTIST, album.albumArtist.name)
-        tag.setField(FieldKey.ARTIST, artist.name)
-        tag.setField(FieldKey.GENRE, genre.capitalize())
-        tag.setField(FieldKey.COUNTRY, artist.countryCode.name)
-        comments?.let { tag.setField(FieldKey.COMMENT, it) }
-        trackNumber?.let { tag.setField(FieldKey.TRACK, it.toString()) }
-        album.year?.let { tag.setField(FieldKey.YEAR, it.toString()) }
-        tag.setField(FieldKey.ENCODER, encoder)
-        tag.setField(FieldKey.GROUPING, album.label.name)
-        discNumber?.let { tag.setField(FieldKey.DISC_NO, it.toString()) }
-        tag.setField(FieldKey.IS_COMPILATION, album.isCompilation.toString())
-        bpm?.let {
-            if (tag is Mp4Tag) {
-                tag.setField(FieldKey.BPM, it.toInt().toString())
-            } else {
-                tag.setField(FieldKey.BPM, it.toString())
-            }
-        }
-        coverImageBytes?.let {
-            tag.deleteArtworkField()
-            tag.addField(createArtwork(it))
-        }
-    }
-
-    private fun createArtwork(coverBytes: ByteArray): Artwork {
-        val tempCover: Path
-        try {
-            tempCover = Files.createTempFile("tempCover_$fileName", ".tmp")
-            Files.write(tempCover, coverBytes, StandardOpenOption.CREATE)
-            tempCover.toFile().deleteOnExit()
-            return ArtworkFactory.createArtworkFromFile(tempCover.toFile())
-        } catch (exception: IOException) {
-            val errorText = "Error creating artwork of $this"
-            logger.error(errorText, exception)
-            throw AudioItemManipulationException(errorText, exception)
-        }
-    }
 
     internal fun incrementPlayCount() = _playCount++
 

--- a/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/audio/FXAudioItem.kt
+++ b/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/audio/FXAudioItem.kt
@@ -17,21 +17,16 @@
 
 package net.transgressoft.commons.fx.music.audio
 
-import net.transgressoft.commons.music.AudioUtils
+import net.transgressoft.commons.music.AudioUtils.audioItemTrackDiscNumberComparator
+import net.transgressoft.commons.music.AudioUtils.getArtistsNamesInvolved
 import net.transgressoft.commons.music.audio.Album
 import net.transgressoft.commons.music.audio.Artist
-import net.transgressoft.commons.music.audio.AudioFileType.FLAC
-import net.transgressoft.commons.music.audio.AudioFileType.MP3
-import net.transgressoft.commons.music.audio.AudioFileType.WAV
-import net.transgressoft.commons.music.audio.AudioItemManipulationException
+import net.transgressoft.commons.music.audio.AudioItemMetadataUtils.readMetadata
+import net.transgressoft.commons.music.audio.AudioItemMetadataUtils.writeMetadataToFile
 import net.transgressoft.commons.music.audio.Genre
-import net.transgressoft.commons.music.audio.ImmutableAlbum
 import net.transgressoft.commons.music.audio.ImmutableArtist
-import net.transgressoft.commons.music.audio.ImmutableLabel
-import net.transgressoft.commons.music.audio.Label
 import net.transgressoft.commons.music.audio.UNASSIGNED_ID
 import net.transgressoft.lirp.entity.ReactiveEntityBase
-import com.neovisionaries.i18n.CountryCode
 import javafx.beans.property.ObjectProperty
 import javafx.beans.property.ReadOnlyIntegerProperty
 import javafx.beans.property.ReadOnlyObjectProperty
@@ -45,24 +40,9 @@ import javafx.beans.property.StringProperty
 import javafx.collections.FXCollections
 import javafx.scene.image.Image
 import mu.KotlinLogging
-import org.jaudiotagger.audio.AudioFileIO
-import org.jaudiotagger.audio.AudioHeader
-import org.jaudiotagger.audio.wav.WavOptions
-import org.jaudiotagger.tag.FieldKey
-import org.jaudiotagger.tag.Tag
-import org.jaudiotagger.tag.TagOptionSingleton
-import org.jaudiotagger.tag.flac.FlacTag
-import org.jaudiotagger.tag.id3.ID3v24Tag
-import org.jaudiotagger.tag.images.Artwork
-import org.jaudiotagger.tag.images.ArtworkFactory
-import org.jaudiotagger.tag.mp4.Mp4Tag
-import org.jaudiotagger.tag.wav.WavInfoTag
-import org.jaudiotagger.tag.wav.WavTag
 import java.io.ByteArrayInputStream
-import java.io.IOException
 import java.nio.file.Files
 import java.nio.file.Path
-import java.nio.file.StandardOpenOption
 import java.time.Duration
 import java.time.LocalDateTime
 import java.util.Objects
@@ -146,13 +126,7 @@ class FXAudioItem internal constructor(override val path: Path, override val id:
         }
 
         @Transient
-        private val audioFile = AudioFileIO.read(path.toFile())
-
-        @Transient
-        private val audioHeader = audioFile.audioHeader
-
-        @Transient
-        private val tag: Tag = audioFile.tag
+        private val metadata = readMetadata(path, path.extension)
 
         init {
             require(Files.exists(path)) { "File '${path.toAbsolutePath()}' does not exist" }
@@ -160,21 +134,21 @@ class FXAudioItem internal constructor(override val path: Path, override val id:
 
         /** Immutable properties */
 
-        private var _bitRate: Int = getBitRate(audioHeader)
+        private var _bitRate: Int = metadata.bitRate
 
         @Serializable
         override val bitRate: Int = _bitRate
 
-        private var _duration: Duration = Duration.ofSeconds(audioHeader.trackLength.toLong())
+        private var _duration: Duration = metadata.duration
 
         override val duration: Duration = _duration
 
-        private var _encoder: String? = getFieldIfExisting(tag, FieldKey.ENCODER) ?: ""
+        private var _encoder: String? = metadata.encoder ?: ""
 
         @Serializable
         override val encoder: String? = _encoder
 
-        private var _encoding: String? = audioHeader.encodingType
+        private var _encoding: String? = metadata.encoding
 
         @Serializable
         override val encoding: String? = _encoding
@@ -211,14 +185,14 @@ class FXAudioItem internal constructor(override val path: Path, override val id:
 
         /** Mutable properties */
 
-        override var title: String = getFieldIfExisting(tag, FieldKey.TITLE) ?: ""
+        override var title: String = metadata.title
             set(value) {
                 if (!suppressEvents) {
                     mutateAndPublish {
                         field = value
                         artistsInvolvedProperty.clear()
                         artistsInvolvedProperty.addAll(
-                            AudioUtils.getArtistsNamesInvolved(
+                            getArtistsNamesInvolved(
                                 value, artistProperty.value.name, albumProperty.value.albumArtist.name
                             ).map { ImmutableArtist.of(it) }.toSet()
                         )
@@ -236,14 +210,14 @@ class FXAudioItem internal constructor(override val path: Path, override val id:
                 }
             }
 
-        override var artist: Artist = readArtist(tag)
+        override var artist: Artist = metadata.artist
             set(value) {
                 if (!suppressEvents) {
                     mutateAndPublish {
                         field = value
                         artistsInvolvedProperty.clear()
                         artistsInvolvedProperty.addAll(
-                            AudioUtils.getArtistsNamesInvolved(
+                            getArtistsNamesInvolved(
                                 titleProperty.value, value.name, albumProperty.value.albumArtist.name
                             ).map { ImmutableArtist.of(it) }.toSet()
                         )
@@ -261,14 +235,14 @@ class FXAudioItem internal constructor(override val path: Path, override val id:
                 }
             }
 
-        override var album: Album = readAlbum(tag, extension)
+        override var album: Album = metadata.album
             set(value) {
                 if (!suppressEvents) {
                     mutateAndPublish {
                         field = value
                         artistsInvolvedProperty.clear()
                         artistsInvolvedProperty.addAll(
-                            AudioUtils.getArtistsNamesInvolved(
+                            getArtistsNamesInvolved(
                                 titleProperty.value, artistProperty.value.name, value.albumArtist.name
                             ).map { ImmutableArtist.of(it) }.toSet()
                         )
@@ -286,7 +260,7 @@ class FXAudioItem internal constructor(override val path: Path, override val id:
                 }
             }
 
-        override var genre: Genre = getFieldIfExisting(tag, FieldKey.GENRE)?.let { Genre.parseGenre(it) } ?: Genre.UNDEFINED
+        override var genre: Genre = metadata.genre
             set(value) {
                 if (!suppressEvents) mutateAndPublish { field = value } else field = value
             }
@@ -299,7 +273,7 @@ class FXAudioItem internal constructor(override val path: Path, override val id:
                 }
             }
 
-        override var comments: String? = getFieldIfExisting(tag, FieldKey.COMMENT)?.takeIf { it.isNotEmpty() }
+        override var comments: String? = metadata.comments
             set(value) {
                 if (!suppressEvents) mutateAndPublish { field = value } else field = value
             }
@@ -312,8 +286,7 @@ class FXAudioItem internal constructor(override val path: Path, override val id:
                 }
             }
 
-        override var trackNumber: Short? =
-            getFieldIfExisting(tag, FieldKey.TRACK)?.takeUnless { it.isEmpty().and(it == "0") }?.toShortOrNull()?.takeIf { it > 0 }
+        override var trackNumber: Short? = metadata.trackNumber
             set(value) {
                 if (!suppressEvents) mutateAndPublish { field = value } else field = value
             }
@@ -326,8 +299,7 @@ class FXAudioItem internal constructor(override val path: Path, override val id:
                 }
             }
 
-        override var discNumber: Short? =
-            getFieldIfExisting(tag, FieldKey.DISC_NO)?.takeUnless { it.isEmpty().and(it == "0") }?.toShortOrNull()?.takeIf { it > 0 }
+        override var discNumber: Short? = metadata.discNumber
             set(value) {
                 if (!suppressEvents) mutateAndPublish { field = value } else field = value
             }
@@ -340,7 +312,7 @@ class FXAudioItem internal constructor(override val path: Path, override val id:
                 }
             }
 
-        override var bpm: Float? = getFieldIfExisting(tag, FieldKey.BPM)?.takeUnless { it.isEmpty().and(it == "0") }?.toFloatOrNull()?.takeIf { it > 0 }
+        override var bpm: Float? = metadata.bpm
             set(value) {
                 if (!suppressEvents) mutateAndPublish { field = value } else field = value
             }
@@ -365,7 +337,7 @@ class FXAudioItem internal constructor(override val path: Path, override val id:
         @Transient
         override val lastDateModifiedProperty: ReadOnlyObjectProperty<LocalDateTime> = _lastDateModifiedProperty
 
-        override var coverImageBytes: ByteArray? = getCoverBytes(tag)
+        override var coverImageBytes: ByteArray? = metadata.coverBytes
             set(value) {
                 if (!suppressEvents) {
                     mutateAndPublish {
@@ -393,7 +365,7 @@ class FXAudioItem internal constructor(override val path: Path, override val id:
             SimpleSetProperty(
                 this, "artists involved",
                 FXCollections.observableSet(
-                    AudioUtils.getArtistsNamesInvolved(
+                    getArtistsNamesInvolved(
                         titleProperty.value, artistProperty.value.name, albumProperty.value.albumArtist.name
                     ).map { ImmutableArtist.of(it) }.toSet()
                 )
@@ -411,136 +383,16 @@ class FXAudioItem internal constructor(override val path: Path, override val id:
         @Transient
         override val playCountProperty: ReadOnlyIntegerProperty = _playCountProperty
 
-        private fun getFieldIfExisting(tag: Tag, fieldKey: FieldKey): String? = tag.hasField(fieldKey).takeIf { it }.run { tag.getFirst(fieldKey) }
-
-        private fun readArtist(tag: Tag): Artist =
-            getFieldIfExisting(tag, FieldKey.ARTIST)?.let { artistName ->
-                val country =
-                    getFieldIfExisting(tag, FieldKey.COUNTRY)?.let { _country ->
-                        if (_country.isNotEmpty()) CountryCode.valueOf(_country)
-                        else CountryCode.UNDEFINED
-                    } ?: CountryCode.UNDEFINED
-                ImmutableArtist.of(AudioUtils.beautifyArtistName(artistName), country)
-            } ?: ImmutableArtist.UNKNOWN
-
-        private fun readAlbum(tag: Tag, extension: String): Album =
-            getFieldIfExisting(tag, FieldKey.ALBUM).let { albumName ->
-                return if (albumName == null) {
-                    ImmutableAlbum.UNKNOWN
-                } else {
-                    val albumArtistName = getFieldIfExisting(tag, FieldKey.ALBUM_ARTIST) ?: ""
-                    val isCompilation =
-                        getFieldIfExisting(tag, FieldKey.IS_COMPILATION)?.let {
-                            if ("m4a" == extension) "1" == tag.getFirst(FieldKey.IS_COMPILATION)
-                            else "true" == tag.getFirst(FieldKey.IS_COMPILATION)
-                        } == true
-                    val year = getFieldIfExisting(tag, FieldKey.YEAR)?.toShortOrNull()?.takeIf { it > 0 }
-                    val label = getFieldIfExisting(tag, FieldKey.GROUPING)?.let { ImmutableLabel.of(it) } as Label
-                    ImmutableAlbum(albumName, ImmutableArtist.of(AudioUtils.beautifyArtistName(albumArtistName)), isCompilation, year, label)
-                }
-            }
-
-        private fun getBitRate(audioHeader: AudioHeader): Int {
-            val bitRate = audioHeader.bitRate
-            return if ("~" == bitRate.substring(0, 1)) {
-                bitRate.substring(1).toInt()
-            } else {
-                bitRate.toInt()
-            }
-        }
-
-        private fun getCoverBytes(tag: Tag): ByteArray? = tag.artworkList.isNotEmpty().takeIf { it }?.let { tag.firstArtwork.binaryData }
-
         override fun writeMetadata(): Job =
             ioScope.launch {
                 logger.debug { "Writing metadata of $this to file '${path.toAbsolutePath()}'" }
-
-                val audioFile = path.toFile()
-                val audio = AudioFileIO.read(audioFile)
-                createTag(audio.audioHeader.format).let {
-                    audio.tag = it
-                }
-
-                audio.commit()
+                writeMetadataToFile(
+                    path, title, album, artist, genre,
+                    comments, trackNumber, discNumber, bpm, encoder,
+                    coverImageBytes, fileName, logger
+                )
                 logger.debug { "Metadata of $this successfully written to file" }
             }
-
-        private fun createTag(format: String): Tag =
-            when {
-                format.startsWith(WAV.extension, ignoreCase = true) -> {
-                    val wavTag = WavTag(WavOptions.READ_ID3_ONLY)
-                    wavTag.iD3Tag = ID3v24Tag()
-                    wavTag.infoTag = WavInfoTag()
-                    wavTag
-                }
-
-                format.startsWith(MP3.extension, ignoreCase = true) -> {
-                    TagOptionSingleton.getInstance().isWriteMp3GenresAsText = true
-                    val tag: Tag = ID3v24Tag()
-                    tag.artworkList.clear()
-                    tag
-                }
-
-                format.startsWith(FLAC.extension, ignoreCase = true) -> {
-                    val tag: Tag = FlacTag()
-                    tag.artworkList.clear()
-                    tag
-                }
-
-                format.startsWith("Aac", ignoreCase = true) -> {
-                    TagOptionSingleton.getInstance().isWriteMp4GenresAsText = true
-                    val tag: Tag = Mp4Tag()
-                    tag.artworkList.clear()
-                    tag
-                }
-
-                else -> {
-                    WavInfoTag()
-                }
-            }.also {
-                setTrackFieldsToTag(it)
-            }
-
-        private fun setTrackFieldsToTag(tag: Tag) {
-            tag.setField(FieldKey.TITLE, title)
-            tag.setField(FieldKey.ALBUM, album.name)
-            tag.setField(FieldKey.ALBUM_ARTIST, album.albumArtist.name)
-            tag.setField(FieldKey.ARTIST, artist.name)
-            tag.setField(FieldKey.GENRE, genre.capitalize())
-            tag.setField(FieldKey.COUNTRY, artist.countryCode.name)
-            comments?.let { tag.setField(FieldKey.COMMENT, it) }
-            trackNumber?.let { tag.setField(FieldKey.TRACK, it.toString()) }
-            album.year?.let { tag.setField(FieldKey.YEAR, it.toString()) }
-            tag.setField(FieldKey.ENCODER, encoder)
-            tag.setField(FieldKey.GROUPING, album.label.name)
-            discNumber?.let { tag.setField(FieldKey.DISC_NO, it.toString()) }
-            tag.setField(FieldKey.IS_COMPILATION, album.isCompilation.toString())
-            bpm?.let {
-                if (tag is Mp4Tag) {
-                    tag.setField(FieldKey.BPM, it.toInt().toString())
-                } else {
-                    tag.setField(FieldKey.BPM, it.toString())
-                }
-            }
-            coverImageBytes?.let {
-                tag.deleteArtworkField()
-                tag.addField(createArtwork(it))
-            }
-        }
-
-        private fun createArtwork(coverBytes: ByteArray): Artwork {
-            val tempCover: Path
-            try {
-                tempCover = Files.createTempFile("tempCover_$fileName", ".tmp")
-                Files.write(tempCover, coverBytes, StandardOpenOption.CREATE)
-                tempCover.toFile().deleteOnExit()
-                return ArtworkFactory.createArtworkFromFile(tempCover.toFile())
-            } catch (exception: IOException) {
-                val errorText = "Error creating artwork of $this"
-                logger.error(errorText, exception)
-                throw AudioItemManipulationException(errorText, exception)
-            }
-        }
 
         internal fun incrementPlayCount() {
             mutateAndPublish {
@@ -548,7 +400,7 @@ class FXAudioItem internal constructor(override val path: Path, override val id:
             }
         }
 
-        override operator fun compareTo(other: ObservableAudioItem) = AudioUtils.audioItemTrackDiscNumberComparator<ObservableAudioItem>().compare(this, other)
+        override operator fun compareTo(other: ObservableAudioItem) = audioItemTrackDiscNumberComparator<ObservableAudioItem>().compare(this, other)
 
         override fun equals(other: Any?): Boolean {
             if (this === other) return true

--- a/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/audio/ObservableAudioItemSerializer.kt
+++ b/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/audio/ObservableAudioItemSerializer.kt
@@ -17,12 +17,10 @@
 
 package net.transgressoft.commons.fx.music.audio
 
+import net.transgressoft.commons.music.audio.Album
+import net.transgressoft.commons.music.audio.Artist
 import net.transgressoft.commons.music.audio.AudioItemSerializerBase
 import net.transgressoft.commons.music.audio.Genre
-import net.transgressoft.commons.music.audio.ImmutableAlbum
-import net.transgressoft.commons.music.audio.ImmutableArtist
-import net.transgressoft.commons.music.audio.ImmutableLabel
-import com.neovisionaries.i18n.CountryCode
 import java.nio.file.Path
 import java.time.Duration
 import java.time.LocalDateTime
@@ -42,51 +40,28 @@ val ObservableAudioItemMapSerializer: KSerializer<Map<Int, ObservableAudioItem>>
  */
 internal object ObservableAudioItemSerializer : AudioItemSerializerBase<ObservableAudioItem>() {
 
-    override fun createInstance(propertiesList: List<Any?>): ObservableAudioItem =
+    override fun constructEntity(
+        path: Path,
+        id: Int,
+        title: String,
+        duration: Duration,
+        bitRate: Int,
+        artist: Artist,
+        album: Album,
+        genre: Genre,
+        comments: String?,
+        trackNumber: Short?,
+        discNumber: Short?,
+        bpm: Float?,
+        encoder: String?,
+        encoding: String?,
+        dateOfCreation: LocalDateTime,
+        lastDateModified: LocalDateTime,
+        playCount: Short
+    ): ObservableAudioItem =
         FXAudioItem(
-            // path
-            propertiesList[0] as Path,
-            // id
-            propertiesList[1] as Int,
-            // title
-            propertiesList[2] as String,
-            // duration
-            propertiesList[3] as Duration,
-            // bitRate
-            propertiesList[4] as Int,
-            // artist name and artist country code
-            ImmutableArtist.of(propertiesList[5] as String, CountryCode.getByCode(propertiesList[6] as String)),
-            ImmutableAlbum(
-                // album name
-                propertiesList[7] as String,
-                // album artist name
-                ImmutableArtist.of(propertiesList[8] as String),
-                // album isCompilation
-                propertiesList[9] as Boolean,
-                // album year
-                propertiesList[10] as Short?,
-                // album label name
-                ImmutableLabel.of(propertiesList[11] as String)
-            ),
-            // genre
-            Genre.parseGenre(propertiesList[12] as String),
-            // comments
-            propertiesList[13] as String?,
-            // trackNumber
-            propertiesList[14] as Short?,
-            // discNumber
-            propertiesList[15] as Short?,
-            // bpm
-            propertiesList[16] as Float?,
-            // encoder
-            propertiesList[17] as String?,
-            // encoding
-            propertiesList[18] as String?,
-            // dateOfCreation
-            propertiesList[19] as LocalDateTime,
-            // lastDateModified
-            propertiesList[20] as LocalDateTime,
-            // playCount
-            propertiesList[21] as Short
+            path, id, title, duration, bitRate, artist, album, genre,
+            comments, trackNumber, discNumber, bpm, encoder, encoding,
+            dateOfCreation, lastDateModified, playCount
         )
 }


### PR DESCRIPTION
## Summary

**Phase 5: Reduce code duplication across core and FX modules**
**Goal:** Reduce verbatim code duplication from ~7% to ~4-5% by extracting shared JAudioTagger metadata logic and applying template method pattern to serializers.
**Status:** Verified — 6/6 must-haves passed

Centralizes all JAudioTagger-dependent code into `AudioItemMetadataUtils`, making `MutableAudioItem` and `FXAudioItem` completely free of JAudioTagger imports. Applies template method pattern to `AudioItemSerializerBase` to eliminate duplicated `createInstance` logic.

## Changes

### AudioItemMetadataUtils (new)
- Public API: `readMetadata(path, extension)` returns `AudioFileMetadata` data class, `readCoverBytes(path)`, `writeMetadataToFile(...)`
- All JAudioTagger types (`Tag`, `AudioHeader`, `FieldKey`, `AudioFileIO`) confined to this single object
- Creates clean seam for future library replacement

### MutableAudioItem refactoring
- Removed `audioFile`, `audioHeader`, `tag` fields and all JAudioTagger imports
- Field initializers now destructure from `metadata` val (`AudioFileMetadata`)
- `writeMetadata()` delegates to `AudioItemMetadataUtils.writeMetadataToFile()`
- `coverImageBytes` lazy getter uses `AudioItemMetadataUtils.readCoverBytes()`

### FXAudioItem refactoring
- Same treatment — zero JAudioTagger imports
- Preserves FX-specific post-processing differences (e.g. `encoder ?: ""`)

### Serializer template method
- `AudioItemSerializerBase` now contains shared `createInstance` logic with `protected abstract fun constructEntity(...)` 
- `AudioItemSerializer` and `ObservableAudioItemSerializer` override only `constructEntity` (1-line each, down from 47 lines)

## Requirements Addressed

- **QUAL-01**: Extract shared metadata reading/writing logic from MutableAudioItem/FXAudioItem duplication (#18)

## Verification

- [x] Automated verification: 6/6 must-haves passed
- [x] `gradle compileKotlin compileTestKotlin ktlintCheck test` — BUILD SUCCESSFUL
- [x] Zero JAudioTagger imports in MutableAudioItem and FXAudioItem
- [x] All existing tests pass without modification

## Key Decisions

- `AudioItemMetadataUtils` is `public` (not `internal`) to allow cross-module access from FX module — documented as implementation utility, not part of library API contract
- `equals()`, `hashCode()`, `clone()` remain duplicated per D-04 — class-specific properties make extraction not worth the complexity
- ArtistCatalog and PlaylistHierarchy structural duplication accepted (D-07, D-08) — cross-module visibility + FX threading constraints
- DummyPlaylist/FakeSubscription dedup deferred to lirp 1.2.0 migration (#39)

## Stats

5 files changed, +474/-446 lines


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced audio metadata handling with improved support for reading and writing metadata across all audio formats (MP3, FLAC, WAV, AAC).

* **Refactor**
  * Improved internal code organization for audio metadata processing and serialization logic for better reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->