### PR TITLE
#42 Remove duplicate audio item filtering from FXPlaylist.addAudioItems()

### DIFF
--- a/music-commons-api/src/main/kotlin/net/transgressoft/commons/music/playlist/ReactiveAudioPlaylist.kt
+++ b/music-commons-api/src/main/kotlin/net/transgressoft/commons/music/playlist/ReactiveAudioPlaylist.kt
@@ -33,6 +33,12 @@ interface ReactiveAudioPlaylist<I : ReactiveAudioItem<I>, P : ReactiveAudioPlayl
 
     fun addAudioItem(audioItem: I): Boolean = addAudioItems(listOf(audioItem))
 
+    /**
+     * Adds the given audio items to this playlist. Duplicate items are allowed — if an item
+     * already exists in the playlist, it will be added again.
+     *
+     * @return `true` if any existing item in the playlist is not contained in the given collection
+     */
     fun addAudioItems(audioItems: Collection<I>): Boolean
 
     fun removeAudioItem(audioItem: I): Boolean = removeAudioItems(listOf(audioItem))

--- a/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/audio/FXAudioItem.kt
+++ b/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/audio/FXAudioItem.kt
@@ -367,7 +367,7 @@ class FXAudioItem internal constructor(override val path: Path, override val id:
                 FXCollections.observableSet(
                     getArtistsNamesInvolved(
                         titleProperty.value, artistProperty.value.name, albumProperty.value.albumArtist.name
-                    ).map { ImmutableArtist.of(it) }.toSet()
+                    ).map { ImmutableArtist.of(it) }.toMutableSet()
                 )
             )
 

--- a/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/playlist/ObservablePlaylistHierarchy.kt
+++ b/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/playlist/ObservablePlaylistHierarchy.kt
@@ -289,33 +289,50 @@ class ObservablePlaylistHierarchy
 
             override val coverImageProperty: ReadOnlyObjectProperty<Optional<Image>> = _coverImageProperty
 
-            override fun addAudioItems(audioItems: Collection<ObservableAudioItem>) =
-                audioItems.stream().anyMatch { it !in _audioItemsProperty }.also { hasNew ->
-                    if (hasNew) {
-                        Platform.runLater {
-                            _audioItemsProperty.addAll(audioItems.filter { it !in _audioItemsProperty })
-                        }
-                        logger.debug { "Added $audioItems to playlist $uniqueId" }
+            override fun addAudioItems(audioItems: Collection<ObservableAudioItem>): Boolean {
+                val itemsToAdd = audioItems.toList()
+                val currentItems = synchronized(_audioItemsProperty) { _audioItemsProperty.toList() }
+                val result = currentItems.any { it !in itemsToAdd }
+                Platform.runLater {
+                    synchronized(_audioItemsProperty) {
+                        _audioItemsProperty.addAll(itemsToAdd)
                     }
                 }
+                logger.debug { "Added $itemsToAdd to playlist $uniqueId" }
+                return result
+            }
 
-            override fun removeAudioItems(audioItems: Collection<ObservableAudioItem>) =
-                audioItems.stream().anyMatch { it in _audioItemsProperty }.also { hasItems ->
-                    if (hasItems) {
-                        Platform.runLater {
-                            _audioItemsProperty.removeAll(audioItems.toSet())
-                        }
-                        logger.debug { "Removed $audioItems from playlist $uniqueId" }
+            override fun removeAudioItems(audioItems: Collection<ObservableAudioItem>): Boolean {
+                val itemsToRemove = audioItems.toSet()
+                val currentItems = synchronized(_audioItemsProperty) { _audioItemsProperty.toSet() }
+                val hasItems = itemsToRemove.any { it in currentItems }
+                Platform.runLater {
+                    synchronized(_audioItemsProperty) {
+                        _audioItemsProperty.removeAll(itemsToRemove)
                     }
                 }
+                if (hasItems) {
+                    logger.debug { "Removed $itemsToRemove from playlist $uniqueId" }
+                }
+                return hasItems
+            }
 
             @Suppress("INAPPLICABLE_JVM_NAME")
             @JvmName("removeAudioItemIds")
-            override fun removeAudioItems(audioItemIds: Collection<Int>) =
-                this.audioItems.stream().anyMatch { it.id in audioItemIds }.also {
-                    Platform.runLater { _audioItemsProperty.removeAll { it.id in audioItemIds } }
-                    logger.debug { "Removed audio items with ids $audioItemIds from playlist $uniqueId" }
+            override fun removeAudioItems(audioItemIds: Collection<Int>): Boolean {
+                val idsToRemove = audioItemIds.toSet()
+                val currentItems = synchronized(_audioItemsProperty) { _audioItemsProperty.toList() }
+                val hasItems = currentItems.any { it.id in idsToRemove }
+                Platform.runLater {
+                    synchronized(_audioItemsProperty) {
+                        _audioItemsProperty.removeAll { it.id in idsToRemove }
+                    }
                 }
+                if (hasItems) {
+                    logger.debug { "Removed audio items with ids $idsToRemove from playlist $uniqueId" }
+                }
+                return hasItems
+            }
 
             override fun addPlaylists(playlists: Collection<ObservablePlaylist>): Boolean {
                 playlists.forEach {

--- a/music-commons-fx/src/test/kotlin/net/transgressoft/commons/fx/music/playlist/ObservablePlaylistHierarchyTest.kt
+++ b/music-commons-fx/src/test/kotlin/net/transgressoft/commons/fx/music/playlist/ObservablePlaylistHierarchyTest.kt
@@ -672,6 +672,21 @@ internal class ObservablePlaylistHierarchyTest : StringSpec({
         }
     }
 
+    "FXPlaylist allows adding duplicate audio items" {
+        val hierarchy = ObservablePlaylistHierarchy()
+        val item = Arb.fxAudioItem { title = "Duplicate Me" }.next()
+        val playlist = hierarchy.createPlaylist("Dupes", listOf(item))
+
+        playlist.addAudioItem(item)
+
+        testDispatcher.scheduler.advanceUntilIdle()
+        WaitForAsyncUtils.waitForFxEvents()
+
+        eventuallyOnFxThread {
+            playlist.audioItemsProperty.size shouldBe 2
+        }
+    }
+
     "Rapid playlist modifications are eventually consistent" {
         val hierarchy = ObservablePlaylistHierarchy()
         val audioItems = List(10) { Arb.fxAudioItem { title = "Item-$it" }.next() }


### PR DESCRIPTION
Closes #42

## Summary
- Remove dedup filter from `FXPlaylist.addAudioItems()` — aligns with `MutablePlaylistBase` which allows duplicates
- Add KDoc to `ReactiveAudioPlaylist.addAudioItems()` clarifying duplicates are allowed by contract
- Add test proving duplicate items are accepted in FXPlaylist

## Context
Musicott's playlist feature (Phase 4, decision D-05) requires drag-and-drop of tracks already present in a playlist to add them again. The FX-specific dedup blocked this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Playlists retain duplicate audio items when re-added; UI reflects added items consistently.

* **Documentation**
  * Clarified API docs for add behavior and its return semantics.

* **Tests**
  * Added tests confirming duplicates are accepted and UI updates complete before subsequent operations.

* **Stability**
  * Improved internal update scheduling to ensure consistent add/remove propagation in the UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->