### PR TITLE
#48 Add defensive copy semantics for coverImageBytes

### DIFF
--- a/music-commons-api/src/main/kotlin/net/transgressoft/commons/music/audio/ReactiveAudioItem.kt
+++ b/music-commons-api/src/main/kotlin/net/transgressoft/commons/music/audio/ReactiveAudioItem.kt
@@ -53,6 +53,15 @@ interface ReactiveAudioItem<I: ReactiveAudioItem<I>>: ReactiveEntity<Int, I>, Co
     val encoder: String?
     val encoding: String?
     val length: Long
+
+    /**
+     * The cover image bytes for this audio item, or `null` if no cover image is present.
+     *
+     * Implementations return a defensive copy of the internal array, so mutating the
+     * returned array does not affect internal state. Likewise, the setter stores a
+     * defensive copy of the provided array. All state changes go through the setter
+     * to ensure reactive change notifications are published.
+     */
     var coverImageBytes: ByteArray?
     val dateOfCreation: LocalDateTime
     val playCount: Short

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/MutableAudioItem.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/MutableAudioItem.kt
@@ -214,7 +214,14 @@ internal class MutableAudioItem(
     override var album: Album by reactiveProperty(metadata.album)
 
     @Transient
-    override var coverImageBytes: ByteArray? by reactiveProperty(metadata.coverBytes)
+    private var _coverImageBytes: ByteArray? = metadata.coverBytes?.copyOf()
+
+    @Transient
+    override var coverImageBytes: ByteArray?
+        by reactiveProperty(
+            getter = { _coverImageBytes?.copyOf() },
+            setter = { _coverImageBytes = it?.copyOf() }
+        )
 
     /**
      * Asynchronously writes the current metadata back to the audio file.

--- a/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/audio/MutableAudioItemTest.kt
+++ b/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/audio/MutableAudioItemTest.kt
@@ -171,6 +171,27 @@ internal class MutableAudioItemTest : FunSpec({
         }
     }
 
+    context("MutableAudioItem coverImageBytes defensive copy") {
+        test("MutableAudioItem getter returns defensive copy — mutating returned array does not affect internal state") {
+            val audioItem = createAudioItem(Arb.realAudioFile(ID3_V_24).next())
+            audioItem.coverImageBytes = testCoverBytes
+            val returned = audioItem.coverImageBytes!!
+            val originalContent = returned.copyOf()
+            returned[0] = 0x00.toByte()
+
+            audioItem.coverImageBytes!! shouldBe originalContent
+        }
+
+        test("MutableAudioItem setter stores defensive copy — mutating source array after set does not affect internal state") {
+            val audioItem = createAudioItem(Arb.realAudioFile(ID3_V_24).next())
+            val source = byteArrayOf(1, 2, 3, 4, 5)
+            audioItem.coverImageBytes = source
+            source[0] = 99.toByte()
+
+            audioItem.coverImageBytes!![0] shouldBe 1.toByte()
+        }
+    }
+
     test("AudioItemManipulationException has proper message and cause") {
         val testMessage = "Test error message"
         val testCause = RuntimeException("Test cause")

--- a/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/audio/FXAudioItem.kt
+++ b/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/audio/FXAudioItem.kt
@@ -296,11 +296,13 @@ class FXAudioItem internal constructor(override val path: Path, override val id:
         @Transient
         override val lastDateModifiedProperty: ReadOnlyObjectProperty<LocalDateTime> = _lastDateModifiedProperty
 
-        override var coverImageBytes: ByteArray? = metadata.coverBytes
+        override var coverImageBytes: ByteArray? = metadata.coverBytes?.copyOf()
+            get() = field?.copyOf()
             set(value) {
+                val copy = value?.copyOf()
                 mutateAndPublish {
-                    field = value
-                    _coverImageProperty.set(Optional.ofNullable(value).map { bytes: ByteArray -> Image(ByteArrayInputStream(bytes)) })
+                    field = copy
+                    _coverImageProperty.set(Optional.ofNullable(copy).map { bytes: ByteArray -> Image(ByteArrayInputStream(bytes)) })
                 }
             }
 

--- a/music-commons-fx/src/test/kotlin/net/transgressoft/commons/fx/music/audio/FXAudioItemTest.kt
+++ b/music-commons-fx/src/test/kotlin/net/transgressoft/commons/fx/music/audio/FXAudioItemTest.kt
@@ -205,6 +205,26 @@ internal class FXAudioItemTest : StringSpec({
             it.height shouldBe Image(ByteArrayInputStream(decodedAudioItem.coverImageBytes)).height
         }
     }
+
+    "FXAudioItem getter returns defensive copy — mutating returned array does not affect internal state" {
+        val fxAudioItem = FXAudioItem(Arb.realAudioFile().next())
+        fxAudioItem.coverImageBytes = testCoverBytes
+
+        val returned = fxAudioItem.coverImageBytes!!
+        val originalContent = returned.copyOf()
+        returned[0] = 0x00.toByte()
+
+        fxAudioItem.coverImageBytes!! shouldBe originalContent
+    }
+
+    "FXAudioItem setter stores defensive copy — mutating source array after set does not affect internal state" {
+        val fxAudioItem = FXAudioItem(Arb.realAudioFile().next())
+        val source = byteArrayOf(1, 2, 3, 4, 5)
+        fxAudioItem.coverImageBytes = source
+        source[0] = 99.toByte()
+
+        fxAudioItem.coverImageBytes!![0] shouldBe 1.toByte()
+    }
 })
 
 fun Genre.randomDifferent(): Genre {


### PR DESCRIPTION
## Summary

**Phase 13: Public mutable ByteArray in API**
**Goal:** `ReactiveAudioItem.coverImageBytes` uses defensive copies so callers cannot silently mutate internal state without triggering reactive notifications

Closes #48

## Changes

### Plan 01: Defensive copies for coverImageBytes + KDoc + tests

- `ReactiveAudioItem.kt` — KDoc documenting defensive copy contract on `coverImageBytes` property
- `MutableAudioItem.kt` — `reactiveProperty(getter, setter)` delegate with `copyOf()` on both get and set via private `_coverImageBytes` backing field
- `FXAudioItem.kt` — explicit `get() = field?.copyOf()` and `val copy = value?.copyOf()` in setter, integrated with `_coverImageProperty` Image update
- 4 new tests (2 per class) proving getter/setter copy isolation

## Verification

- [x] Automated verification passed (build, tests, ktlint)
- [x] Human verification: reactive notifications confirmed via `reactiveProperty` delegate (same mechanism as all other properties)

## Key Decisions

- Used `reactiveProperty(getter, setter)` for `MutableAudioItem` instead of `mutateAndPublish(newValue, oldValue)` — the three-arg overload does not exist in transgressoft-commons 1.7.0
- `FXAudioItem` keeps explicit field-backed property to integrate with existing `_coverImageProperty` Image update logic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented external mutation of cover image bytes by ensuring stored and returned data are isolated copies.

* **Documentation**
  * Clarified expected behavior for the cover image byte-array property, including defensive-copy semantics and update notifications.

* **Tests**
  * Added tests verifying getter/setter defensive-copy behavior for cover image data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->