### PR TITLE
#49 Document Platform.runLater error handling as intentionally omitted

### DIFF
--- a/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/audio/FXArtistCatalog.kt
+++ b/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/audio/FXArtistCatalog.kt
@@ -48,6 +48,8 @@ import java.util.concurrent.ConcurrentHashMap
  * structure of the core [net.transgressoft.commons.music.audio.MutableArtistCatalog].
  * All mutations update both the internal data structure and the JavaFX observable properties,
  * with property updates dispatched on the JavaFX Application Thread via [Platform.runLater].
+ * The dispatches intentionally omit error handling because they perform only simple property mutations;
+ * any exception indicates a programming error that should surface through the default uncaught exception handler.
  *
  * @param artist The artist this catalog represents
  */

--- a/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/audio/FXAudioLibrary.kt
+++ b/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/audio/FXAudioLibrary.kt
@@ -56,6 +56,10 @@ import java.util.concurrent.CopyOnWriteArraySet
  * Registers its backing repository in [net.transgressoft.lirp.persistence.LirpContext] on construction
  * via [RegistryBase.registerRepository], enabling playlist hierarchies to resolve audio item references
  * lazily through the context. Deregisters on [close] to support repeated construction within the same JVM.
+ *
+ * The [Platform.runLater] dispatches intentionally omit error handling because they perform only simple
+ * collection and property mutations; any exception indicates a programming error that should surface
+ * through the default uncaught exception handler.
  */
 @LirpRepository
 internal class FXAudioLibrary(repository: Repository<Int, ObservableAudioItem>)

--- a/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/player/JavaFxPlayer.kt
+++ b/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/player/JavaFxPlayer.kt
@@ -44,7 +44,11 @@ import javafx.util.Duration
 import java.util.EnumSet
 
 /**
- * Basic player that uses the native JavaFX [MediaPlayer]
+ * Basic player that uses the native JavaFX [MediaPlayer].
+ *
+ * Uses [Platform.runLater] for volume property updates to ensure thread-safe JavaFX property access.
+ * These dispatches intentionally omit error handling because they perform only simple property mutations;
+ * any exception indicates a programming error that should surface through the default uncaught exception handler.
  */
 class JavaFxPlayer(
     private val publisher: LirpEventPublisher<AudioItemPlayerEvent.Type, AudioItemPlayerEvent> = FlowEventPublisher("JavaFxPlayer")

--- a/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/playlist/FXPlaylistHierarchy.kt
+++ b/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/playlist/FXPlaylistHierarchy.kt
@@ -39,7 +39,10 @@ import mu.KotlinLogging
  * Maintains an observable set of all playlists in the hierarchy that automatically syncs
  * with repository changes. Enables JavaFX UI components to bind directly to the playlist
  * collection and receive automatic updates when playlists are created, modified, or removed.
- * All modifications are executed on the JavaFX Application Thread for thread safety.
+ * All modifications are executed on the JavaFX Application Thread for thread safety. The
+ * [Platform.runLater] dispatches intentionally omit error handling because they perform only simple
+ * set mutations; any exception indicates a programming error that should surface through the default
+ * uncaught exception handler.
  *
  * Playlist deserialization is driven by `lirpSerializer(FXPlaylist(0))` passed to a
  * [net.transgressoft.lirp.persistence.json.JsonFileRepository] at construction time.


### PR DESCRIPTION
## Summary

**Phase 14: Platform.runLater() error handling**
**Goal:** Evaluate and address unhandled errors in FX thread dispatches

Closes #49

**Decision:** No error handling needed. The `Platform.runLater` blocks dispatch only simple property mutations (set, add, remove on observable collections/properties) that do not perform I/O or complex computation. Wrapping them would mask programming errors rather than surface them.

## Changes

- Added KDoc to `FXAudioLibrary`, `FXArtistCatalog`, `FXPlaylistHierarchy`, and `JavaFxPlayer` documenting the rationale
- No code changes — documentation only

## Verification

- [x] `gradle :music-commons-fx:compileKotlin :music-commons-fx:ktlintCheck` passes
- [x] GitHub issue #49 closed with rationale comment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal documentation clarifying implementation details across audio catalog, library, player, and playlist components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->