### PR TITLE
#14 Refactor Genre from enum to sealed class

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,17 @@ implementation("net.transgressoft:lirp-core:2.3.0")
 
 ## Key Features
 
+### Genre Handling
+
+`Genre` is a sealed class with ~370 predefined genre constants (data objects) and a `Custom` variant for arbitrary genre strings. Audio items carry multiple genres as a `Set<Genre>`, populated by parsing comma-separated tags from audio file metadata.
+
+```kotlin
+val genres: Set<Genre> = Genre.parseGenre("Rock, Jazz")  // setOf(Genre.Rock, Genre.Jazz)
+val custom: Set<Genre> = Genre.parseGenre("Vaporwave")   // setOf(Genre.Custom("Vaporwave"))
+```
+
+Unknown genre strings are preserved as `Genre.Custom(name)` instead of being discarded. Serialization uses a JSON array: `"genres": ["Rock", "Jazz"]`
+
 ### Audio Library Management
 
 - **Multi-format support**: MP3, M4A, WAV, and FLAC with automatic metadata extraction

--- a/music-commons-api/src/main/kotlin/net/transgressoft/commons/music/audio/Genre.kt
+++ b/music-commons-api/src/main/kotlin/net/transgressoft/commons/music/audio/Genre.kt
@@ -18,31 +18,1169 @@
 package net.transgressoft.commons.music.audio
 
 /**
- * Enumeration of music genres.
+ * Represents a music genre as a sealed type hierarchy.
+ *
+ * Known genres are predefined [data object] singletons from the
+ * [whatlastgenre whitelist](https://github.com/YetAnotherNerd/whatlastgenre).
+ * Unrecognized genre strings are preserved via [Custom] instead of being
+ * mapped to a lossy fallback.
+ *
+ * @property name display-friendly genre name (e.g. "Hip Hop", "Drum And Bass")
  */
-enum class Genre {
+sealed class Genre(open val name: String) {
 
-    ROCK,
-    UNDEFINED;
+    data object Abstract : Genre("Abstract")
 
-    fun capitalize(): String {
-        val replaced = name.replace('_', ' ')
-        val capitalized = CharArray(replaced.length)
-        capitalized[0] = replaced[0].titlecaseChar()
-        for (c in 1 until replaced.toCharArray().size) {
-            if (replaced[c - 1] == ' ' || replaced[c - 1] == ',') capitalized[c] =
-                replaced[c].titlecaseChar() else capitalized[c] = replaced[c].lowercaseChar()
+    data object AbstractHipHop : Genre("Abstract Hip Hop")
+
+    data object AbstractRock : Genre("Abstract Rock")
+
+    data object Acapella : Genre("Acapella")
+
+    data object AcidBreakbeat : Genre("Acid Breakbeat")
+
+    data object AcidHouse : Genre("Acid House")
+
+    data object AcidJazz : Genre("Acid Jazz")
+
+    data object AcidRock : Genre("Acid Rock")
+
+    data object Acoustic : Genre("Acoustic")
+
+    data object Alternative : Genre("Alternative")
+
+    data object AlternativeCountry : Genre("Alternative Country")
+
+    data object AlternativeDance : Genre("Alternative Dance")
+
+    data object AlternativeMetal : Genre("Alternative Metal")
+
+    data object AlternativeRock : Genre("Alternative Rock")
+
+    data object Ambient : Genre("Ambient")
+
+    data object Americana : Genre("Americana")
+
+    data object Anime : Genre("Anime")
+
+    data object ArtRock : Genre("Art Rock")
+
+    data object Avantgarde : Genre("Avantgarde")
+
+    data object AvantgardeJazz : Genre("Avantgarde Jazz")
+
+    data object AvantgardeMetal : Genre("Avantgarde Metal")
+
+    data object Bachata : Genre("Bachata")
+
+    data object Baroque : Genre("Baroque")
+
+    data object BassMusic : Genre("Bass Music")
+
+    data object Beatbox : Genre("Beatbox")
+
+    data object Bebop : Genre("Bebop")
+
+    data object BigBand : Genre("Big Band")
+
+    data object BigBeat : Genre("Big Beat")
+
+    data object Bitcore : Genre("Bitcore")
+
+    data object Bitpop : Genre("Bitpop")
+
+    data object BlackMetal : Genre("Black Metal")
+
+    data object Bluegrass : Genre("Bluegrass")
+
+    data object Blues : Genre("Blues")
+
+    data object BluesRock : Genre("Blues Rock")
+
+    data object Boogie : Genre("Boogie")
+
+    data object BoogieWoogie : Genre("Boogie Woogie")
+
+    data object BossaNova : Genre("Bossa Nova")
+
+    data object BrassBand : Genre("Brass Band")
+
+    data object Breakbeat : Genre("Breakbeat")
+
+    data object Breakcore : Genre("Breakcore")
+
+    data object Britpop : Genre("Britpop")
+
+    data object BrokenBeat : Genre("Broken Beat")
+
+    data object BumbaMeuBoi : Genre("Bumba Meu Boi")
+
+    data object Celtic : Genre("Celtic")
+
+    data object CelticFusion : Genre("Celtic Fusion")
+
+    data object CelticMetal : Genre("Celtic Metal")
+
+    data object CelticPunk : Genre("Celtic Punk")
+
+    data object CelticReggae : Genre("Celtic Reggae")
+
+    data object CelticRock : Genre("Celtic Rock")
+
+    data object Chamber : Genre("Chamber")
+
+    data object ChamberJazz : Genre("Chamber Jazz")
+
+    data object ChamberMusic : Genre("Chamber Music")
+
+    data object ChamberPop : Genre("Chamber Pop")
+
+    data object Chanson : Genre("Chanson")
+
+    data object Chant : Genre("Chant")
+
+    data object ChaChaCha : Genre("Cha Cha Cha")
+
+    data object Chicha : Genre("Chicha")
+
+    data object Children : Genre("Children")
+
+    data object Chillout : Genre("Chillout")
+
+    data object Chillwave : Genre("Chillwave")
+
+    data object Chiptune : Genre("Chiptune")
+
+    data object Christian : Genre("Christian")
+
+    data object Christmas : Genre("Christmas")
+
+    data object CityPop : Genre("City Pop")
+
+    data object Classic : Genre("Classic")
+
+    data object Classical : Genre("Classical")
+
+    data object ClassicPop : Genre("Classic Pop")
+
+    data object ClassicRock : Genre("Classic Rock")
+
+    data object Club : Genre("Club")
+
+    data object Comedy : Genre("Comedy")
+
+    data object ContemporaryBlues : Genre("Contemporary Blues")
+
+    data object ContemporaryClassical : Genre("Contemporary Classical")
+
+    data object ContemporaryJazz : Genre("Contemporary Jazz")
+
+    data object CoolJazz : Genre("Cool Jazz")
+
+    data object Country : Genre("Country")
+
+    data object CountryPop : Genre("Country Pop")
+
+    data object CountryRock : Genre("Country Rock")
+
+    data object Crossover : Genre("Crossover")
+
+    data object Crunk : Genre("Crunk")
+
+    data object Crunkcore : Genre("Crunkcore")
+
+    data object CrustPunk : Genre("Crust Punk")
+
+    data object CGothic : Genre("C Gothic")
+
+    data object CHipHop : Genre("C Hip Hop")
+
+    data object CJazz : Genre("C Jazz")
+
+    data object CPop : Genre("C Pop")
+
+    data object CRock : Genre("C Rock")
+
+    data object CSka : Genre("C Ska")
+
+    data object CTrance : Genre("C Trance")
+
+    data object Dance : Genre("Dance")
+
+    data object Dancehall : Genre("Dancehall")
+
+    data object DarkAmbient : Genre("Dark Ambient")
+
+    data object DarkCore : Genre("Dark Core")
+
+    data object DarkPop : Genre("Dark Pop")
+
+    data object DarkStep : Genre("Dark Step")
+
+    data object DarkWave : Genre("Dark Wave")
+
+    data object Deathcore : Genre("Deathcore")
+
+    data object Deathgrind : Genre("Deathgrind")
+
+    data object DeathMetal : Genre("Death Metal")
+
+    data object DeepFunk : Genre("Deep Funk")
+
+    data object DeepHouse : Genre("Deep House")
+
+    data object DeepSoul : Genre("Deep Soul")
+
+    data object Disco : Genre("Disco")
+
+    data object DiscoHouse : Genre("Disco House")
+
+    data object DixielandJazz : Genre("Dixieland Jazz")
+
+    data object Doomcore : Genre("Doomcore")
+
+    data object DoomMetal : Genre("Doom Metal")
+
+    data object DooWop : Genre("Doo Wop")
+
+    data object Downtempo : Genre("Downtempo")
+
+    data object DreamPop : Genre("Dream Pop")
+
+    data object Drone : Genre("Drone")
+
+    data object DroneMetal : Genre("Drone Metal")
+
+    data object DrumAndBass : Genre("Drum And Bass")
+
+    data object Dub : Genre("Dub")
+
+    data object Dubstep : Genre("Dubstep")
+
+    data object DubHouse : Genre("Dub House")
+
+    data object Dubtronica : Genre("Dubtronica")
+
+    data object Ebm : Genre("Ebm")
+
+    data object Edm : Genre("Edm")
+
+    data object Electro : Genre("Electro")
+
+    data object Electronic : Genre("Electronic")
+
+    data object Electronica : Genre("Electronica")
+
+    data object ElectronicDance : Genre("Electronic Dance")
+
+    data object Electropop : Genre("Electropop")
+
+    data object ElectroSwing : Genre("Electro Swing")
+
+    data object ElectroWave : Genre("Electro Wave")
+
+    data object Emo : Genre("Emo")
+
+    data object EmoPop : Genre("Emo Pop")
+
+    data object EmoRap : Genre("Emo Rap")
+
+    data object Enka : Genre("Enka")
+
+    data object Ethnic : Genre("Ethnic")
+
+    data object EuroDance : Genre("Euro Dance")
+
+    data object EuroDisco : Genre("Euro Disco")
+
+    data object EuroHouse : Genre("Euro House")
+
+    data object EuroPop : Genre("Euro Pop")
+
+    data object EuroTrance : Genre("Euro Trance")
+
+    data object Experimental : Genre("Experimental")
+
+    data object ExperimentalNoise : Genre("Experimental Noise")
+
+    data object ExperimentalPop : Genre("Experimental Pop")
+
+    data object ExperimentalRock : Genre("Experimental Rock")
+
+    data object FemaleVocalist : Genre("Female Vocalist")
+
+    data object Fingerstyle : Genre("Fingerstyle")
+
+    data object Flamenco : Genre("Flamenco")
+
+    data object Folk : Genre("Folk")
+
+    data object FolkHop : Genre("Folk Hop")
+
+    data object FolkMetal : Genre("Folk Metal")
+
+    data object FolkPop : Genre("Folk Pop")
+
+    data object FolkPunk : Genre("Folk Punk")
+
+    data object FolkRock : Genre("Folk Rock")
+
+    data object Folktronica : Genre("Folktronica")
+
+    data object FreakFolk : Genre("Freak Folk")
+
+    data object Funk : Genre("Funk")
+
+    data object Fusion : Genre("Fusion")
+
+    data object FusionJazz : Genre("Fusion Jazz")
+
+    data object FutureBass : Genre("Future Bass")
+
+    data object FutureJazz : Genre("Future Jazz")
+
+    data object Garage : Genre("Garage")
+
+    data object GarageRock : Genre("Garage Rock")
+
+    data object GlamMetal : Genre("Glam Metal")
+
+    data object GlamPunk : Genre("Glam Punk")
+
+    data object GlamRock : Genre("Glam Rock")
+
+    data object Glitch : Genre("Glitch")
+
+    data object GlitchHop : Genre("Glitch Hop")
+
+    data object GloFi : Genre("Glo Fi")
+
+    data object Goa : Genre("Goa")
+
+    data object Gospel : Genre("Gospel")
+
+    data object Gothic : Genre("Gothic")
+
+    data object GothicMetal : Genre("Gothic Metal")
+
+    data object GothicRock : Genre("Gothic Rock")
+
+    data object Grime : Genre("Grime")
+
+    data object Grindcore : Genre("Grindcore")
+
+    data object Grunge : Genre("Grunge")
+
+    data object GypsyJazz : Genre("Gypsy Jazz")
+
+    data object GypsyPunk : Genre("Gypsy Punk")
+
+    data object GFunk : Genre("G Funk")
+
+    data object Hardcore : Genre("Hardcore")
+
+    data object Hardstyle : Genre("Hardstyle")
+
+    data object HardBop : Genre("Hard Bop")
+
+    data object HardHouse : Genre("Hard House")
+
+    data object HardRock : Genre("Hard Rock")
+
+    data object HardTrance : Genre("Hard Trance")
+
+    data object HeavyMetal : Genre("Heavy Metal")
+
+    data object HipHop : Genre("Hip Hop")
+
+    data object Horrorcore : Genre("Horrorcore")
+
+    data object HorrorPunk : Genre("Horror Punk")
+
+    data object House : Genre("House")
+
+    data object Idm : Genre("Idm")
+
+    data object Illbient : Genre("Illbient")
+
+    data object Impressionist : Genre("Impressionist")
+
+    data object Incidental : Genre("Incidental")
+
+    data object Indie : Genre("Indie")
+
+    data object IndieFolk : Genre("Indie Folk")
+
+    data object IndiePop : Genre("Indie Pop")
+
+    data object IndieRock : Genre("Indie Rock")
+
+    data object Indietronic : Genre("Indietronic")
+
+    data object Industrial : Genre("Industrial")
+
+    data object IndustrialMetal : Genre("Industrial Metal")
+
+    data object IndustrialRock : Genre("Industrial Rock")
+
+    data object Instrumental : Genre("Instrumental")
+
+    data object InstrumentalHipHop : Genre("Instrumental Hip Hop")
+
+    data object InstrumentalRock : Genre("Instrumental Rock")
+
+    data object Jazz : Genre("Jazz")
+
+    data object JazzFusion : Genre("Jazz Fusion")
+
+    data object JazzHop : Genre("Jazz Hop")
+
+    data object Jumpstyle : Genre("Jumpstyle")
+
+    data object Jungle : Genre("Jungle")
+
+    data object JFusion : Genre("J Fusion")
+
+    data object JGothic : Genre("J Gothic")
+
+    data object JHipHop : Genre("J Hip Hop")
+
+    data object JJazz : Genre("J Jazz")
+
+    data object JPop : Genre("J Pop")
+
+    data object JRock : Genre("J Rock")
+
+    data object JSka : Genre("J Ska")
+
+    data object JTrance : Genre("J Trance")
+
+    data object Krautrock : Genre("Krautrock")
+
+    data object KGothic : Genre("K Gothic")
+
+    data object KHipHop : Genre("K Hip Hop")
+
+    data object KJazz : Genre("K Jazz")
+
+    data object KPop : Genre("K Pop")
+
+    data object KRock : Genre("K Rock")
+
+    data object KSka : Genre("K Ska")
+
+    data object KTrance : Genre("K Trance")
+
+    data object Latin : Genre("Latin")
+
+    data object LatinJazz : Genre("Latin Jazz")
+
+    data object LatinPop : Genre("Latin Pop")
+
+    data object LatinRock : Genre("Latin Rock")
+
+    data object LiquidFunk : Genre("Liquid Funk")
+
+    data object LoFi : Genre("Lo Fi")
+
+    data object Lounge : Genre("Lounge")
+
+    data object Mambo : Genre("Mambo")
+
+    data object Marimba : Genre("Marimba")
+
+    data object Mathcore : Genre("Mathcore")
+
+    data object MathRock : Genre("Math Rock")
+
+    data object Medieval : Genre("Medieval")
+
+    data object MedievalMetal : Genre("Medieval Metal")
+
+    data object MedievalRock : Genre("Medieval Rock")
+
+    data object MelodicMetal : Genre("Melodic Metal")
+
+    data object MelodicMetalcore : Genre("Melodic Metalcore")
+
+    data object MelodicTrance : Genre("Melodic Trance")
+
+    data object Merengue : Genre("Merengue")
+
+    data object Metal : Genre("Metal")
+
+    data object Metalcore : Genre("Metalcore")
+
+    data object Microhouse : Genre("Microhouse")
+
+    data object Minimal : Genre("Minimal")
+
+    data object ModalJazz : Genre("Modal Jazz")
+
+    data object ModernClassical : Genre("Modern Classical")
+
+    data object ModernRock : Genre("Modern Rock")
+
+    data object Motown : Genre("Motown")
+
+    data object Mpb : Genre("Mpb")
+
+    data object Musical : Genre("Musical")
+
+    data object MushroomJazz : Genre("Mushroom Jazz")
+
+    data object Ndw : Genre("Ndw")
+
+    data object NeoClassical : Genre("Neo Classical")
+
+    data object NeoFolk : Genre("Neo Folk")
+
+    data object NeoMedieval : Genre("Neo Medieval")
+
+    data object NeoProgressive : Genre("Neo Progressive")
+
+    data object NeoPsychedelic : Genre("Neo Psychedelic")
+
+    data object NeoSoul : Genre("Neo Soul")
+
+    data object Nerdcore : Genre("Nerdcore")
+
+    data object NewAge : Genre("New Age")
+
+    data object NewWave : Genre("New Wave")
+
+    data object Newgrass : Genre("Newgrass")
+
+    data object Noise : Genre("Noise")
+
+    data object NoisePop : Genre("Noise Pop")
+
+    data object NoiseRock : Genre("Noise Rock")
+
+    data object NuDisco : Genre("Nu Disco")
+
+    data object NuJazz : Genre("Nu Jazz")
+
+    data object NuMetal : Genre("Nu Metal")
+
+    data object NuSoul : Genre("Nu Soul")
+
+    data object Nwa : Genre("Nwa")
+
+    data object Nwobhm : Genre("Nwobhm")
+
+    data object Nyhc : Genre("Nyhc")
+
+    data object Oldies : Genre("Oldies")
+
+    data object Opera : Genre("Opera")
+
+    data object Orchestral : Genre("Orchestral")
+
+    data object Oriental : Genre("Oriental")
+
+    data object OutlawCountry : Genre("Outlaw Country")
+
+    data object Pop : Genre("Pop")
+
+    data object PopPunk : Genre("Pop Punk")
+
+    data object PopRock : Genre("Pop Rock")
+
+    data object PostBritpop : Genre("Post Britpop")
+
+    data object PostDisco : Genre("Post Disco")
+
+    data object PostGrunge : Genre("Post Grunge")
+
+    data object PostHardcore : Genre("Post Hardcore")
+
+    data object PostIndustrial : Genre("Post Industrial")
+
+    data object PostMetal : Genre("Post Metal")
+
+    data object PostPunk : Genre("Post Punk")
+
+    data object PostRock : Genre("Post Rock")
+
+    data object PowerMetal : Genre("Power Metal")
+
+    data object PowerNoise : Genre("Power Noise")
+
+    data object PowerPop : Genre("Power Pop")
+
+    data object ProgressiveBluegrass : Genre("Progressive Bluegrass")
+
+    data object ProgressiveCountry : Genre("Progressive Country")
+
+    data object ProgressiveHouse : Genre("Progressive House")
+
+    data object ProgressiveMetal : Genre("Progressive Metal")
+
+    data object ProgressiveRock : Genre("Progressive Rock")
+
+    data object ProgressiveTrance : Genre("Progressive Trance")
+
+    data object Protopunk : Genre("Protopunk")
+
+    data object Psychedelic : Genre("Psychedelic")
+
+    data object PsychedelicPop : Genre("Psychedelic Pop")
+
+    data object PsychedelicRock : Genre("Psychedelic Rock")
+
+    data object PsyTrance : Genre("Psy Trance")
+
+    data object Punk : Genre("Punk")
+
+    data object PunkRock : Genre("Punk Rock")
+
+    data object PFunk : Genre("P Funk")
+
+    data object Ragga : Genre("Ragga")
+
+    data object Rap : Genre("Rap")
+
+    data object Rapcore : Genre("Rapcore")
+
+    data object Reggae : Genre("Reggae")
+
+    data object Reggaeton : Genre("Reggaeton")
+
+    data object ReggaeFusion : Genre("Reggae Fusion")
+
+    data object Renaissance : Genre("Renaissance")
+
+    data object Rock : Genre("Rock")
+
+    data object Rockabilly : Genre("Rockabilly")
+
+    data object Rocksteady : Genre("Rocksteady")
+
+    data object RockAndRoll : Genre("Rock And Roll")
+
+    data object RootsReggae : Genre("Roots Reggae")
+
+    data object RootsRock : Genre("Roots Rock")
+
+    data object RAndB : Genre("R And B")
+
+    data object Salsa : Genre("Salsa")
+
+    data object Samba : Genre("Samba")
+
+    data object Schlager : Genre("Schlager")
+
+    data object Schranz : Genre("Schranz")
+
+    data object Screamo : Genre("Screamo")
+
+    data object Shoegaze : Genre("Shoegaze")
+
+    data object SingerSongwriter : Genre("Singer Songwriter")
+
+    data object Ska : Genre("Ska")
+
+    data object Skacore : Genre("Skacore")
+
+    data object SkaPunk : Genre("Ska Punk")
+
+    data object Skatepunk : Genre("Skatepunk")
+
+    data object Skiffle : Genre("Skiffle")
+
+    data object Slowcore : Genre("Slowcore")
+
+    data object SludgeMetal : Genre("Sludge Metal")
+
+    data object SmoothJazz : Genre("Smooth Jazz")
+
+    data object SoftRock : Genre("Soft Rock")
+
+    data object Soul : Genre("Soul")
+
+    data object Soundtrack : Genre("Soundtrack")
+
+    data object SouthernRock : Genre("Southern Rock")
+
+    data object SpaceRock : Genre("Space Rock")
+
+    data object SpeedGarage : Genre("Speed Garage")
+
+    data object SpeedMetal : Genre("Speed Metal")
+
+    data object Speedcore : Genre("Speedcore")
+
+    data object StageAndScreen : Genre("Stage And Screen")
+
+    data object StonerMetal : Genre("Stoner Metal")
+
+    data object StonerRock : Genre("Stoner Rock")
+
+    data object SwampBlues : Genre("Swamp Blues")
+
+    data object SwampPop : Genre("Swamp Pop")
+
+    data object SwampRock : Genre("Swamp Rock")
+
+    data object Swing : Genre("Swing")
+
+    data object SymphonicMetal : Genre("Symphonic Metal")
+
+    data object SymphonicRock : Genre("Symphonic Rock")
+
+    data object Synthwave : Genre("Synthwave")
+
+    data object SynthPop : Genre("Synth Pop")
+
+    data object SynthPunk : Genre("Synth Punk")
+
+    data object Tango : Genre("Tango")
+
+    data object TechnicalMetal : Genre("Technical Metal")
+
+    data object Techno : Genre("Techno")
+
+    data object Techstep : Genre("Techstep")
+
+    data object TechHouse : Genre("Tech House")
+
+    data object TechTrance : Genre("Tech Trance")
+
+    data object ThrashMetal : Genre("Thrash Metal")
+
+    data object Trance : Genre("Trance")
+
+    data object Trap : Genre("Trap")
+
+    data object TribalHouse : Genre("Tribal House")
+
+    data object TripHop : Genre("Trip Hop")
+
+    data object TripRock : Genre("Trip Rock")
+
+    data object TropicalHouse : Genre("Tropical House")
+
+    data object Turntablism : Genre("Turntablism")
+
+    data object TwoStep : Genre("Two Step")
+
+    data object VocalHouse : Genre("Vocal House")
+
+    data object VocalJazz : Genre("Vocal Jazz")
+
+    data object VocalTrance : Genre("Vocal Trance")
+
+    data object World : Genre("World")
+
+    data object WorldFusion : Genre("World Fusion")
+
+    data class Custom(override val name: String) : Genre(name) {
+        init {
+            require("," !in name) { "Custom genre name must not contain commas: '$name'" }
         }
-        return String(capitalized)
     }
 
     companion object {
-        @JvmStatic
-        fun parseGenre(value: String): Genre {
-            for (genre in entries) {
-                if (genre.name.equals(value.replace(" ", "_"), ignoreCase = true)) return genre
+        // Hardcoded map avoids kotlin-reflect dependency on Genre::class.sealedSubclasses.
+        // Lazy initialization is required because data object instances are not yet initialized
+        // when the companion object's static initializer runs during class loading.
+        private val BY_NAME: Map<String, Genre> by lazy {
+            buildMap {
+                put(Abstract.name.lowercase(), Abstract)
+                put(AbstractHipHop.name.lowercase(), AbstractHipHop)
+                put(AbstractRock.name.lowercase(), AbstractRock)
+                put(Acapella.name.lowercase(), Acapella)
+                put(AcidBreakbeat.name.lowercase(), AcidBreakbeat)
+                put(AcidHouse.name.lowercase(), AcidHouse)
+                put(AcidJazz.name.lowercase(), AcidJazz)
+                put(AcidRock.name.lowercase(), AcidRock)
+                put(Acoustic.name.lowercase(), Acoustic)
+                put(Alternative.name.lowercase(), Alternative)
+                put(AlternativeCountry.name.lowercase(), AlternativeCountry)
+                put(AlternativeDance.name.lowercase(), AlternativeDance)
+                put(AlternativeMetal.name.lowercase(), AlternativeMetal)
+                put(AlternativeRock.name.lowercase(), AlternativeRock)
+                put(Ambient.name.lowercase(), Ambient)
+                put(Americana.name.lowercase(), Americana)
+                put(Anime.name.lowercase(), Anime)
+                put(ArtRock.name.lowercase(), ArtRock)
+                put(Avantgarde.name.lowercase(), Avantgarde)
+                put(AvantgardeJazz.name.lowercase(), AvantgardeJazz)
+                put(AvantgardeMetal.name.lowercase(), AvantgardeMetal)
+                put(Bachata.name.lowercase(), Bachata)
+                put(Baroque.name.lowercase(), Baroque)
+                put(BassMusic.name.lowercase(), BassMusic)
+                put(Beatbox.name.lowercase(), Beatbox)
+                put(Bebop.name.lowercase(), Bebop)
+                put(BigBand.name.lowercase(), BigBand)
+                put(BigBeat.name.lowercase(), BigBeat)
+                put(Bitcore.name.lowercase(), Bitcore)
+                put(Bitpop.name.lowercase(), Bitpop)
+                put(BlackMetal.name.lowercase(), BlackMetal)
+                put(Bluegrass.name.lowercase(), Bluegrass)
+                put(Blues.name.lowercase(), Blues)
+                put(BluesRock.name.lowercase(), BluesRock)
+                put(Boogie.name.lowercase(), Boogie)
+                put(BoogieWoogie.name.lowercase(), BoogieWoogie)
+                put(BossaNova.name.lowercase(), BossaNova)
+                put(BrassBand.name.lowercase(), BrassBand)
+                put(Breakbeat.name.lowercase(), Breakbeat)
+                put(Breakcore.name.lowercase(), Breakcore)
+                put(Britpop.name.lowercase(), Britpop)
+                put(BrokenBeat.name.lowercase(), BrokenBeat)
+                put(BumbaMeuBoi.name.lowercase(), BumbaMeuBoi)
+                put(Celtic.name.lowercase(), Celtic)
+                put(CelticFusion.name.lowercase(), CelticFusion)
+                put(CelticMetal.name.lowercase(), CelticMetal)
+                put(CelticPunk.name.lowercase(), CelticPunk)
+                put(CelticReggae.name.lowercase(), CelticReggae)
+                put(CelticRock.name.lowercase(), CelticRock)
+                put(Chamber.name.lowercase(), Chamber)
+                put(ChamberJazz.name.lowercase(), ChamberJazz)
+                put(ChamberMusic.name.lowercase(), ChamberMusic)
+                put(ChamberPop.name.lowercase(), ChamberPop)
+                put(Chanson.name.lowercase(), Chanson)
+                put(Chant.name.lowercase(), Chant)
+                put(ChaChaCha.name.lowercase(), ChaChaCha)
+                put(Chicha.name.lowercase(), Chicha)
+                put(Children.name.lowercase(), Children)
+                put(Chillout.name.lowercase(), Chillout)
+                put(Chillwave.name.lowercase(), Chillwave)
+                put(Chiptune.name.lowercase(), Chiptune)
+                put(Christian.name.lowercase(), Christian)
+                put(Christmas.name.lowercase(), Christmas)
+                put(CityPop.name.lowercase(), CityPop)
+                put(Classic.name.lowercase(), Classic)
+                put(Classical.name.lowercase(), Classical)
+                put(ClassicPop.name.lowercase(), ClassicPop)
+                put(ClassicRock.name.lowercase(), ClassicRock)
+                put(Club.name.lowercase(), Club)
+                put(Comedy.name.lowercase(), Comedy)
+                put(ContemporaryBlues.name.lowercase(), ContemporaryBlues)
+                put(ContemporaryClassical.name.lowercase(), ContemporaryClassical)
+                put(ContemporaryJazz.name.lowercase(), ContemporaryJazz)
+                put(CoolJazz.name.lowercase(), CoolJazz)
+                put(Country.name.lowercase(), Country)
+                put(CountryPop.name.lowercase(), CountryPop)
+                put(CountryRock.name.lowercase(), CountryRock)
+                put(Crossover.name.lowercase(), Crossover)
+                put(Crunk.name.lowercase(), Crunk)
+                put(Crunkcore.name.lowercase(), Crunkcore)
+                put(CrustPunk.name.lowercase(), CrustPunk)
+                put(CGothic.name.lowercase(), CGothic)
+                put(CHipHop.name.lowercase(), CHipHop)
+                put(CJazz.name.lowercase(), CJazz)
+                put(CPop.name.lowercase(), CPop)
+                put(CRock.name.lowercase(), CRock)
+                put(CSka.name.lowercase(), CSka)
+                put(CTrance.name.lowercase(), CTrance)
+                put(Dance.name.lowercase(), Dance)
+                put(Dancehall.name.lowercase(), Dancehall)
+                put(DarkAmbient.name.lowercase(), DarkAmbient)
+                put(DarkCore.name.lowercase(), DarkCore)
+                put(DarkPop.name.lowercase(), DarkPop)
+                put(DarkStep.name.lowercase(), DarkStep)
+                put(DarkWave.name.lowercase(), DarkWave)
+                put(Deathcore.name.lowercase(), Deathcore)
+                put(Deathgrind.name.lowercase(), Deathgrind)
+                put(DeathMetal.name.lowercase(), DeathMetal)
+                put(DeepFunk.name.lowercase(), DeepFunk)
+                put(DeepHouse.name.lowercase(), DeepHouse)
+                put(DeepSoul.name.lowercase(), DeepSoul)
+                put(Disco.name.lowercase(), Disco)
+                put(DiscoHouse.name.lowercase(), DiscoHouse)
+                put(DixielandJazz.name.lowercase(), DixielandJazz)
+                put(Doomcore.name.lowercase(), Doomcore)
+                put(DoomMetal.name.lowercase(), DoomMetal)
+                put(DooWop.name.lowercase(), DooWop)
+                put(Downtempo.name.lowercase(), Downtempo)
+                put(DreamPop.name.lowercase(), DreamPop)
+                put(Drone.name.lowercase(), Drone)
+                put(DroneMetal.name.lowercase(), DroneMetal)
+                put(DrumAndBass.name.lowercase(), DrumAndBass)
+                put(Dub.name.lowercase(), Dub)
+                put(Dubstep.name.lowercase(), Dubstep)
+                put(DubHouse.name.lowercase(), DubHouse)
+                put(Dubtronica.name.lowercase(), Dubtronica)
+                put(Ebm.name.lowercase(), Ebm)
+                put(Edm.name.lowercase(), Edm)
+                put(Electro.name.lowercase(), Electro)
+                put(Electronic.name.lowercase(), Electronic)
+                put(Electronica.name.lowercase(), Electronica)
+                put(ElectronicDance.name.lowercase(), ElectronicDance)
+                put(Electropop.name.lowercase(), Electropop)
+                put(ElectroSwing.name.lowercase(), ElectroSwing)
+                put(ElectroWave.name.lowercase(), ElectroWave)
+                put(Emo.name.lowercase(), Emo)
+                put(EmoPop.name.lowercase(), EmoPop)
+                put(EmoRap.name.lowercase(), EmoRap)
+                put(Enka.name.lowercase(), Enka)
+                put(Ethnic.name.lowercase(), Ethnic)
+                put(EuroDance.name.lowercase(), EuroDance)
+                put(EuroDisco.name.lowercase(), EuroDisco)
+                put(EuroHouse.name.lowercase(), EuroHouse)
+                put(EuroPop.name.lowercase(), EuroPop)
+                put(EuroTrance.name.lowercase(), EuroTrance)
+                put(Experimental.name.lowercase(), Experimental)
+                put(ExperimentalNoise.name.lowercase(), ExperimentalNoise)
+                put(ExperimentalPop.name.lowercase(), ExperimentalPop)
+                put(ExperimentalRock.name.lowercase(), ExperimentalRock)
+                put(FemaleVocalist.name.lowercase(), FemaleVocalist)
+                put(Fingerstyle.name.lowercase(), Fingerstyle)
+                put(Flamenco.name.lowercase(), Flamenco)
+                put(Folk.name.lowercase(), Folk)
+                put(FolkHop.name.lowercase(), FolkHop)
+                put(FolkMetal.name.lowercase(), FolkMetal)
+                put(FolkPop.name.lowercase(), FolkPop)
+                put(FolkPunk.name.lowercase(), FolkPunk)
+                put(FolkRock.name.lowercase(), FolkRock)
+                put(Folktronica.name.lowercase(), Folktronica)
+                put(FreakFolk.name.lowercase(), FreakFolk)
+                put(Funk.name.lowercase(), Funk)
+                put(Fusion.name.lowercase(), Fusion)
+                put(FusionJazz.name.lowercase(), FusionJazz)
+                put(FutureBass.name.lowercase(), FutureBass)
+                put(FutureJazz.name.lowercase(), FutureJazz)
+                put(Garage.name.lowercase(), Garage)
+                put(GarageRock.name.lowercase(), GarageRock)
+                put(GlamMetal.name.lowercase(), GlamMetal)
+                put(GlamPunk.name.lowercase(), GlamPunk)
+                put(GlamRock.name.lowercase(), GlamRock)
+                put(Glitch.name.lowercase(), Glitch)
+                put(GlitchHop.name.lowercase(), GlitchHop)
+                put(GloFi.name.lowercase(), GloFi)
+                put(Goa.name.lowercase(), Goa)
+                put(Gospel.name.lowercase(), Gospel)
+                put(Gothic.name.lowercase(), Gothic)
+                put(GothicMetal.name.lowercase(), GothicMetal)
+                put(GothicRock.name.lowercase(), GothicRock)
+                put(Grime.name.lowercase(), Grime)
+                put(Grindcore.name.lowercase(), Grindcore)
+                put(Grunge.name.lowercase(), Grunge)
+                put(GypsyJazz.name.lowercase(), GypsyJazz)
+                put(GypsyPunk.name.lowercase(), GypsyPunk)
+                put(GFunk.name.lowercase(), GFunk)
+                put(Hardcore.name.lowercase(), Hardcore)
+                put(Hardstyle.name.lowercase(), Hardstyle)
+                put(HardBop.name.lowercase(), HardBop)
+                put(HardHouse.name.lowercase(), HardHouse)
+                put(HardRock.name.lowercase(), HardRock)
+                put(HardTrance.name.lowercase(), HardTrance)
+                put(HeavyMetal.name.lowercase(), HeavyMetal)
+                put(HipHop.name.lowercase(), HipHop)
+                put(Horrorcore.name.lowercase(), Horrorcore)
+                put(HorrorPunk.name.lowercase(), HorrorPunk)
+                put(House.name.lowercase(), House)
+                put(Idm.name.lowercase(), Idm)
+                put(Illbient.name.lowercase(), Illbient)
+                put(Impressionist.name.lowercase(), Impressionist)
+                put(Incidental.name.lowercase(), Incidental)
+                put(Indie.name.lowercase(), Indie)
+                put(IndieFolk.name.lowercase(), IndieFolk)
+                put(IndiePop.name.lowercase(), IndiePop)
+                put(IndieRock.name.lowercase(), IndieRock)
+                put(Indietronic.name.lowercase(), Indietronic)
+                put(Industrial.name.lowercase(), Industrial)
+                put(IndustrialMetal.name.lowercase(), IndustrialMetal)
+                put(IndustrialRock.name.lowercase(), IndustrialRock)
+                put(Instrumental.name.lowercase(), Instrumental)
+                put(InstrumentalHipHop.name.lowercase(), InstrumentalHipHop)
+                put(InstrumentalRock.name.lowercase(), InstrumentalRock)
+                put(Jazz.name.lowercase(), Jazz)
+                put(JazzFusion.name.lowercase(), JazzFusion)
+                put(JazzHop.name.lowercase(), JazzHop)
+                put(Jumpstyle.name.lowercase(), Jumpstyle)
+                put(Jungle.name.lowercase(), Jungle)
+                put(JFusion.name.lowercase(), JFusion)
+                put(JGothic.name.lowercase(), JGothic)
+                put(JHipHop.name.lowercase(), JHipHop)
+                put(JJazz.name.lowercase(), JJazz)
+                put(JPop.name.lowercase(), JPop)
+                put(JRock.name.lowercase(), JRock)
+                put(JSka.name.lowercase(), JSka)
+                put(JTrance.name.lowercase(), JTrance)
+                put(Krautrock.name.lowercase(), Krautrock)
+                put(KGothic.name.lowercase(), KGothic)
+                put(KHipHop.name.lowercase(), KHipHop)
+                put(KJazz.name.lowercase(), KJazz)
+                put(KPop.name.lowercase(), KPop)
+                put(KRock.name.lowercase(), KRock)
+                put(KSka.name.lowercase(), KSka)
+                put(KTrance.name.lowercase(), KTrance)
+                put(Latin.name.lowercase(), Latin)
+                put(LatinJazz.name.lowercase(), LatinJazz)
+                put(LatinPop.name.lowercase(), LatinPop)
+                put(LatinRock.name.lowercase(), LatinRock)
+                put(LiquidFunk.name.lowercase(), LiquidFunk)
+                put(LoFi.name.lowercase(), LoFi)
+                put(Lounge.name.lowercase(), Lounge)
+                put(Mambo.name.lowercase(), Mambo)
+                put(Marimba.name.lowercase(), Marimba)
+                put(Mathcore.name.lowercase(), Mathcore)
+                put(MathRock.name.lowercase(), MathRock)
+                put(Medieval.name.lowercase(), Medieval)
+                put(MedievalMetal.name.lowercase(), MedievalMetal)
+                put(MedievalRock.name.lowercase(), MedievalRock)
+                put(MelodicMetal.name.lowercase(), MelodicMetal)
+                put(MelodicMetalcore.name.lowercase(), MelodicMetalcore)
+                put(MelodicTrance.name.lowercase(), MelodicTrance)
+                put(Merengue.name.lowercase(), Merengue)
+                put(Metal.name.lowercase(), Metal)
+                put(Metalcore.name.lowercase(), Metalcore)
+                put(Microhouse.name.lowercase(), Microhouse)
+                put(Minimal.name.lowercase(), Minimal)
+                put(ModalJazz.name.lowercase(), ModalJazz)
+                put(ModernClassical.name.lowercase(), ModernClassical)
+                put(ModernRock.name.lowercase(), ModernRock)
+                put(Motown.name.lowercase(), Motown)
+                put(Mpb.name.lowercase(), Mpb)
+                put(Musical.name.lowercase(), Musical)
+                put(MushroomJazz.name.lowercase(), MushroomJazz)
+                put(Ndw.name.lowercase(), Ndw)
+                put(NeoClassical.name.lowercase(), NeoClassical)
+                put(NeoFolk.name.lowercase(), NeoFolk)
+                put(NeoMedieval.name.lowercase(), NeoMedieval)
+                put(NeoProgressive.name.lowercase(), NeoProgressive)
+                put(NeoPsychedelic.name.lowercase(), NeoPsychedelic)
+                put(NeoSoul.name.lowercase(), NeoSoul)
+                put(Nerdcore.name.lowercase(), Nerdcore)
+                put(NewAge.name.lowercase(), NewAge)
+                put(NewWave.name.lowercase(), NewWave)
+                put(Newgrass.name.lowercase(), Newgrass)
+                put(Noise.name.lowercase(), Noise)
+                put(NoisePop.name.lowercase(), NoisePop)
+                put(NoiseRock.name.lowercase(), NoiseRock)
+                put(NuDisco.name.lowercase(), NuDisco)
+                put(NuJazz.name.lowercase(), NuJazz)
+                put(NuMetal.name.lowercase(), NuMetal)
+                put(NuSoul.name.lowercase(), NuSoul)
+                put(Nwa.name.lowercase(), Nwa)
+                put(Nwobhm.name.lowercase(), Nwobhm)
+                put(Nyhc.name.lowercase(), Nyhc)
+                put(Oldies.name.lowercase(), Oldies)
+                put(Opera.name.lowercase(), Opera)
+                put(Orchestral.name.lowercase(), Orchestral)
+                put(Oriental.name.lowercase(), Oriental)
+                put(OutlawCountry.name.lowercase(), OutlawCountry)
+                put(Pop.name.lowercase(), Pop)
+                put(PopPunk.name.lowercase(), PopPunk)
+                put(PopRock.name.lowercase(), PopRock)
+                put(PostBritpop.name.lowercase(), PostBritpop)
+                put(PostDisco.name.lowercase(), PostDisco)
+                put(PostGrunge.name.lowercase(), PostGrunge)
+                put(PostHardcore.name.lowercase(), PostHardcore)
+                put(PostIndustrial.name.lowercase(), PostIndustrial)
+                put(PostMetal.name.lowercase(), PostMetal)
+                put(PostPunk.name.lowercase(), PostPunk)
+                put(PostRock.name.lowercase(), PostRock)
+                put(PowerMetal.name.lowercase(), PowerMetal)
+                put(PowerNoise.name.lowercase(), PowerNoise)
+                put(PowerPop.name.lowercase(), PowerPop)
+                put(ProgressiveBluegrass.name.lowercase(), ProgressiveBluegrass)
+                put(ProgressiveCountry.name.lowercase(), ProgressiveCountry)
+                put(ProgressiveHouse.name.lowercase(), ProgressiveHouse)
+                put(ProgressiveMetal.name.lowercase(), ProgressiveMetal)
+                put(ProgressiveRock.name.lowercase(), ProgressiveRock)
+                put(ProgressiveTrance.name.lowercase(), ProgressiveTrance)
+                put(Protopunk.name.lowercase(), Protopunk)
+                put(Psychedelic.name.lowercase(), Psychedelic)
+                put(PsychedelicPop.name.lowercase(), PsychedelicPop)
+                put(PsychedelicRock.name.lowercase(), PsychedelicRock)
+                put(PsyTrance.name.lowercase(), PsyTrance)
+                put(Punk.name.lowercase(), Punk)
+                put(PunkRock.name.lowercase(), PunkRock)
+                put(PFunk.name.lowercase(), PFunk)
+                put(Ragga.name.lowercase(), Ragga)
+                put(Rap.name.lowercase(), Rap)
+                put(Rapcore.name.lowercase(), Rapcore)
+                put(Reggae.name.lowercase(), Reggae)
+                put(Reggaeton.name.lowercase(), Reggaeton)
+                put(ReggaeFusion.name.lowercase(), ReggaeFusion)
+                put(Renaissance.name.lowercase(), Renaissance)
+                put(Rock.name.lowercase(), Rock)
+                put(Rockabilly.name.lowercase(), Rockabilly)
+                put(Rocksteady.name.lowercase(), Rocksteady)
+                put(RockAndRoll.name.lowercase(), RockAndRoll)
+                put(RootsReggae.name.lowercase(), RootsReggae)
+                put(RootsRock.name.lowercase(), RootsRock)
+                put(RAndB.name.lowercase(), RAndB)
+                put(Salsa.name.lowercase(), Salsa)
+                put(Samba.name.lowercase(), Samba)
+                put(Schlager.name.lowercase(), Schlager)
+                put(Schranz.name.lowercase(), Schranz)
+                put(Screamo.name.lowercase(), Screamo)
+                put(Shoegaze.name.lowercase(), Shoegaze)
+                put(SingerSongwriter.name.lowercase(), SingerSongwriter)
+                put(Ska.name.lowercase(), Ska)
+                put(Skacore.name.lowercase(), Skacore)
+                put(SkaPunk.name.lowercase(), SkaPunk)
+                put(Skatepunk.name.lowercase(), Skatepunk)
+                put(Skiffle.name.lowercase(), Skiffle)
+                put(Slowcore.name.lowercase(), Slowcore)
+                put(SludgeMetal.name.lowercase(), SludgeMetal)
+                put(SmoothJazz.name.lowercase(), SmoothJazz)
+                put(SoftRock.name.lowercase(), SoftRock)
+                put(Soul.name.lowercase(), Soul)
+                put(Soundtrack.name.lowercase(), Soundtrack)
+                put(SouthernRock.name.lowercase(), SouthernRock)
+                put(SpaceRock.name.lowercase(), SpaceRock)
+                put(SpeedGarage.name.lowercase(), SpeedGarage)
+                put(SpeedMetal.name.lowercase(), SpeedMetal)
+                put(Speedcore.name.lowercase(), Speedcore)
+                put(StageAndScreen.name.lowercase(), StageAndScreen)
+                put(StonerMetal.name.lowercase(), StonerMetal)
+                put(StonerRock.name.lowercase(), StonerRock)
+                put(SwampBlues.name.lowercase(), SwampBlues)
+                put(SwampPop.name.lowercase(), SwampPop)
+                put(SwampRock.name.lowercase(), SwampRock)
+                put(Swing.name.lowercase(), Swing)
+                put(SymphonicMetal.name.lowercase(), SymphonicMetal)
+                put(SymphonicRock.name.lowercase(), SymphonicRock)
+                put(Synthwave.name.lowercase(), Synthwave)
+                put(SynthPop.name.lowercase(), SynthPop)
+                put(SynthPunk.name.lowercase(), SynthPunk)
+                put(Tango.name.lowercase(), Tango)
+                put(TechnicalMetal.name.lowercase(), TechnicalMetal)
+                put(Techno.name.lowercase(), Techno)
+                put(Techstep.name.lowercase(), Techstep)
+                put(TechHouse.name.lowercase(), TechHouse)
+                put(TechTrance.name.lowercase(), TechTrance)
+                put(ThrashMetal.name.lowercase(), ThrashMetal)
+                put(Trance.name.lowercase(), Trance)
+                put(Trap.name.lowercase(), Trap)
+                put(TribalHouse.name.lowercase(), TribalHouse)
+                put(TripHop.name.lowercase(), TripHop)
+                put(TripRock.name.lowercase(), TripRock)
+                put(TropicalHouse.name.lowercase(), TropicalHouse)
+                put(Turntablism.name.lowercase(), Turntablism)
+                put(TwoStep.name.lowercase(), TwoStep)
+                put(VocalHouse.name.lowercase(), VocalHouse)
+                put(VocalJazz.name.lowercase(), VocalJazz)
+                put(VocalTrance.name.lowercase(), VocalTrance)
+                put(World.name.lowercase(), World)
+                put(WorldFusion.name.lowercase(), WorldFusion)
             }
-            return UNDEFINED
+        }
+
+        /**
+         * Parses a genre string into a set of [Genre] instances.
+         *
+         * Supports comma-separated genre tags (e.g. "Rock, Alternative"). Each segment is
+         * matched case-insensitively against the known genre list. Unrecognized segments
+         * are wrapped in [Custom] to preserve their original value.
+         *
+         * @param value the raw genre string from audio metadata or JSON persistence
+         * @return a set of resolved genres, or an empty set if [value] is blank
+         */
+        @JvmStatic
+        fun parseGenre(value: String): Set<Genre> {
+            if (value.isBlank()) return emptySet()
+            return value.split(",")
+                .map { it.trim() }
+                .filter { it.isNotEmpty() }
+                .map { part -> BY_NAME[part.lowercase()] ?: Custom(part) }
+                .toSet()
         }
     }
 }

--- a/music-commons-api/src/main/kotlin/net/transgressoft/commons/music/audio/ReactiveAudioItem.kt
+++ b/music-commons-api/src/main/kotlin/net/transgressoft/commons/music/audio/ReactiveAudioItem.kt
@@ -24,7 +24,9 @@ import java.time.LocalDateTime
 import java.time.ZoneOffset
 import kotlin.io.path.absolutePathString
 import kotlinx.coroutines.Job
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 
@@ -45,7 +47,7 @@ interface ReactiveAudioItem<I: ReactiveAudioItem<I>>: ReactiveEntity<Int, I>, Co
     var artist: Artist
     val artistsInvolved: Set<Artist>
     var album: Album
-    var genre: Genre
+    var genres: Set<Genre>
     var comments: String?
     var trackNumber: Short?
     var discNumber: Short?
@@ -114,7 +116,7 @@ fun ReactiveAudioItem<*>.toJsonObject(): JsonObject =
                 )
             }
         )
-        put("genre", genre.name)
+        put("genres", JsonArray(genres.map { it.name }.sorted().map(::JsonPrimitive)))
         put("comments", comments)
         put("trackNumber", trackNumber)
         put("discNumber", discNumber)

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/MusicLibrary.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/MusicLibrary.kt
@@ -248,26 +248,24 @@ class MusicLibrary private constructor(
             val audioLibrary = DefaultAudioLibrary(audioRepo)
 
             var waveformRepository: DefaultAudioWaveformRepository<AudioItem>? = null
-            val playlistHierarchy: DefaultPlaylistHierarchy
             try {
                 // 2. Waveform repository
                 val waveformRepo = createWaveformRepository()
                 waveformRepository = DefaultAudioWaveformRepository(waveformRepo)
 
                 // 3. Playlist hierarchy last — needs AudioItem already registered in LirpContext
-                playlistHierarchy = createPlaylistHierarchy()
+                val playlistHierarchy = createPlaylistHierarchy()
+
+                // 4. Wire subscriptions so audio library events propagate to subscribers
+                audioLibrary.subscribe(waveformRepository)
+                audioLibrary.subscribe(playlistHierarchy)
+
+                return MusicLibrary(audioLibrary, playlistHierarchy, waveformRepository)
             } catch (ex: Exception) {
                 waveformRepository?.close()
                 audioLibrary.close()
                 throw ex
             }
-
-            // 4. Wire subscriptions so audio library events propagate to subscribers
-            val waveforms = checkNotNull(waveformRepository) { "waveformRepository must be initialized before wiring subscriptions" }
-            audioLibrary.subscribe(waveforms)
-            audioLibrary.subscribe(playlistHierarchy)
-
-            return MusicLibrary(audioLibrary, playlistHierarchy, waveforms)
         }
 
         // Safe cast: generic type erased at runtime but guaranteed by the builder/serializer contract

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/AudioItemMetadataUtils.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/AudioItemMetadataUtils.kt
@@ -56,7 +56,7 @@ data class AudioFileMetadata(
     val title: String,
     val artist: Artist,
     val album: Album,
-    val genre: Genre,
+    val genres: Set<Genre>,
     val comments: String?,
     val trackNumber: Short?,
     val discNumber: Short?,
@@ -95,7 +95,7 @@ object AudioItemMetadataUtils {
             title = getFieldIfExisting(tag, FieldKey.TITLE) ?: "",
             artist = parseArtist(tag),
             album = parseAlbum(tag),
-            genre = getFieldIfExisting(tag, FieldKey.GENRE)?.let { Genre.parseGenre(it) } ?: Genre.UNDEFINED,
+            genres = getFieldIfExisting(tag, FieldKey.GENRE)?.let { Genre.parseGenre(it) } ?: emptySet(),
             comments = getFieldIfExisting(tag, FieldKey.COMMENT)?.takeIf { it.isNotEmpty() },
             trackNumber = parseOptionalShort(getFieldIfExisting(tag, FieldKey.TRACK)),
             discNumber = parseOptionalShort(getFieldIfExisting(tag, FieldKey.DISC_NO)),
@@ -129,7 +129,7 @@ object AudioItemMetadataUtils {
         title: String,
         album: Album,
         artist: Artist,
-        genre: Genre,
+        genres: Set<Genre>,
         comments: String?,
         trackNumber: Short?,
         discNumber: Short?,
@@ -141,7 +141,7 @@ object AudioItemMetadataUtils {
     ) {
         val audio = AudioFileIO.read(path.toFile())
         createTag(
-            audio.audioHeader.format, title, album, artist, genre,
+            audio.audioHeader.format, title, album, artist, genres,
             comments, trackNumber, discNumber, bpm, encoder,
             coverImageBytes, fileName, logger
         ).let {
@@ -193,10 +193,10 @@ object AudioItemMetadataUtils {
     private fun parseCoverBytes(tag: Tag): ByteArray? = tag.artworkList.isNotEmpty().takeIf { it }?.let { tag.firstArtwork.binaryData }
 
     private fun parseOptionalShort(value: String?): Short? =
-        value?.takeUnless { it.isEmpty().and(it == "0") }?.toShortOrNull()?.takeIf { it > 0 }
+        value?.takeUnless { it.isEmpty() || it == "0" }?.toShortOrNull()?.takeIf { it > 0 }
 
     private fun parseOptionalBpm(value: String?): Float? =
-        value?.takeUnless { it.isEmpty().and(it == "0") }?.toFloatOrNull()?.takeIf { it > 0 }
+        value?.takeUnless { it.isEmpty() || it == "0" }?.toFloatOrNull()?.takeIf { it > 0 }
 
     @SuppressWarnings("kotlin:S107")
     private fun createTag(
@@ -204,7 +204,7 @@ object AudioItemMetadataUtils {
         title: String,
         album: Album,
         artist: Artist,
-        genre: Genre,
+        genres: Set<Genre>,
         comments: String?,
         trackNumber: Short?,
         discNumber: Short?,
@@ -246,7 +246,7 @@ object AudioItemMetadataUtils {
                 WavInfoTag()
             }
         }.also {
-            setTrackFieldsToTag(it, title, album, artist, genre, comments, trackNumber, discNumber, bpm, encoder, coverImageBytes, fileName, logger)
+            setTrackFieldsToTag(it, title, album, artist, genres, comments, trackNumber, discNumber, bpm, encoder, coverImageBytes, fileName, logger)
         }
 
     @SuppressWarnings("kotlin:S107")
@@ -255,7 +255,7 @@ object AudioItemMetadataUtils {
         title: String,
         album: Album,
         artist: Artist,
-        genre: Genre,
+        genres: Set<Genre>,
         comments: String?,
         trackNumber: Short?,
         discNumber: Short?,
@@ -269,7 +269,7 @@ object AudioItemMetadataUtils {
         tag.setField(FieldKey.ALBUM, album.name)
         tag.setField(FieldKey.ALBUM_ARTIST, album.albumArtist.name)
         tag.setField(FieldKey.ARTIST, artist.name)
-        tag.setField(FieldKey.GENRE, genre.capitalize())
+        tag.setField(FieldKey.GENRE, genres.joinToString(", ") { it.name })
         tag.setField(FieldKey.COUNTRY, artist.countryCode.name)
         comments?.let { tag.setField(FieldKey.COMMENT, it) }
         trackNumber?.let { tag.setField(FieldKey.TRACK, it.toString()) }

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/AudioItemSerializer.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/AudioItemSerializer.kt
@@ -42,6 +42,7 @@ import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.floatOrNull
 import kotlinx.serialization.json.int
 import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.long
@@ -66,7 +67,7 @@ internal object AudioItemSerializer : AudioItemSerializerBase<AudioItem>() {
         bitRate: Int,
         artist: Artist,
         album: Album,
-        genre: Genre,
+        genres: Set<Genre>,
         comments: String?,
         trackNumber: Short?,
         discNumber: Short?,
@@ -78,7 +79,7 @@ internal object AudioItemSerializer : AudioItemSerializerBase<AudioItem>() {
         playCount: Short
     ): AudioItem =
         MutableAudioItem(
-            path, id, title, duration, bitRate, artist, album, genre,
+            path, id, title, duration, bitRate, artist, album, genres,
             comments, trackNumber, discNumber, bpm, encoder, encoding,
             dateOfCreation, lastDateModified, playCount
         )
@@ -104,7 +105,7 @@ abstract class AudioItemSerializerBase<I : ReactiveAudioItem<I>> : LirpEntityPol
      * @param bitRate audio bitrate in kbps
      * @param artist track artist
      * @param album track album
-     * @param genre track genre
+     * @param genres track genres
      * @param comments optional comments
      * @param trackNumber optional track number
      * @param discNumber optional disc number
@@ -124,7 +125,7 @@ abstract class AudioItemSerializerBase<I : ReactiveAudioItem<I>> : LirpEntityPol
         bitRate: Int,
         artist: Artist,
         album: Album,
-        genre: Genre,
+        genres: Set<Genre>,
         comments: String?,
         trackNumber: Short?,
         discNumber: Short?,
@@ -182,7 +183,13 @@ abstract class AudioItemSerializerBase<I : ReactiveAudioItem<I>> : LirpEntityPol
         val labelName = requireString(labelObj, "name", "album.label.name")
         val album = ImmutableAlbum(albumName, ImmutableArtist.of(albumArtistName, albumArtistCountryCode), isCompilation, year, ImmutableLabel.of(labelName))
 
-        val genre = Genre.parseGenre(requireString(json, "genre"))
+        val genres: Set<Genre> =
+            json["genres"]?.jsonArray
+                ?.mapNotNull { it.jsonPrimitive.contentOrNull }
+                ?.flatMap { Genre.parseGenre(it) }
+                ?.toSet()
+                ?: json["genre"]?.jsonPrimitive?.contentOrNull?.let { Genre.parseGenre(it) }
+                ?: emptySet()
         val comments = json["comments"]?.jsonPrimitive?.contentOrNull
         val trackNumber = json["trackNumber"]?.jsonPrimitive?.intOrNull?.toShort()
         val discNumber = json["discNumber"]?.jsonPrimitive?.intOrNull?.toShort()
@@ -194,7 +201,7 @@ abstract class AudioItemSerializerBase<I : ReactiveAudioItem<I>> : LirpEntityPol
         val playCount = json["playCount"]?.jsonPrimitive?.intOrNull?.toShort() ?: 0.toShort()
 
         return constructEntity(
-            path, id, title, duration, bitRate, artist, album, genre,
+            path, id, title, duration, bitRate, artist, album, genres,
             comments, trackNumber, discNumber, bpm, encoder, encoding,
             dateOfCreation, lastDateModified, playCount
         )

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/MutableAudioItem.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/MutableAudioItem.kt
@@ -92,7 +92,7 @@ internal class MutableAudioItem(
         bitRate: Int,
         artist: Artist,
         album: Album,
-        genre: Genre,
+        genres: Set<Genre>,
         comments: String?,
         trackNumber: Short?,
         discNumber: Short?,
@@ -107,7 +107,7 @@ internal class MutableAudioItem(
         this.title = title
         this._duration = duration
         this.artist = artist
-        this.genre = genre
+        this.genres = genres
         this.comments = comments
         this.trackNumber = trackNumber
         this.discNumber = discNumber
@@ -132,27 +132,32 @@ internal class MutableAudioItem(
     private var _bitRate: Int = metadata.bitRate
 
     @Serializable
-    override val bitRate: Int = _bitRate
+    override val bitRate: Int
+        get() = _bitRate
 
     private var _duration: Duration = metadata.duration
 
     @Serializable
-    override val duration: Duration = _duration
+    override val duration: Duration
+        get() = _duration
 
     private var _encoder: String? = metadata.encoder?.takeIf { it.isNotEmpty() }
 
     @Serializable
-    override val encoder: String? = _encoder
+    override val encoder: String?
+        get() = _encoder
 
     private var _encoding: String? = metadata.encoding?.takeIf { it.isNotEmpty() }
 
     @Serializable
-    override val encoding: String? = _encoding
+    override val encoding: String?
+        get() = _encoding
 
     private var _dateOfCreation: LocalDateTime = LocalDateTime.now()
 
     @Serializable
-    override val dateOfCreation: LocalDateTime = _dateOfCreation
+    override val dateOfCreation: LocalDateTime
+        get() = _dateOfCreation
 
     @Serializable
     override var lastDateModified: LocalDateTime = _dateOfCreation
@@ -196,10 +201,17 @@ internal class MutableAudioItem(
     override var artist: Artist by reactiveProperty(metadata.artist)
 
     @Serializable
-    override var genre: Genre by reactiveProperty(metadata.genre)
+    override var genres: Set<Genre> by reactiveProperty(metadata.genres)
+
+    @Transient
+    private var _comments: String? = metadata.comments
 
     @Serializable
-    override var comments: String? by reactiveProperty(metadata.comments)
+    override var comments: String?
+        by reactiveProperty(
+            getter = { _comments },
+            setter = { _comments = it?.takeIf { s -> s.isNotEmpty() } }
+        )
 
     @Serializable
     override var trackNumber: Short? by reactiveProperty(metadata.trackNumber)
@@ -234,7 +246,7 @@ internal class MutableAudioItem(
         ioScope.launch {
             logger.debug { "Writing metadata of $this to file '${path.toAbsolutePath()}'" }
             writeMetadataToFile(
-                path, title, album, artist, genre,
+                path, title, album, artist, genres,
                 comments, trackNumber, discNumber, bpm, encoder,
                 coverImageBytes, fileName, logger
             )
@@ -256,16 +268,16 @@ internal class MutableAudioItem(
             title == that.title &&
             artist == that.artist &&
             album == that.album &&
-            genre === that.genre &&
+            genres == that.genres &&
             comments == that.comments &&
             duration == that.duration
     }
 
-    override fun hashCode() = Objects.hash(path, title, artist, album, genre, comments, trackNumber, discNumber, bpm, duration)
+    override fun hashCode() = Objects.hash(path, title, artist, album, genres, comments, trackNumber, discNumber, bpm, duration)
 
     override fun clone(): MutableAudioItem =
         MutableAudioItem(
-            path, id, title, duration, bitRate, artist, album, genre,
+            path, id, title, duration, bitRate, artist, album, genres,
             comments, trackNumber, discNumber, bpm, encoder, encoding,
             dateOfCreation, lastDateModified, _playCount
         )

--- a/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/audio/ArtistCatalogRegistryTest.kt
+++ b/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/audio/ArtistCatalogRegistryTest.kt
@@ -57,7 +57,7 @@ internal class ArtistCatalogRegistryTest : BehaviorSpec({
                 val audioItemBeforeChange = audioItem.clone()
                 audioItem.apply {
                     title = "Natural Blues"
-                    genre = Genre.ROCK
+                    genres = setOf(Genre.Rock)
                     comments = "Comments"
                     bpm = 120f
                 }
@@ -218,7 +218,7 @@ internal class ArtistCatalogRegistryTest : BehaviorSpec({
                     album = expectedAlbum
                     trackNumber = 1
                     discNumber = 1
-                    genre = Genre.UNDEFINED
+                    genres = emptySet()
                 }.next()
             val audioItem = createAudioItem(audioFilePath)
 
@@ -257,7 +257,7 @@ internal class ArtistCatalogRegistryTest : BehaviorSpec({
                 receivedEvents.clear()
 
                 val audioItemBeforeChange = audioItem.clone()
-                audioItem.genre = Genre.ROCK
+                audioItem.genres = setOf(Genre.Rock)
 
                 registry.updateCatalog(audioItem, audioItemBeforeChange)
 

--- a/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/audio/AudioItemSerializerTest.kt
+++ b/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/audio/AudioItemSerializerTest.kt
@@ -11,6 +11,7 @@ import io.kotest.property.Arb
 import io.kotest.property.arbitrary.next
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -39,7 +40,7 @@ internal class AudioItemSerializerTest : StringSpec({
                 this.title = "Come Together"
                 this.artist = artist
                 this.album = album
-                this.genre = Genre.ROCK
+                this.genres = setOf(Genre.Rock)
                 this.comments = "Classic track"
                 this.trackNumber = 1
                 this.discNumber = 1
@@ -58,7 +59,7 @@ internal class AudioItemSerializerTest : StringSpec({
         encoded shouldContain "The Beatles"
         encoded shouldContain "\"album\""
         encoded shouldContain "Abbey Road"
-        encoded shouldContain "\"genre\""
+        encoded shouldContain "\"genres\""
         encoded shouldContain "\"playCount\""
     }
 
@@ -72,7 +73,7 @@ internal class AudioItemSerializerTest : StringSpec({
                 this.title = "Round Trip Song"
                 this.artist = artist
                 this.album = album
-                this.genre = Genre.ROCK
+                this.genres = setOf(Genre.Rock)
                 this.comments = "Test comment"
                 this.trackNumber = 3
                 this.discNumber = 2
@@ -98,7 +99,7 @@ internal class AudioItemSerializerTest : StringSpec({
         decodedItem.album.isCompilation shouldBe originalItem.album.isCompilation
         decodedItem.album.year shouldBe originalItem.album.year
         decodedItem.album.label.name shouldBe originalItem.album.label.name
-        decodedItem.genre shouldBe originalItem.genre
+        decodedItem.genres shouldBe originalItem.genres
         decodedItem.comments shouldBe originalItem.comments
         decodedItem.trackNumber shouldBe originalItem.trackNumber
         decodedItem.discNumber shouldBe originalItem.discNumber

--- a/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/audio/MutableAudioItemTest.kt
+++ b/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/audio/MutableAudioItemTest.kt
@@ -48,7 +48,7 @@ internal class MutableAudioItemTest : FunSpec({
             trackNumber = 13,
             discNumber = 1,
             comments = "Best song ever!",
-            genre = Genre.ROCK,
+            genres = setOf(Genre.Rock),
             encoder = "transgressoft",
             playCount = 0
         ).next()
@@ -77,11 +77,11 @@ internal class MutableAudioItemTest : FunSpec({
                         expectedAttributes.apply {
                             // when a MutableAudioItem is created outside a repository it does not have and ID
                             id = UNASSIGNED_ID
-                            // the album artists' country code is not saved in the ID3 tag
+                            // the album artists' and label's country code is not saved in the ID3 tag
                             album =
                                 ImmutableAlbum(
                                     "Help!",
-                                    ImmutableArtist.of("The Beatles Band", CountryCode.UNDEFINED), true, 1965, ImmutableLabel.of("EMI", CountryCode.US)
+                                    ImmutableArtist.of("The Beatles Band", CountryCode.UNDEFINED), true, 1965, ImmutableLabel.of("EMI", CountryCode.UNDEFINED)
                                 )
                         }
                 }
@@ -138,7 +138,7 @@ internal class MutableAudioItemTest : FunSpec({
                 loadedAudioItem.trackNumber shouldBe audioItem.trackNumber
                 loadedAudioItem.discNumber shouldBe audioItem.discNumber
                 loadedAudioItem.comments shouldBe audioItem.comments
-                loadedAudioItem.genre shouldBe audioItem.genre
+                loadedAudioItem.genres shouldBe audioItem.genres
                 loadedAudioItem.encoding shouldBe audioItem.encoding
                 loadedAudioItem.encoder shouldBe audioItem.encoder
                 loadedAudioItem.playCount shouldBe audioItem.playCount

--- a/music-commons-fx-test/src/main/kotlin/net/transgressoft/commons/fx/music/FxAudioArb.kt
+++ b/music-commons-fx-test/src/main/kotlin/net/transgressoft/commons/fx/music/FxAudioArb.kt
@@ -64,7 +64,7 @@ fun Arb.Companion.fxAudioItem(attributes: AudioItemTestAttributes): Arb<Observab
             every { title } returns attributes.title
             every { artist } returns attributes.artist
             every { album } returns attributes.album
-            every { genre } returns attributes.genre
+            every { genres } returns attributes.genres
             every { comments } returns attributes.comments
             every { trackNumber } returns attributes.trackNumber
             every { discNumber } returns attributes.discNumber
@@ -81,8 +81,8 @@ fun Arb.Companion.fxAudioItem(attributes: AudioItemTestAttributes): Arb<Observab
             every { this@mockk.albumProperty } answers {
                 SimpleObjectProperty(this, "album", attributes.album)
             }
-            every { this@mockk.genreProperty } answers {
-                SimpleObjectProperty(this, "genre", attributes.genre)
+            every { this@mockk.genresProperty } answers {
+                SimpleObjectProperty(this, "genres", attributes.genres)
             }
             every { this@mockk.commentsProperty } answers {
                 SimpleStringProperty(this, "comments", attributes.comments)

--- a/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/FXMusicLibrary.kt
+++ b/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/FXMusicLibrary.kt
@@ -229,24 +229,27 @@ class FXMusicLibrary private constructor(
             val audioLibrary = FXAudioLibrary(audioRepo)
 
             var waveformRepository: AudioWaveformRepository<AudioWaveform, ObservableAudioItem>? = null
-            val playlistHierarchy: FXPlaylistHierarchy
             try {
                 val waveformRepo = createWaveformRepository()
                 waveformRepository = audioWaveformRepository(waveformRepo)
 
                 val playlistRepo = createPlaylistRepository()
-                playlistHierarchy = FXPlaylistHierarchy(playlistRepo)
+                val playlistHierarchy = FXPlaylistHierarchy(playlistRepo)
+
+                try {
+                    audioLibrary.subscribe(waveformRepository)
+                    audioLibrary.subscribe(playlistHierarchy)
+                } catch (subscribeEx: Exception) {
+                    playlistHierarchy.close()
+                    throw subscribeEx
+                }
+
+                return FXMusicLibrary(audioLibrary, playlistHierarchy, waveformRepository)
             } catch (ex: Exception) {
                 waveformRepository?.close()
                 audioLibrary.close()
                 throw ex
             }
-
-            val waveforms = checkNotNull(waveformRepository) { "waveformRepository must be initialized before wiring subscriptions" }
-            audioLibrary.subscribe(waveforms)
-            audioLibrary.subscribe(playlistHierarchy)
-
-            return FXMusicLibrary(audioLibrary, playlistHierarchy, waveforms)
         }
 
         // Safe cast: generic type erased at runtime but guaranteed by the builder/serializer contract

--- a/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/audio/FXAudioItem.kt
+++ b/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/audio/FXAudioItem.kt
@@ -103,7 +103,7 @@ class FXAudioItem internal constructor(override val path: Path, override val id:
             bitRate: Int,
             artist: Artist,
             album: Album,
-            genre: Genre,
+            genres: Set<Genre>,
             comments: String?,
             trackNumber: Short?,
             discNumber: Short?,
@@ -118,7 +118,7 @@ class FXAudioItem internal constructor(override val path: Path, override val id:
             this.title = title
             this._duration = duration
             this.artist = artist
-            this.genre = genre
+            this.genres = genres
             this.comments = comments
             this.trackNumber = trackNumber
             this.discNumber = discNumber
@@ -146,21 +146,25 @@ class FXAudioItem internal constructor(override val path: Path, override val id:
         private var _bitRate: Int = metadata.bitRate
 
         @Serializable
-        override val bitRate: Int = _bitRate
+        override val bitRate: Int
+            get() = _bitRate
 
         private var _duration: Duration = metadata.duration
 
-        override val duration: Duration = _duration
+        override val duration: Duration
+            get() = _duration
 
         private var _encoder: String? = metadata.encoder?.takeIf { it.isNotEmpty() }
 
         @Serializable
-        override val encoder: String? = _encoder
+        override val encoder: String?
+            get() = _encoder
 
         private var _encoding: String? = metadata.encoding?.takeIf { it.isNotEmpty() }
 
         @Serializable
-        override val encoding: String? = _encoding
+        override val encoding: String?
+            get() = _encoding
 
         private var _dateOfCreation: LocalDateTime = LocalDateTime.now()
 
@@ -241,12 +245,13 @@ class FXAudioItem internal constructor(override val path: Path, override val id:
 
         @Transient
         @Suppress("UNCHECKED_CAST")
-        override val genreProperty: ObjectProperty<Genre> = fxObject(metadata.genre) as ObjectProperty<Genre>
+        override val genresProperty: ObjectProperty<Set<Genre>> = fxObject(metadata.genres.toSet()) as ObjectProperty<Set<Genre>>
 
-        override var genre: Genre = metadata.genre
+        override var genres: Set<Genre> = metadata.genres.toSet()
             set(value) {
-                mutateAndPublish { field = value }
-                genreProperty.set(value)
+                val copy = value.toSet()
+                mutateAndPublish { field = copy }
+                genresProperty.set(copy)
             }
 
         @Transient
@@ -351,8 +356,8 @@ class FXAudioItem internal constructor(override val path: Path, override val id:
             albumProperty.addListener { _, _, newAlbum ->
                 if (newAlbum != null && album != newAlbum) album = newAlbum
             }
-            genreProperty.addListener { _, _, newGenre ->
-                if (newGenre != null && genre != newGenre) genre = newGenre
+            genresProperty.addListener { _, _, newGenres ->
+                if (newGenres != null && genres != newGenres) genres = newGenres
             }
             commentsProperty.addListener { _, _, newComments ->
                 val newValue = newComments.takeIf { it.isNotEmpty() }
@@ -387,7 +392,7 @@ class FXAudioItem internal constructor(override val path: Path, override val id:
             ioScope.launch {
                 logger.debug { "Writing metadata of $this to file '${path.toAbsolutePath()}'" }
                 writeMetadataToFile(
-                    path, title, album, artist, genre,
+                    path, title, album, artist, genres,
                     comments, trackNumber, discNumber, bpm, encoder,
                     coverImageBytes, fileName, logger
                 )
@@ -413,7 +418,7 @@ class FXAudioItem internal constructor(override val path: Path, override val id:
                 title == that.title &&
                 artist == that.artist &&
                 album == that.album &&
-                genre === that.genre &&
+                genres == that.genres &&
                 comments == that.comments &&
                 duration == that.duration &&
                 playCount == that.playCount &&
@@ -421,11 +426,11 @@ class FXAudioItem internal constructor(override val path: Path, override val id:
         }
 
         override fun hashCode() =
-            Objects.hash(path, title, artist, album, genre, comments, trackNumber, discNumber, bpm, duration, playCount, coverImageBytes.contentHashCode())
+            Objects.hash(path, title, artist, album, genres, comments, trackNumber, discNumber, bpm, duration, playCount, coverImageBytes.contentHashCode())
 
         override fun clone(): FXAudioItem =
             FXAudioItem(
-                path, id, title, duration, bitRate, artist, album, genre,
+                path, id, title, duration, bitRate, artist, album, genres,
                 comments, trackNumber, discNumber, bpm, encoder, encoding,
                 dateOfCreation, lastDateModified, playCount
             )

--- a/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/audio/ObservableAudioItem.kt
+++ b/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/audio/ObservableAudioItem.kt
@@ -48,7 +48,7 @@ interface ObservableAudioItem : ReactiveAudioItem<ObservableAudioItem> {
 
     val albumProperty: ObjectProperty<Album>
 
-    val genreProperty: ObjectProperty<Genre>
+    val genresProperty: ObjectProperty<Set<Genre>>
 
     val commentsProperty: StringProperty
 

--- a/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/audio/ObservableAudioItemSerializer.kt
+++ b/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/audio/ObservableAudioItemSerializer.kt
@@ -48,7 +48,7 @@ internal object ObservableAudioItemSerializer : AudioItemSerializerBase<Observab
         bitRate: Int,
         artist: Artist,
         album: Album,
-        genre: Genre,
+        genres: Set<Genre>,
         comments: String?,
         trackNumber: Short?,
         discNumber: Short?,
@@ -60,8 +60,22 @@ internal object ObservableAudioItemSerializer : AudioItemSerializerBase<Observab
         playCount: Short
     ): ObservableAudioItem =
         FXAudioItem(
-            path, id, title, duration, bitRate, artist, album, genre,
-            comments, trackNumber, discNumber, bpm, encoder, encoding,
-            dateOfCreation, lastDateModified, playCount
+            path = path,
+            id = id,
+            title = title,
+            duration = duration,
+            bitRate = bitRate,
+            artist = artist,
+            album = album,
+            genres = genres,
+            comments = comments,
+            trackNumber = trackNumber,
+            discNumber = discNumber,
+            bpm = bpm,
+            encoder = encoder,
+            encoding = encoding,
+            dateOfCreation = dateOfCreation,
+            lastDateModified = lastDateModified,
+            playCount = playCount
         )
 }

--- a/music-commons-fx/src/test/kotlin/net/transgressoft/commons/fx/music/audio/FXAudioItemTest.kt
+++ b/music-commons-fx/src/test/kotlin/net/transgressoft/commons/fx/music/audio/FXAudioItemTest.kt
@@ -24,7 +24,6 @@ import io.kotest.property.arbitrary.next
 import javafx.scene.image.Image
 import java.io.ByteArrayInputStream
 import java.util.Optional
-import kotlin.random.Random
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.serialization.json.Json
 
@@ -44,11 +43,11 @@ internal class FXAudioItemTest : StringSpec({
             fxAudioItem.titleProperty.value shouldBe fxAudioItem.title
             fxAudioItem.artistProperty.value shouldBe fxAudioItem.artist
             fxAudioItem.albumProperty.value shouldBe fxAudioItem.album
-            fxAudioItem.genre shouldBe fxAudioItem.genre
-            fxAudioItem.comments shouldBe fxAudioItem.comments
-            fxAudioItem.trackNumber shouldBe fxAudioItem.trackNumber
-            fxAudioItem.discNumber shouldBe fxAudioItem.discNumber
-            fxAudioItem.bpm shouldBe fxAudioItem.bpm
+            fxAudioItem.genresProperty.value shouldBe fxAudioItem.genres
+            fxAudioItem.commentsProperty.value shouldBe (fxAudioItem.comments ?: "")
+            fxAudioItem.trackNumberProperty.value shouldBe (fxAudioItem.trackNumber?.toInt() ?: -1)
+            fxAudioItem.discNumberProperty.value shouldBe (fxAudioItem.discNumber?.toInt() ?: -1)
+            fxAudioItem.bpmProperty.value shouldBe (fxAudioItem.bpm ?: 0f)
             fxAudioItem.coverImageProperty.value shouldBePresent {
                 it.height shouldBe Image(ByteArrayInputStream(fxAudioItem.coverImageBytes)).height
             }
@@ -84,10 +83,11 @@ internal class FXAudioItemTest : StringSpec({
         }
 
         lastDateUpdated = fxAudioItem.lastDateModified
-        val newGenre = fxAudioItem.genre.randomDifferent()
-        fxAudioItem.genre = newGenre
+        val newGenres = fxAudioItem.genres.randomDifferent()
+        fxAudioItem.genresProperty.set(newGenres)
         eventually(100.milliseconds) {
-            fxAudioItem.genreProperty.value shouldBe newGenre
+            fxAudioItem.genres shouldBe newGenres
+            fxAudioItem.genresProperty.value shouldBe newGenres
             fxAudioItem.lastDateModified shouldBeAfter lastDateUpdated
             fxAudioItem.lastDateModifiedProperty.value shouldBeAfter lastDateUpdated
         }
@@ -178,11 +178,15 @@ internal class FXAudioItemTest : StringSpec({
             loadedAudioItem.album.label.countryCode shouldBe CountryCode.UNDEFINED // label country code is not updated because there is no ID3 tag for it
             loadedAudioItem.artist.name shouldBe fxAudioItem.artist.name
             loadedAudioItem.artist.countryCode shouldBe fxAudioItem.artist.countryCode // artist country code is saved into COUNTRY ID3 tag
-            loadedAudioItem.genre shouldBe fxAudioItem.genre
+            loadedAudioItem.genres shouldBe fxAudioItem.genres
             loadedAudioItem.comments shouldBe fxAudioItem.comments
             loadedAudioItem.trackNumber shouldBe fxAudioItem.trackNumber
             loadedAudioItem.discNumber shouldBe fxAudioItem.discNumber
-            loadedAudioItem.bpm shouldBe fxAudioItem.bpm
+            if (testAudioFile.toString().endsWith(".m4a")) {
+                loadedAudioItem.bpm shouldBe fxAudioItem.bpm?.toInt()?.toFloat()
+            } else {
+                loadedAudioItem.bpm shouldBe fxAudioItem.bpm
+            }
             loadedAudioItem.coverImageBytes shouldBe fxAudioItem.coverImageBytes
             loadedAudioItem.playCount shouldBe fxAudioItem.playCount
             loadedAudioItem.uniqueId shouldBe fxAudioItem.uniqueId
@@ -227,7 +231,13 @@ internal class FXAudioItemTest : StringSpec({
     }
 })
 
-fun Genre.randomDifferent(): Genre {
-    val values = enumValues<Genre>().filter { it != this }
-    return values[Random.nextInt(values.size)]
+fun Set<Genre>.randomDifferent(): Set<Genre> {
+    val knownGenres =
+        listOf(
+            Genre.Rock, Genre.Alternative, Genre.Jazz, Genre.Blues,
+            Genre.Electronic, Genre.HipHop, Genre.Classical, Genre.Folk,
+            Genre.Metal, Genre.Pop, Genre.Punk, Genre.Reggae
+        )
+    val differentGenre = knownGenres.first { it !in this }
+    return setOf(differentGenre)
 }

--- a/music-commons-fx/src/test/kotlin/net/transgressoft/commons/fx/music/audio/ObservableAudioItemSerializerTest.kt
+++ b/music-commons-fx/src/test/kotlin/net/transgressoft/commons/fx/music/audio/ObservableAudioItemSerializerTest.kt
@@ -1,6 +1,7 @@
 package net.transgressoft.commons.fx.music.audio
 
 import net.transgressoft.commons.music.audio.AudioItemTestFactory
+import net.transgressoft.commons.music.audio.Genre
 import net.transgressoft.commons.music.audio.VirtualFiles.virtualAudioFile
 import io.kotest.assertions.json.shouldContainJsonKey
 import io.kotest.core.spec.style.StringSpec
@@ -9,6 +10,9 @@ import io.kotest.property.Arb
 import io.kotest.property.arbitrary.next
 import java.time.temporal.ChronoUnit.SECONDS
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.put
 
 /**
  * Tests for [ObservableAudioItemSerializer] verifying golden JSON structure and round-trip fidelity.
@@ -33,7 +37,7 @@ internal class ObservableAudioItemSerializerTest : StringSpec({
         encoded shouldContainJsonKey "bitRate"
         encoded shouldContainJsonKey "artist"
         encoded shouldContainJsonKey "album"
-        encoded shouldContainJsonKey "genre"
+        encoded shouldContainJsonKey "genres"
         encoded shouldContainJsonKey "dateOfCreation"
         encoded shouldContainJsonKey "lastDateModified"
         encoded shouldContainJsonKey "playCount"
@@ -53,7 +57,7 @@ internal class ObservableAudioItemSerializerTest : StringSpec({
         decoded.bitRate shouldBe original.bitRate
         decoded.artist shouldBe original.artist
         decoded.album shouldBe original.album
-        decoded.genre shouldBe original.genre
+        decoded.genres shouldBe original.genres
         decoded.comments shouldBe original.comments
         decoded.trackNumber shouldBe original.trackNumber
         decoded.discNumber shouldBe original.discNumber
@@ -63,6 +67,29 @@ internal class ObservableAudioItemSerializerTest : StringSpec({
         decoded.dateOfCreation.truncatedTo(SECONDS) shouldBe original.dateOfCreation.truncatedTo(SECONDS)
         decoded.lastDateModified.truncatedTo(SECONDS) shouldBe original.lastDateModified.truncatedTo(SECONDS)
         decoded.playCount shouldBe original.playCount
+    }
+
+    "ObservableAudioItemSerializer deserializes legacy single-genre field into genres set" {
+        val path =
+            Arb.virtualAudioFile {
+                this.genres = setOf(Genre.Rock)
+            }.next()
+        val original = FXAudioItem(path, AudioItemTestFactory.nextTestId())
+
+        val encoded = json.encodeToString(ObservableAudioItemSerializer, original)
+
+        // Replace "genres" array with legacy "genre" single-string field
+        val jsonTree = Json.parseToJsonElement(encoded).jsonObject
+        val legacyItem =
+            buildJsonObject {
+                for ((k, v) in jsonTree) {
+                    if (k != "genres") put(k, v)
+                }
+                put("genre", "Rock")
+            }
+
+        val decoded = json.decodeFromString(ObservableAudioItemSerializer, legacyItem.toString())
+        decoded.genres shouldBe setOf(Genre.Rock)
     }
 
     "ObservableAudioItemMapSerializer round-trip preserves the map entries" {

--- a/music-commons-fx/src/test/kotlin/net/transgressoft/commons/fx/music/player/JavaFxPlayerTest.kt
+++ b/music-commons-fx/src/test/kotlin/net/transgressoft/commons/fx/music/player/JavaFxPlayerTest.kt
@@ -77,7 +77,7 @@ internal class JavaFxPlayerTest : StringSpec({
     }
 
     "Playing an audio item increases the play count and serializes the repository".config(
-        enabledIf = { System.getenv("CI") == null }
+        enabled = System.getenv("CI") == null
     ) {
         player.subscribe(observableAudioItemRepository.playerSubscriber)
         val audioItemLength = audioItem.duration.toMillis()
@@ -98,7 +98,7 @@ internal class JavaFxPlayerTest : StringSpec({
     }
 
     "Playing an audio item modifies its observable properties".config(
-        enabledIf = { System.getenv("CI") == null }
+        enabled = System.getenv("CI") == null
     ) {
         player.status() shouldBe UNKNOWN
         player.statusProperty.get() shouldBe UNKNOWN

--- a/music-commons-test/src/main/kotlin/net/transgressoft/commons/music/audio/AudioArb.kt
+++ b/music-commons-test/src/main/kotlin/net/transgressoft/commons/music/audio/AudioArb.kt
@@ -93,7 +93,7 @@ fun Arb.Companion.audioItem(audioItem: AudioItem, changeAction: AudioItemChange.
                     change.year?.takeIf { year -> year > 0 } ?: audioItem.album.year,
                     change.label ?: audioItem.album.label
                 )
-            every { genre } returns (change.genre ?: audioItem.genre)
+            every { genres } returns (change.genres ?: audioItem.genres)
             every { comments } returns (change.comments ?: audioItem.comments)
             every { trackNumber } returns (change.trackNumber ?: audioItem.trackNumber)
             every { discNumber } returns (change.discNumber ?: audioItem.discNumber)
@@ -137,7 +137,7 @@ fun Arb.Companion.audioItem(attributes: AudioItemTestAttributes): Arb<AudioItem>
             every { title } returns attributes.title
             every { artist } returns attributes.artist
             every { album } returns attributes.album
-            every { genre } returns attributes.genre
+            every { genres } returns attributes.genres
             every { comments } returns attributes.comments
             every { trackNumber } returns attributes.trackNumber
             every { discNumber } returns attributes.discNumber
@@ -208,7 +208,7 @@ fun Arb.Companion.audioItemChange(): Arb<AudioItemChange> =
             attributes.album.isCompilation,
             attributes.album.year,
             attributes.album.label,
-            attributes.genre,
+            attributes.genres,
             attributes.comments,
             attributes.trackNumber,
             attributes.discNumber,
@@ -216,6 +216,23 @@ fun Arb.Companion.audioItemChange(): Arb<AudioItemChange> =
             attributes.coverImageBytes,
             attributes.playCount
         )
+    }
+
+fun Arb.Companion.genre(): Arb<Genre> =
+    arbitrary {
+        val samples =
+            listOf(
+                Genre.Rock, Genre.Alternative, Genre.Jazz, Genre.Blues, Genre.Electronic,
+                Genre.HipHop, Genre.Classical, Genre.Folk, Genre.Metal, Genre.Pop
+            )
+        if (Arb.boolean().bind()) samples[Arb.int(0 until samples.size).bind()]
+        else Genre.Custom(Arb.string(1..30).bind().replace(",", "").ifEmpty { "Custom" })
+    }
+
+fun Arb.Companion.genres(): Arb<Set<Genre>> =
+    arbitrary {
+        val count = Arb.int(0..3).bind()
+        (1..count).map { Arb.genre().bind() }.toSet()
     }
 
 fun Arb.Companion.audioAttributes(
@@ -226,7 +243,7 @@ fun Arb.Companion.audioAttributes(
     bitRate: Int? = null,
     artist: Artist? = null,
     album: Album? = null,
-    genre: Genre? = null,
+    genres: Set<Genre>? = null,
     comments: String? = null,
     trackNumber: Short? = null,
     discNumber: Short? = null,
@@ -246,7 +263,7 @@ fun Arb.Companion.audioAttributes(
             bitRate ?: Arb.positiveInt().bind(),
             artist ?: artist().bind(),
             album ?: album().bind(),
-            genre ?: Arb.enum<Genre>().bind(),
+            genres ?: Arb.genres().bind(),
             comments ?: Arb.string().bind(),
             trackNumber ?: Arb.positiveShort().bind(),
             discNumber ?: Arb.positiveShort().bind(),

--- a/music-commons-test/src/main/kotlin/net/transgressoft/commons/music/audio/AudioItemAssertions.kt
+++ b/music-commons-test/src/main/kotlin/net/transgressoft/commons/music/audio/AudioItemAssertions.kt
@@ -33,6 +33,7 @@ import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.floatOrNull
 import kotlinx.serialization.json.int
 import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 
@@ -44,13 +45,13 @@ infix fun AudioItem.shouldMatch(attributes: AudioItemTestAttributes) {
         album.albumArtist.name shouldBe attributes.album.albumArtist.name
         album.albumArtist.countryCode shouldBe attributes.album.albumArtist.countryCode
         album.label.name shouldBe attributes.album.label.name
-        album.label.countryCode shouldBe album.label.countryCode
+        album.label.countryCode shouldBe attributes.album.label.countryCode
         artist shouldBe attributes.artist
         bpm shouldBe attributes.bpm
         trackNumber shouldBe attributes.trackNumber
         discNumber shouldBe attributes.discNumber
         comments shouldBe attributes.comments
-        genre shouldBe attributes.genre
+        genres shouldBe attributes.genres
         encoder shouldBe attributes.encoder
         uniqueId shouldBe
             buildString {
@@ -86,7 +87,8 @@ infix fun JsonObject.shouldContainAudioItem(audioItem: AudioItem) {
     itemJson["bpm"]?.jsonPrimitive?.floatOrNull shouldBe audioItem.bpm
     itemJson["encoder"]?.jsonPrimitive?.contentOrNull shouldBe audioItem.encoder
     itemJson["encoding"]?.jsonPrimitive?.contentOrNull shouldBe audioItem.encoding
-    itemJson["genre"]?.jsonPrimitive?.content shouldBe audioItem.genre.name
+    val genreNames = itemJson["genres"]?.jsonArray?.map { it.jsonPrimitive.content }?.toSet()
+    genreNames shouldBe audioItem.genres.map { it.name }.toSet()
     itemJson["comments"]?.jsonPrimitive?.contentOrNull shouldBe audioItem.comments
     itemJson["playCount"]?.jsonPrimitive?.int shouldBe audioItem.playCount.toInt()
 

--- a/music-commons-test/src/main/kotlin/net/transgressoft/commons/music/audio/AudioItemChange.kt
+++ b/music-commons-test/src/main/kotlin/net/transgressoft/commons/music/audio/AudioItemChange.kt
@@ -31,7 +31,7 @@ data class AudioItemChange(
     var isCompilation: Boolean? = null,
     var year: Short? = null,
     var label: Label? = null,
-    var genre: Genre? = null,
+    var genres: Set<Genre>? = null,
     var comments: String? = null,
     var trackNumber: Short? = null,
     var discNumber: Short? = null,

--- a/music-commons-test/src/main/kotlin/net/transgressoft/commons/music/audio/AudioItemExtensions.kt
+++ b/music-commons-test/src/main/kotlin/net/transgressoft/commons/music/audio/AudioItemExtensions.kt
@@ -28,10 +28,10 @@ fun <I : ReactiveAudioItem<I>> I.update(change: AudioItemChange) {
             change.year?.takeIf { year -> year > 0 } ?: album.year,
             change.label ?: album.label
         )
-    change.genre ?: genre
-    change.comments ?: comments
-    change.trackNumber?.takeIf { trackNum -> trackNum > 0 } ?: trackNumber
-    change.discNumber?.takeIf { discNum -> discNum > 0 } ?: discNumber
-    change.bpm?.takeIf { bpm -> bpm > 0 } ?: bpm
-    change.coverImageBytes ?: coverImageBytes
+    change.genres?.let { genres = it }
+    change.comments?.let { comments = it }
+    change.trackNumber?.takeIf { it > 0 }?.let { trackNumber = it }
+    change.discNumber?.takeIf { it > 0 }?.let { discNumber = it }
+    change.bpm?.takeIf { it > 0 }?.let { bpm = it }
+    change.coverImageBytes?.let { coverImageBytes = it }
 }

--- a/music-commons-test/src/main/kotlin/net/transgressoft/commons/music/audio/AudioItemTestAttributes.kt
+++ b/music-commons-test/src/main/kotlin/net/transgressoft/commons/music/audio/AudioItemTestAttributes.kt
@@ -28,7 +28,7 @@ data class AudioItemTestAttributes(
     var bitRate: Int,
     var artist: Artist,
     var album: Album,
-    var genre: Genre,
+    var genres: Set<Genre>,
     var comments: String? = null,
     var trackNumber: Short? = null,
     var discNumber: Short? = null,

--- a/music-commons-test/src/main/kotlin/net/transgressoft/commons/music/audio/RealTestFiles.kt
+++ b/music-commons-test/src/main/kotlin/net/transgressoft/commons/music/audio/RealTestFiles.kt
@@ -60,7 +60,7 @@ object ArbitraryAudioFile : TestConfiguration() {
             this.trackNumber = attributesAction.trackNumber
             this.discNumber = attributesAction.discNumber
             this.comments = attributesAction.comments
-            this.genre = attributesAction.genre
+            this.genres = attributesAction.genres
             this.encoder = attributesAction.encoder
             this.dateOfCreation = attributesAction.dateOfCreation
             this.lastDateModified = attributesAction.lastDateModified
@@ -109,7 +109,7 @@ object ArbitraryAudioFile : TestConfiguration() {
         tag.setField(FieldKey.COUNTRY, attributes.artist.countryCode.name)
         tag.setField(FieldKey.ALBUM_ARTIST, attributes.album.albumArtist.name)
         tag.setField(FieldKey.ARTIST, attributes.artist.name)
-        tag.setField(FieldKey.GENRE, attributes.genre.name)
+        tag.setField(FieldKey.GENRE, attributes.genres.joinToString(", ") { it.name })
         attributes.comments?.let { tag.setField(FieldKey.COMMENT, it) }
         attributes.trackNumber?.let { tag.setField(FieldKey.TRACK, it.toString()) }
         attributes.discNumber?.let { tag.setField(FieldKey.DISC_NO, it.toString()) }

--- a/music-commons-test/src/main/kotlin/net/transgressoft/commons/music/audio/VirtualTestFiles.kt
+++ b/music-commons-test/src/main/kotlin/net/transgressoft/commons/music/audio/VirtualTestFiles.kt
@@ -105,7 +105,7 @@ object VirtualFiles {
         val album = attributes.album.name
         val albumArtist = attributes.album.albumArtist.name
         val title = attributes.title
-        val genre = attributes.genre.name
+        val genre = attributes.genres.joinToString(", ") { it.name }
         val year = attributes.album.year
         val trackNumber = attributes.trackNumber
         val discNumber = attributes.discNumber
@@ -142,11 +142,11 @@ object VirtualFiles {
         every { tag.hasField(FieldKey.GROUPING) } returns true
         every { tag.hasField(FieldKey.IS_COMPILATION) } returns true
         every { tag.hasField(FieldKey.COUNTRY) } returns true
-        every { tag.hasField(FieldKey.TRACK) } returns (trackNumber == null)
-        every { tag.hasField(FieldKey.DISC_NO) } returns (discNumber == null)
-        every { tag.hasField(FieldKey.BPM) } returns (bpm == null)
-        every { tag.hasField(FieldKey.COMMENT) } returns (comment == null)
-        every { tag.hasField(FieldKey.ENCODER) } returns (encoder == null)
+        every { tag.hasField(FieldKey.TRACK) } returns (trackNumber != null)
+        every { tag.hasField(FieldKey.DISC_NO) } returns (discNumber != null)
+        every { tag.hasField(FieldKey.BPM) } returns (bpm != null)
+        every { tag.hasField(FieldKey.COMMENT) } returns (comment != null)
+        every { tag.hasField(FieldKey.ENCODER) } returns (encoder != null)
 
         coverBytes?.let {
             every { tag.firstArtwork } returns


### PR DESCRIPTION
## Summary

Closes #14

Rewrites `Genre` from a 2-entry enum (`ROCK`, `UNDEFINED`) to a sealed class with ~370 known-genre `data object` singletons sourced from the [whatlastgenre whitelist](https://github.com/YetAnotherNerd/whatlastgenre), plus a `Custom(name)` variant for arbitrary genre strings.

## Changes

### API
- `Genre.kt` — sealed class with ~370 data objects + `Custom` + `parseGenre()` returning `Set<Genre>`
- `ReactiveAudioItem` — `genre: Genre` replaced with `genres: Set<Genre>`

### Core
- `MutableAudioItem` — backing field + mutateAndPublish for `genres: Set<Genre>`
- `AudioItemSerializer` — writes `"genres"` JSON array, reads legacy `"genre"` string for backwards compatibility
- `AudioItemMetadataUtils` — genre tag parsing via `parseGenre()`
- `MusicLibrary.Builder.build()` — removed redundant `checkNotNull` (SonarQube S6619)

### FX
- `FXAudioItem` — `genresProperty` as `ObjectProperty<Set<Genre>>` via `fxObject` delegate
- `ObservableAudioItem` — property signature updated
- `ObservableAudioItemSerializer` — aligned with new genre format
- `FXMusicLibrary.Builder.build()` — removed redundant `checkNotNull` (SonarQube S6619)

### Test utilities
- `AudioArb`, `AudioItemAssertions`, `AudioItemChange`, `AudioItemExtensions`, `AudioItemTestAttributes`, `RealTestFiles`, `VirtualTestFiles`, `FxAudioArb` — migrated to `Set<Genre>`

### Documentation
- README updated with sealed class Genre documentation

## SonarQube fixes included

| Rule | File | Fix |
|------|------|-----|
| `kotlin:S6619` | `MusicLibrary.kt` | Removed useless `checkNotNull` — moved success path inside try block |
| `kotlin:S6619` | `FXMusicLibrary.kt` | Removed useless `checkNotNull` — moved success path inside try block |

## Verification

- `gradle compileKotlin compileTestKotlin` — passes across all modules
- `gradle :music-commons-core:test :music-commons-fx:test` — all tests pass
- Backwards-compatible deserialization handles old `"genre": "ROCK"` format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Audio items now support multiple genres per track instead of a single genre
  * JSON serialization format updated to `genres` array (backwards compatible with legacy `genre` field)

* **Documentation**
  * Added "Genre Handling" section describing multi-genre support and serialization format

* **Chores**
  * Updated lirp dependency to version 2.3.1-SNAPSHOT

<!-- end of auto-generated comment: release notes by coderabbit.ai -->