### PR TITLE
#69 #71 Fix spurious mutateAndPublish WARN and playlist self-reference binding

### DIFF
--- a/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/FXMusicLibrary.kt
+++ b/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/FXMusicLibrary.kt
@@ -34,6 +34,8 @@ import net.transgressoft.commons.music.waveform.AudioWaveformRepository
 import net.transgressoft.commons.music.waveform.audioWaveformRepository
 import net.transgressoft.lirp.event.CrudEvent
 import net.transgressoft.lirp.event.LirpEventPublisher
+import net.transgressoft.lirp.persistence.PersistentRepository
+import net.transgressoft.lirp.persistence.RegistryBase
 import net.transgressoft.lirp.persistence.Repository
 import net.transgressoft.lirp.persistence.VolatileRepository
 import net.transgressoft.lirp.persistence.json.JsonFileRepository
@@ -227,6 +229,7 @@ class FXMusicLibrary private constructor(
         fun build(): FXMusicLibrary {
             val audioRepo = createAudioRepository()
             val audioLibrary = FXAudioLibrary(audioRepo)
+            var playlistRepoRegistered = false
 
             var waveformRepository: AudioWaveformRepository<AudioWaveform, ObservableAudioItem>? = null
             try {
@@ -234,6 +237,11 @@ class FXMusicLibrary private constructor(
                 waveformRepository = audioWaveformRepository(waveformRepo)
 
                 val playlistRepo = createPlaylistRepository()
+                if (playlistRepo is PersistentRepository<*, *>) {
+                    RegistryBase.registerRepository(ObservablePlaylist::class.java, playlistRepo)
+                    playlistRepoRegistered = true
+                    playlistRepo.load()
+                }
                 val playlistHierarchy = FXPlaylistHierarchy(playlistRepo)
 
                 try {
@@ -246,6 +254,9 @@ class FXMusicLibrary private constructor(
 
                 return FXMusicLibrary(audioLibrary, playlistHierarchy, waveformRepository)
             } catch (ex: Exception) {
+                if (playlistRepoRegistered) {
+                    RegistryBase.deregisterRepository(ObservablePlaylist::class.java)
+                }
                 waveformRepository?.close()
                 audioLibrary.close()
                 throw ex
@@ -258,17 +269,20 @@ class FXMusicLibrary private constructor(
             when (val config = audioLibraryStorage) {
                 is VolatileStorage -> VolatileRepository("FXAudioLibrary")
                 is JsonFileStorage -> JsonFileRepository(config.file, ObservableAudioItemMapSerializer)
-                is SqlStorage<*> ->
-                    SqlRepository((config as SqlStorage<ObservableAudioItem>).dataSource, config.tableDef)
+                is SqlStorage<*> -> SqlRepository((config as SqlStorage<ObservableAudioItem>).dataSource, config.tableDef)
             }
 
         @Suppress("UNCHECKED_CAST")
         private fun createPlaylistRepository(): Repository<Int, ObservablePlaylist> =
             when (val config = playlistHierarchyStorage) {
                 is VolatileStorage -> VolatileRepository("FXPlaylistHierarchy")
-                is JsonFileStorage -> JsonFileRepository(config.file, ObservablePlaylistMapSerializer)
+                is JsonFileStorage -> JsonFileRepository(config.file, ObservablePlaylistMapSerializer, loadOnInit = false)
                 is SqlStorage<*> ->
-                    SqlRepository((config as SqlStorage<ObservablePlaylist>).dataSource, config.tableDef)
+                    SqlRepository(
+                        (config as SqlStorage<ObservablePlaylist>).dataSource,
+                        config.tableDef,
+                        loadOnInit = false
+                    )
             }
 
         @Suppress("UNCHECKED_CAST")
@@ -276,8 +290,7 @@ class FXMusicLibrary private constructor(
             when (val config = waveformRepositoryStorage) {
                 is VolatileStorage -> VolatileRepository("FXWaveformRepository")
                 is JsonFileStorage -> JsonFileRepository(config.file, AudioWaveformMapSerializer)
-                is SqlStorage<*> ->
-                    SqlRepository((config as SqlStorage<AudioWaveform>).dataSource, config.tableDef)
+                is SqlStorage<*> -> SqlRepository((config as SqlStorage<AudioWaveform>).dataSource, config.tableDef)
             }
     }
 

--- a/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/audio/FXArtistCatalog.kt
+++ b/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/audio/FXArtistCatalog.kt
@@ -230,10 +230,11 @@ internal class FXArtistCatalog(
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is FXArtistCatalog) return false
-        return artist == other.artist
+        if (artist != other.artist) return false
+        return audioItemsByAlbumName == other.audioItemsByAlbumName
     }
 
-    override fun hashCode(): Int = artist.hashCode()
+    override fun hashCode(): Int = 31 * artist.hashCode() + audioItemsByAlbumName.hashCode()
 
     override fun toString() = "FXArtistCatalog(artist=$artist, size=$size)"
 }

--- a/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/playlist/FXPlaylistHierarchy.kt
+++ b/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/playlist/FXPlaylistHierarchy.kt
@@ -78,6 +78,17 @@ internal class FXPlaylistHierarchy(
         RegistryBase.deregisterRepository(ObservablePlaylist::class.java)
         RegistryBase.registerRepository(ObservablePlaylist::class.java, repository)
 
+        // Re-sync self-referencing playlist aggregates after all entities are loaded.
+        // During repository load, entities are added one at a time, so forward references
+        // (e.g. ROOT playlist referencing CHILD playlist) cannot resolve because the
+        // referenced entity isn't in the repo yet. Now that all entities are loaded,
+        // syncLocalCache resolves the backing IDs to actual entities.
+        forEach { playlist ->
+            if (playlist is FXPlaylist) {
+                playlist.playlistsAggregate.syncLocalCache()
+            }
+        }
+
         forEach { playlist ->
             Platform.runLater { observablePlaylistsSet.add(playlist) }
         }

--- a/music-commons-fx/src/test/kotlin/net/transgressoft/commons/fx/music/FXMusicLibraryTest.kt
+++ b/music-commons-fx/src/test/kotlin/net/transgressoft/commons/fx/music/FXMusicLibraryTest.kt
@@ -4,6 +4,8 @@ import net.transgressoft.commons.music.audio.VirtualFiles.virtualAudioFile
 import net.transgressoft.lirp.event.ReactiveScope
 import io.kotest.assertions.nondeterministic.eventually
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.engine.spec.tempfile
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.optional.shouldBePresent
 import io.kotest.matchers.shouldBe
@@ -100,6 +102,34 @@ internal class FXMusicLibraryTest : StringSpec({
 
         library.findPlaylistByName("My Playlist") shouldBePresent {
             it.name shouldBe "My Playlist"
+        }
+
+        library.close()
+    }
+
+    "FXMusicLibrary resolves playlist self-references after JSON deserialization" {
+        val playlistFile = tempfile("playlist-self-ref-test", ".json").also { it.deleteOnExit() }
+        playlistFile.writeText(
+            """
+            {
+                "1": { "id": 1, "name": "ROOT", "isDirectory": true, "audioItems": [], "playlists": [2] },
+                "2": { "id": 2, "name": "CHILD", "isDirectory": false, "audioItems": [], "playlists": [] }
+            }
+            """.trimIndent()
+        )
+
+        val library =
+            FXMusicLibrary.builder()
+                .playlistHierarchyJsonFile(playlistFile)
+                .build()
+
+        testDispatcher.scheduler.advanceUntilIdle()
+        WaitForAsyncUtils.waitForFxEvents()
+
+        val root = library.findPlaylistByName("ROOT")
+        root shouldBePresent {
+            it.playlists.size shouldBe 1
+            it.playlists.map { p -> p.name } shouldContain "CHILD"
         }
 
         library.close()

--- a/music-commons-fx/src/test/kotlin/net/transgressoft/commons/fx/music/audio/FXArtistCatalogTest.kt
+++ b/music-commons-fx/src/test/kotlin/net/transgressoft/commons/fx/music/audio/FXArtistCatalogTest.kt
@@ -1,0 +1,111 @@
+package net.transgressoft.commons.fx.music.audio
+
+import net.transgressoft.commons.music.audio.ImmutableAlbum
+import net.transgressoft.commons.music.audio.ImmutableArtist
+import net.transgressoft.commons.music.audio.VirtualFiles.virtualAudioFile
+import net.transgressoft.lirp.event.ReactiveScope
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.next
+import org.testfx.api.FxToolkit
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+
+/**
+ * Tests for [FXArtistCatalog] equality and hash code behavior, ensuring
+ * `audioItemsByAlbumName` is included in structural comparison.
+ */
+@ExperimentalCoroutinesApi
+internal class FXArtistCatalogTest : StringSpec({
+
+    val testDispatcher = UnconfinedTestDispatcher()
+    val testScope = CoroutineScope(testDispatcher + kotlinx.coroutines.SupervisorJob())
+
+    val artist = ImmutableArtist.of("Test Artist")
+    val album = ImmutableAlbum("Test Album", artist)
+
+    beforeSpec {
+        ReactiveScope.flowScope = testScope
+        ReactiveScope.ioScope = testScope
+        FxToolkit.registerPrimaryStage()
+    }
+
+    afterSpec {
+        ReactiveScope.resetDefaultFlowScope()
+        ReactiveScope.resetDefaultIoScope()
+    }
+
+    "FXArtistCatalog returns false for equals when audioItemsByAlbumName differs" {
+        val catalog1 = FXArtistCatalog(artist)
+        val catalog2 = FXArtistCatalog(artist)
+
+        val path =
+            Arb.virtualAudioFile {
+                this.artist = artist
+                this.album = album
+            }.next()
+        val audioItem = FXAudioItem(path)
+
+        catalog1.addAudioItem(audioItem)
+
+        catalog1 shouldNotBe catalog2
+    }
+
+    "FXArtistCatalog returns true for equals when artist and audioItemsByAlbumName match" {
+        val catalog1 = FXArtistCatalog(artist)
+        val catalog2 = FXArtistCatalog(artist)
+
+        val path =
+            Arb.virtualAudioFile {
+                this.artist = artist
+                this.album = album
+            }.next()
+        val audioItem = FXAudioItem(path)
+
+        catalog1.addAudioItem(audioItem)
+        catalog2.addAudioItem(audioItem)
+
+        catalog1 shouldBe catalog2
+    }
+
+    "FXArtistCatalog produces different hashCode when audioItemsByAlbumName differs" {
+        val catalog1 = FXArtistCatalog(artist)
+        val catalog2 = FXArtistCatalog(artist)
+
+        val path =
+            Arb.virtualAudioFile {
+                this.artist = artist
+                this.album = album
+            }.next()
+        val audioItem = FXAudioItem(path)
+
+        catalog1.addAudioItem(audioItem)
+
+        catalog1.hashCode() shouldNotBe catalog2.hashCode()
+    }
+
+    "FXArtistCatalog detects state change after addAudioItem via clone comparison" {
+        val catalog = FXArtistCatalog(artist)
+        val cloneBefore = catalog.clone()
+
+        val path =
+            Arb.virtualAudioFile {
+                this.artist = artist
+                this.album = album
+            }.next()
+        val audioItem = FXAudioItem(path)
+        catalog.addAudioItem(audioItem)
+
+        cloneBefore shouldNotBe catalog
+    }
+
+    "FXArtistCatalog returns false for equals with different types or null" {
+        val catalog = FXArtistCatalog(artist)
+
+        (catalog.equals(null)) shouldBe false
+        (catalog.equals("not a catalog")) shouldBe false
+    }
+})


### PR DESCRIPTION
## Summary

Two related FX module bugs fixed in this PR:

### #69 — Spurious mutateAndPublish WARN in FXArtistCatalog

**Root cause:** `FXArtistCatalog.equals()` only compared the `artist` field, ignoring `audioItemsByAlbumName`. When `ReactiveEntityBase.mutateAndPublish()` clones the entity before mutation and compares clone vs mutated entity, the clone always appeared equal — triggering a spurious WARN on every audio item load.

**Fix:** Aligned `FXArtistCatalog.equals()`/`hashCode()` with the already-correct `MutableArtistCatalog` pattern to include `audioItemsByAlbumName` in both methods.

### #71 — Playlist self-referencing aggregates not bound on load

**Root cause:** Playlist self-references (parent→child) were lost after JSON deserialization because the playlist repository was not registered in `LirpContext` when `bindCollectionRefs()` ran during `load()`. The `audioItems` aggregate worked because the audio library repo was registered beforehand, but `playlists` references entities in the same repository.

**Fix:** Two-part:
1. Create persistent playlist repositories with `loadOnInit=false`, register in `LirpContext` before calling `load()`, so `bindCollectionRefs()` can find the registry
2. After all entities are loaded, re-sync each playlist's `playlistsAggregate` via `syncLocalCache()` in `FXPlaylistHierarchy.init` to resolve forward references that couldn't resolve during sequential entity loading

## Changes

### Modified
- `music-commons-fx/.../audio/FXArtistCatalog.kt` — Fixed `equals()`/`hashCode()` to include `audioItemsByAlbumName`
- `music-commons-fx/.../FXMusicLibrary.kt` — Deferred playlist repo load with pre-registration in LirpContext
- `music-commons-fx/.../playlist/FXPlaylistHierarchy.kt` — Post-load `syncLocalCache()` for self-referencing playlist aggregates

### Created
- `music-commons-fx/.../audio/FXArtistCatalogTest.kt` — 5 tests proving equals/hashCode fix correctness

### Test additions
- `FXMusicLibraryTest` — New test verifying playlist self-references resolve after JSON deserialization

## Verification

- [x] `FXArtistCatalog.equals()` contains `audioItemsByAlbumName == other.audioItemsByAlbumName`
- [x] `FXArtistCatalog.hashCode()` contains `31 * artist.hashCode() + audioItemsByAlbumName.hashCode()`
- [x] 5/5 new FXArtistCatalogTest tests pass
- [x] Playlist self-reference test: ROOT playlist with `playlists=[2]` resolves CHILD after deserialization
- [x] Full build passes: `compileKotlin compileTestKotlin ktlintCheck test`
- [x] No regressions in existing tests

Closes #69
Closes #71

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved artist catalog equality and hash behavior to reflect full catalog contents.
  * Ensure playlist repositories that persist are registered and explicitly loaded to stabilize playlist state.
  * Added a pre-population re-sync for playlists to resolve self-references/forward references before UI population.

* **Tests**
  * Added tests validating catalog equality/hash behavior and playlist hierarchy self-reference resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->