### PR TITLE
#57 iTunes library XML import — parsing, metadata policy, and library integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,42 @@ Unknown genre strings are preserved as `Genre.Custom(name)` instead of being dis
 - **Thread safety**: Audio item collections use `FxAggregateList` delegates that auto-dispatch listener notifications to the JavaFX Application Thread; artist catalog and album properties are updated via `Platform.runLater` from CRUD subscriptions
 - **Custom controls**: `WaveformPane` component for waveform visualization
 
+### iTunes Library Import
+
+The `music-commons-core` module includes an iTunes library XML import engine for migrating
+tracks and playlists from Apple Music / iTunes into a `MusicLibrary`.
+
+**Two-step import flow:**
+
+1. **Parse** the iTunes `library.xml` file:
+   ```kotlin
+   val itunesLibrary = ItunesLibraryParser.parse(Paths.get("/path/to/library.xml"))
+   // Inspect itunesLibrary.playlists to let the user select which to import
+   ```
+
+2. **Import** selected playlists with a configurable policy:
+   ```kotlin
+   val service = ItunesImportService(musicLibrary)
+   val future = service.importAsync(
+       selectedPlaylists = chosen,
+       itunesLibrary = itunesLibrary,
+       policy = ItunesImportPolicy(useFileMetadata = false, holdPlayCount = true),
+       onProgress = { progress -> println("${progress.itemsProcessed}/${progress.totalItems}") }
+   )
+   val result = future.get()
+   println("Imported: ${result.importedCount}, Skipped: ${result.skippedCount}")
+   ```
+
+**Import policy options:**
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `useFileMetadata` | `true` | When `true`, metadata comes from audio file tags. When `false`, user-facing fields come from iTunes data. |
+| `holdPlayCount` | `true` | Transfers play counts from iTunes to imported items. |
+| `writeMetadata` | `true` | Writes iTunes metadata to audio file tags after import. |
+| `ignoreNotFound` | `true` | Skips tracks whose files don't exist on disk instead of erroring. |
+| `acceptedFileTypes` | All | Filters tracks by audio file type (MP3, M4A, WAV, FLAC). |
+
 ## Module Details
 
 ### music-commons-api

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ guava = "33.5.0-jre"
 jaudiotagger = "3.0.1"
 jave = "3.5.0"
 nv-i18n = "1.29"
+ddplist = "1.29"
 kotlin-logging = "3.0.5"
 kotlinx-serialization = "1.10.0"
 logback = "1.5.20"
@@ -44,6 +45,7 @@ jaudiotagger = { module = "net.jthink:jaudiotagger", version.ref = "jaudiotagger
 jave-core = { module = "ws.schild:jave-core", version.ref = "jave" }
 jave-nativebin-linux64 = { module = "ws.schild:jave-nativebin-linux64", version.ref = "jave" }
 nv-i18n = { module = "com.neovisionaries:nv-i18n", version.ref = "nv-i18n" }
+dd-plist = { module = "com.googlecode.plist:dd-plist", version.ref = "ddplist" }
 kotlin-logging = { module = "io.github.microutils:kotlin-logging-jvm", version.ref = "kotlin-logging" }
 logback-core = { module = "ch.qos.logback:logback-core", version.ref = "logback" }
 logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }

--- a/music-commons-api/src/main/kotlin/net/transgressoft/commons/music/audio/ReactiveAudioItem.kt
+++ b/music-commons-api/src/main/kotlin/net/transgressoft/commons/music/audio/ReactiveAudioItem.kt
@@ -68,6 +68,18 @@ interface ReactiveAudioItem<I: ReactiveAudioItem<I>>: ReactiveEntity<Int, I>, Co
     val dateOfCreation: LocalDateTime
     val playCount: Short
 
+    /**
+     * Sets the play count to [count].
+     *
+     * Used during import operations (e.g., iTunes import) where the play count is transferred
+     * from an external source rather than incremented through playback. Implementations disable
+     * reactive mutation events during this operation since it represents a bulk data transfer,
+     * not a user-observable state change.
+     *
+     * @param count The play count value to set.
+     */
+    fun setPlayCount(count: Short)
+
     fun writeMetadata(): Job
 
     fun asJsonKeyValue() =

--- a/music-commons-core/build.gradle
+++ b/music-commons-core/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     implementation libs.lirp.sql.get()
     implementation libs.jave.core.get()
     implementation libs.jave.nativebin.linux64.get()
+    implementation libs.dd.plist.get()
 
     ksp libs.lirp.ksp.get()
     kspTest libs.lirp.ksp.get()

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/DefaultAudioLibrary.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/DefaultAudioLibrary.kt
@@ -67,6 +67,14 @@ internal class DefaultAudioLibrary(repository: Repository<Int, AudioItem>) :
                 logger.debug { "New AudioItem was created from file $audioItemPath with id ${audioItem.id}" }
             }
 
+    /**
+     * Returns the next available audio item ID for external construction.
+     *
+     * Used by [ItunesImportService][net.transgressoft.commons.music.itunes.ItunesImportService] when constructing
+     * [MutableAudioItem] via the deserialization constructor for the `useFileMetadata=false` import path.
+     */
+    internal fun nextAudioItemId(): Int = newId()
+
     override fun close() {
         super.close()
         RegistryBase.deregisterRepository(AudioItem::class.java)

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/MutableAudioItem.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/MutableAudioItem.kt
@@ -256,6 +256,7 @@ internal class MutableAudioItem(
     internal fun incrementPlayCount() = _playCount++
 
     override fun setPlayCount(count: Short) {
+        require(count >= 0) { "Play count cannot be negative" }
         withEventsDisabled { _playCount = count }
     }
 

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/MutableAudioItem.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/MutableAudioItem.kt
@@ -83,7 +83,7 @@ internal class MutableAudioItem(
                 }
         )
 
-    // Constructor for deserialization
+    // Constructor for deserialization & iTunes import
     internal constructor(
         path: Path,
         id: Int,
@@ -254,6 +254,10 @@ internal class MutableAudioItem(
         }
 
     internal fun incrementPlayCount() = _playCount++
+
+    override fun setPlayCount(count: Short) {
+        withEventsDisabled { _playCount = count }
+    }
 
     override operator fun compareTo(other: AudioItem) = audioItemTrackDiscNumberComparator<AudioItem>().compare(this, other)
 

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/itunes/ImportProgress.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/itunes/ImportProgress.kt
@@ -1,0 +1,14 @@
+package net.transgressoft.commons.music.itunes
+
+/**
+ * Progress snapshot emitted during an iTunes import operation.
+ *
+ * @property itemsProcessed Number of tracks processed so far.
+ * @property totalItems Total number of tracks to process.
+ * @property currentFile Path of the track currently being processed.
+ */
+data class ImportProgress(
+    val itemsProcessed: Int,
+    val totalItems: Int,
+    val currentFile: String
+)

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/itunes/ItunesImportPolicy.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/itunes/ItunesImportPolicy.kt
@@ -1,0 +1,30 @@
+package net.transgressoft.commons.music.itunes
+
+import net.transgressoft.commons.music.audio.AudioFileType
+
+/**
+ * Configures how tracks from an iTunes library are imported into a [MusicLibrary][net.transgressoft.commons.music.MusicLibrary].
+ *
+ * The policy controls metadata source, play count transfer, tag write-back, missing file handling,
+ * and file type filtering. All fields have sensible defaults matching the most common import scenario.
+ *
+ * @property useFileMetadata When `true` (default), all metadata is read from audio file tags via
+ *   `createFromFile()`. When `false`, only technical metadata (bitrate, duration, encoder) is read
+ *   from file tags, and user-facing fields (title, artist, album, genre) come from iTunes data.
+ * @property holdPlayCount When `true` (default), the iTunes play count is applied to the imported item
+ *   regardless of the [useFileMetadata] setting.
+ * @property writeMetadata When `true` (default), iTunes metadata is written to the audio file's ID3/Vorbis
+ *   tags after import. This is independent of [useFileMetadata]: when both `writeMetadata=true` and
+ *   `useFileMetadata=false`, iTunes metadata overwrites existing file tags. This operation is destructive.
+ * @property ignoreNotFound When `true` (default), tracks whose files do not exist on disk are skipped
+ *   and counted in [ItunesImportResult.skippedCount]. When `false`, missing files cause an error entry.
+ * @property acceptedFileTypes Set of audio file types to import. Tracks with file extensions not in this
+ *   set are skipped.
+ */
+data class ItunesImportPolicy(
+    val useFileMetadata: Boolean = true,
+    val holdPlayCount: Boolean = true,
+    val writeMetadata: Boolean = true,
+    val ignoreNotFound: Boolean = true,
+    val acceptedFileTypes: Set<AudioFileType> = AudioFileType.entries.toSet()
+)

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/itunes/ItunesImportResult.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/itunes/ItunesImportResult.kt
@@ -1,0 +1,29 @@
+package net.transgressoft.commons.music.itunes
+
+/**
+ * Result of an iTunes library import operation.
+ *
+ * @property importedCount Number of tracks successfully imported as [AudioItem][net.transgressoft.commons.music.audio.AudioItem] entities.
+ * @property skippedCount Number of tracks skipped (missing file, unsupported type, or duplicate).
+ * @property errorCount Number of tracks that caused errors during import.
+ * @property errors Per-track error details, each pairing the track's iTunes title with the exception message.
+ * @property playlistsCreated Number of playlists successfully created in the hierarchy.
+ */
+data class ItunesImportResult(
+    val importedCount: Int,
+    val skippedCount: Int,
+    val errorCount: Int,
+    val errors: List<ImportError> = emptyList(),
+    val playlistsCreated: Int = 0
+)
+
+/**
+ * Details of a single track import error.
+ *
+ * @property trackTitle Title of the iTunes track that failed.
+ * @property message Error description.
+ */
+data class ImportError(
+    val trackTitle: String,
+    val message: String
+)

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/itunes/ItunesImportService.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/itunes/ItunesImportService.kt
@@ -1,0 +1,294 @@
+package net.transgressoft.commons.music.itunes
+
+import net.transgressoft.commons.music.MusicLibrary
+import net.transgressoft.commons.music.audio.Album
+import net.transgressoft.commons.music.audio.Artist
+import net.transgressoft.commons.music.audio.AudioFileType
+import net.transgressoft.commons.music.audio.AudioItem
+import net.transgressoft.commons.music.audio.AudioItemMetadataUtils
+import net.transgressoft.commons.music.audio.DefaultAudioLibrary
+import net.transgressoft.commons.music.audio.Genre
+import net.transgressoft.commons.music.audio.ImmutableAlbum
+import net.transgressoft.commons.music.audio.ImmutableArtist
+import net.transgressoft.commons.music.audio.ImmutableLabel
+import net.transgressoft.commons.music.audio.MutableAudioItem
+import mu.KotlinLogging
+import java.net.URI
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.time.Duration
+import java.time.LocalDateTime
+import java.util.concurrent.CompletableFuture
+import kotlin.io.path.extension
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.future.future
+
+/**
+ * Orchestrates importing tracks and playlists from a parsed [ItunesLibrary] into a [MusicLibrary].
+ *
+ * The import follows a two-step flow: the consumer first parses the XML via [ItunesLibraryParser],
+ * selects playlists, then calls [importAsync] with the selection and a configured [ItunesImportPolicy].
+ *
+ * Track import behavior depends on [ItunesImportPolicy.useFileMetadata]:
+ * - When `true`, audio items are created via [MusicLibrary.audioItemFromFile] which reads all
+ *   metadata from file tags.
+ * - When `false`, only technical metadata (bitrate, duration, encoder) is read from file tags.
+ *   User-facing fields (title, artist, album, genre) come from the iTunes data.
+ *
+ * When a playlist name already exists in the hierarchy, the import creates it with an
+ * incremental suffix (e.g., `Playlist_1`, `Playlist_2`). Folder playlists support recursive nesting.
+ *
+ * @param musicLibrary The target library to import into.
+ */
+class ItunesImportService(private val musicLibrary: MusicLibrary) {
+
+    private val logger = KotlinLogging.logger {}
+
+    /**
+     * Imports tracks from [selectedPlaylists] (and their referenced tracks from [itunesLibrary])
+     * into the [MusicLibrary], applying the given [policy].
+     *
+     * Returns a [CompletableFuture] that completes with an [ItunesImportResult] summarizing the import.
+     * The future can be canceled via [CompletableFuture.cancel], which stops processing between tracks.
+     *
+     * @param selectedPlaylists Playlists chosen by the consumer for import.
+     * @param itunesLibrary The full parsed iTunes library (for track lookup).
+     * @param policy Import configuration controlling metadata source, play count, write-back, etc.
+     * @param onProgress Callback invoked after each track is processed.
+     * @return A cancellable future completing with the import result.
+     */
+    fun importAsync(
+        selectedPlaylists: List<ItunesPlaylist>,
+        itunesLibrary: ItunesLibrary,
+        policy: ItunesImportPolicy = ItunesImportPolicy(),
+        onProgress: (ImportProgress) -> Unit = {}
+    ): CompletableFuture<ItunesImportResult> =
+        CoroutineScope(Dispatchers.IO).future {
+            val trackImportResult = importTracks(selectedPlaylists, itunesLibrary, policy, onProgress)
+            val playlistsCreated = createPlaylists(selectedPlaylists, trackImportResult.trackIdToItem)
+
+            ItunesImportResult(
+                importedCount = trackImportResult.importedCount,
+                skippedCount = trackImportResult.skippedCount,
+                errorCount = trackImportResult.errors.size,
+                errors = trackImportResult.errors,
+                playlistsCreated = playlistsCreated
+            )
+        }
+
+    private suspend fun importTracks(
+        selectedPlaylists: List<ItunesPlaylist>,
+        itunesLibrary: ItunesLibrary,
+        policy: ItunesImportPolicy,
+        onProgress: (ImportProgress) -> Unit
+    ): TrackImportAccumulator {
+        val uniqueTrackIds = selectedPlaylists.flatMap(ItunesPlaylist::trackIds).toSet()
+        val accumulator = TrackImportAccumulator(uniqueTrackIds.size)
+
+        for (trackId in uniqueTrackIds) {
+            currentCoroutineContext().ensureActive()
+            val track = itunesLibrary.tracks[trackId] ?: continue
+            processTrack(track, trackId, policy, accumulator)
+            accumulator.itemsProcessed++
+            onProgress(ImportProgress(accumulator.itemsProcessed, accumulator.totalItems, track.location))
+        }
+
+        return accumulator
+    }
+
+    private fun processTrack(track: ItunesTrack, trackId: Int, policy: ItunesImportPolicy, accumulator: TrackImportAccumulator) {
+        try {
+            val path = resolveTrackPath(track)
+
+            if (isUnsupportedFileType(path, policy)) {
+                logger.debug { "Skipping track '${track.title}': unsupported file type '${path.extension.lowercase()}'" }
+                accumulator.skippedCount++
+                return
+            }
+
+            if (!Files.exists(path)) {
+                handleMissingFile(track, path, policy, accumulator)
+                return
+            }
+
+            val audioItem = importTrack(track, path, policy)
+            accumulator.trackIdToItem[trackId] = audioItem
+            accumulator.importedCount++
+            logger.debug { "Imported track '${track.title}' with id ${audioItem.id}" }
+        } catch (e: Exception) {
+            logger.error("Error importing track '${track.title}'", e)
+            accumulator.errors.add(ImportError(track.title, e.message ?: "Unknown error"))
+        }
+    }
+
+    private fun isUnsupportedFileType(path: Path, policy: ItunesImportPolicy): Boolean {
+        val extension = path.extension.lowercase()
+        val fileType = AudioFileType.entries.find { it.extension == extension }
+        return fileType == null || fileType !in policy.acceptedFileTypes
+    }
+
+    private fun handleMissingFile(track: ItunesTrack, path: Path, policy: ItunesImportPolicy, accumulator: TrackImportAccumulator) {
+        if (policy.ignoreNotFound) {
+            logger.debug { "Skipping track '${track.title}': file not found at $path" }
+            accumulator.skippedCount++
+        } else {
+            accumulator.errors.add(ImportError(track.title, "File not found: $path"))
+        }
+    }
+
+    private fun importTrack(track: ItunesTrack, path: Path, policy: ItunesImportPolicy): AudioItem {
+        val audioItem =
+            if (policy.useFileMetadata) {
+                musicLibrary.audioItemFromFile(path)
+            } else {
+                importWithItunesMetadata(track, path, policy)
+            }
+
+        if (policy.holdPlayCount && track.playCount > 0) {
+            audioItem.setPlayCount(track.playCount)
+        }
+
+        if (policy.writeMetadata && !policy.useFileMetadata) {
+            audioItem.writeMetadata()
+        }
+
+        return audioItem
+    }
+
+    private fun importWithItunesMetadata(track: ItunesTrack, path: Path, policy: ItunesImportPolicy): AudioItem {
+        val fileMetadata = AudioItemMetadataUtils.readMetadata(path)
+        val audioLib = musicLibrary.audioLibrary() as DefaultAudioLibrary
+        val id = audioLib.nextAudioItemId()
+        val (artist, album, genres) = resolveItunesMetadata(track)
+        val playCount = if (policy.holdPlayCount) track.playCount else 0.toShort()
+
+        val audioItem =
+            MutableAudioItem(
+                path = path,
+                id = id,
+                title = track.title,
+                duration = Duration.ofMillis(track.totalTimeMs),
+                bitRate = fileMetadata.bitRate,
+                artist = artist,
+                album = album,
+                genres = genres,
+                comments = track.comments,
+                trackNumber = track.trackNumber,
+                discNumber = track.discNumber,
+                bpm = track.bpm,
+                encoder = fileMetadata.encoder,
+                encoding = fileMetadata.encoding,
+                dateOfCreation = track.dateAdded ?: LocalDateTime.now(),
+                lastDateModified = LocalDateTime.now(),
+                playCount = playCount
+            )
+
+        musicLibrary.audioLibrary().add(audioItem)
+        return audioItem
+    }
+
+    private fun resolveItunesMetadata(track: ItunesTrack): ItunesMetadata {
+        val artist = ImmutableArtist.of(track.artist)
+        val albumArtist = ImmutableArtist.of(track.albumArtist)
+        val album =
+            ImmutableAlbum(
+                name = track.album,
+                albumArtist = albumArtist,
+                isCompilation = track.isCompilation,
+                year = track.year,
+                label = ImmutableLabel.UNKNOWN
+            )
+        val genres = track.genre?.let { Genre.parseGenre(it) } ?: emptySet()
+        return ItunesMetadata(artist, album, genres)
+    }
+
+    private fun resolveTrackPath(track: ItunesTrack): Path {
+        val uri = URI(track.location)
+        return Paths.get(uri.path)
+    }
+
+    private fun createPlaylists(selectedPlaylists: List<ItunesPlaylist>, trackIdToItem: Map<Int, AudioItem>): Int {
+        val createdNameByPersistentId = mutableMapOf<String, String>()
+        var playlistsCreated = 0
+
+        playlistsCreated += createFolderDirectories(selectedPlaylists, createdNameByPersistentId)
+        playlistsCreated += createRegularPlaylists(selectedPlaylists, trackIdToItem, createdNameByPersistentId)
+        wirePlaylistHierarchy(selectedPlaylists, createdNameByPersistentId)
+
+        return playlistsCreated
+    }
+
+    private fun createFolderDirectories(
+        selectedPlaylists: List<ItunesPlaylist>,
+        createdNameByPersistentId: MutableMap<String, String>
+    ): Int {
+        var count = 0
+        for (playlist in selectedPlaylists) {
+            if (!playlist.isFolder) continue
+            val uniqueName = resolveUniqueName(playlist.name)
+            musicLibrary.createPlaylistDirectory(uniqueName)
+            createdNameByPersistentId[playlist.persistentId] = uniqueName
+            count++
+            logger.debug { "Created playlist directory '$uniqueName'" }
+        }
+        return count
+    }
+
+    private fun createRegularPlaylists(
+        selectedPlaylists: List<ItunesPlaylist>,
+        trackIdToItem: Map<Int, AudioItem>,
+        createdNameByPersistentId: MutableMap<String, String>
+    ): Int {
+        var count = 0
+        for (playlist in selectedPlaylists) {
+            if (playlist.isFolder) continue
+            val audioItems = playlist.trackIds.mapNotNull { trackIdToItem[it] }
+            val uniqueName = resolveUniqueName(playlist.name)
+            musicLibrary.createPlaylist(uniqueName, audioItems)
+            createdNameByPersistentId[playlist.persistentId] = uniqueName
+            count++
+            logger.debug { "Created playlist '$uniqueName' with ${audioItems.size} items" }
+        }
+        return count
+    }
+
+    private fun wirePlaylistHierarchy(
+        selectedPlaylists: List<ItunesPlaylist>,
+        createdNameByPersistentId: Map<String, String>
+    ) {
+        for (playlist in selectedPlaylists) {
+            val parentId = playlist.parentPersistentId ?: continue
+            val parentName = createdNameByPersistentId[parentId] ?: continue
+            val childName = createdNameByPersistentId[playlist.persistentId] ?: continue
+            try {
+                musicLibrary.playlistHierarchy().addPlaylistsToDirectory(setOf(childName), parentName)
+                logger.debug { "Wired '$childName' to folder '$parentName'" }
+            } catch (e: Exception) {
+                logger.warn("Could not wire '$childName' to folder '$parentName': ${e.message}")
+            }
+        }
+    }
+
+    private fun resolveUniqueName(name: String): String {
+        if (!musicLibrary.findPlaylistByName(name).isPresent) return name
+        var suffix = 1
+        while (musicLibrary.findPlaylistByName("${name}_$suffix").isPresent) {
+            suffix++
+        }
+        return "${name}_$suffix"
+    }
+
+    private data class ItunesMetadata(val artist: Artist, val album: Album, val genres: Set<Genre>)
+
+    private class TrackImportAccumulator(val totalItems: Int) {
+        var itemsProcessed = 0
+        var importedCount = 0
+        var skippedCount = 0
+        val errors = mutableListOf<ImportError>()
+        val trackIdToItem = mutableMapOf<Int, AudioItem>()
+    }
+}

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/itunes/ItunesImportService.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/itunes/ItunesImportService.kt
@@ -100,7 +100,7 @@ class ItunesImportService(private val musicLibrary: MusicLibrary) {
         return accumulator
     }
 
-    private fun processTrack(track: ItunesTrack, trackId: Int, policy: ItunesImportPolicy, accumulator: TrackImportAccumulator) {
+    private suspend fun processTrack(track: ItunesTrack, trackId: Int, policy: ItunesImportPolicy, accumulator: TrackImportAccumulator) {
         try {
             val path = resolveTrackPath(track)
 
@@ -140,7 +140,7 @@ class ItunesImportService(private val musicLibrary: MusicLibrary) {
         }
     }
 
-    private fun importTrack(track: ItunesTrack, path: Path, policy: ItunesImportPolicy): AudioItem {
+    private suspend fun importTrack(track: ItunesTrack, path: Path, policy: ItunesImportPolicy): AudioItem {
         val audioItem =
             if (policy.useFileMetadata) {
                 musicLibrary.audioItemFromFile(path)
@@ -153,7 +153,7 @@ class ItunesImportService(private val musicLibrary: MusicLibrary) {
         }
 
         if (policy.writeMetadata && !policy.useFileMetadata) {
-            audioItem.writeMetadata()
+            audioItem.writeMetadata().join()
         }
 
         return audioItem
@@ -208,7 +208,7 @@ class ItunesImportService(private val musicLibrary: MusicLibrary) {
 
     private fun resolveTrackPath(track: ItunesTrack): Path {
         val uri = URI(track.location)
-        return Paths.get(uri.path)
+        return Paths.get(uri)
     }
 
     private fun createPlaylists(selectedPlaylists: List<ItunesPlaylist>, trackIdToItem: Map<Int, AudioItem>): Int {

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/itunes/ItunesLibrary.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/itunes/ItunesLibrary.kt
@@ -1,0 +1,14 @@
+package net.transgressoft.commons.music.itunes
+
+/**
+ * Immutable snapshot of an iTunes library parsed from a `library.xml` plist file.
+ *
+ * Contains all tracks indexed by their iTunes track ID (for O(1) lookup during playlist import)
+ * and all non-smart playlists including folder playlists for hierarchy reconstruction.
+ * Consumers inspect [playlists] to select which ones to import, then pass this object
+ * along with the selection to `ItunesImportService`.
+ */
+data class ItunesLibrary(
+    val tracks: Map<Int, ItunesTrack>,
+    val playlists: List<ItunesPlaylist>
+)

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/itunes/ItunesLibraryParser.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/itunes/ItunesLibraryParser.kt
@@ -1,0 +1,93 @@
+package net.transgressoft.commons.music.itunes
+
+import com.dd.plist.NSArray
+import com.dd.plist.NSDate
+import com.dd.plist.NSDictionary
+import com.dd.plist.NSNumber
+import com.dd.plist.PropertyListParser
+import mu.KotlinLogging
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.ZoneOffset
+
+/**
+ * Parses an iTunes `library.xml` plist file into an [ItunesLibrary] domain object.
+ *
+ * Uses [PropertyListParser] from the dd-plist library for XML plist parsing.
+ * Smart playlists (those with a `Smart Info` key) and tracks without a `file://` location
+ * are silently skipped during parsing.
+ */
+object ItunesLibraryParser {
+
+    private val logger = KotlinLogging.logger {}
+
+    /**
+     * Parses the iTunes library XML file at the given path.
+     *
+     * @param xmlPath path to the `library.xml` iTunes export file
+     * @return an [ItunesLibrary] containing all valid tracks and non-smart playlists
+     * @throws IllegalArgumentException if the file does not exist
+     */
+    fun parse(xmlPath: Path): ItunesLibrary {
+        require(Files.exists(xmlPath)) { "iTunes library file '${xmlPath.toAbsolutePath()}' does not exist" }
+        val root = PropertyListParser.parse(xmlPath.toFile()) as NSDictionary
+        val tracks = parseTracks(root.objectForKey("Tracks") as? NSDictionary ?: NSDictionary())
+        val playlists = parsePlaylists(root.objectForKey("Playlists") as? NSArray ?: NSArray(0))
+        logger.info { "Parsed iTunes library: ${tracks.size} tracks, ${playlists.size} playlists" }
+        return ItunesLibrary(tracks, playlists)
+    }
+
+    private fun parseTracks(tracksDict: NSDictionary): Map<Int, ItunesTrack> =
+        tracksDict.keys.mapNotNull { key ->
+            val entry = tracksDict.objectForKey(key) as? NSDictionary ?: return@mapNotNull null
+            val id = (entry.objectForKey("Track ID") as? NSNumber)?.intValue() ?: return@mapNotNull null
+            val location =
+                entry.objectForKey("Location")?.toString()
+                    ?.takeIf { it.startsWith("file://") }
+                    ?: return@mapNotNull null
+            id to
+                ItunesTrack(
+                    id = id,
+                    title = entry.objectForKey("Name")?.toString() ?: "",
+                    artist = entry.objectForKey("Artist")?.toString() ?: "",
+                    albumArtist = entry.objectForKey("Album Artist")?.toString() ?: "",
+                    album = entry.objectForKey("Album")?.toString() ?: "",
+                    genre = entry.objectForKey("Genre")?.toString(),
+                    year = (entry.objectForKey("Year") as? NSNumber)?.intValue()?.toShort(),
+                    trackNumber = (entry.objectForKey("Track Number") as? NSNumber)?.intValue()?.toShort(),
+                    discNumber = (entry.objectForKey("Disc Number") as? NSNumber)?.intValue()?.toShort(),
+                    totalTimeMs = (entry.objectForKey("Total Time") as? NSNumber)?.longValue() ?: 0L,
+                    bitRate = (entry.objectForKey("Bit Rate") as? NSNumber)?.intValue() ?: 0,
+                    playCount = (entry.objectForKey("Play Count") as? NSNumber)?.intValue()?.toShort() ?: 0,
+                    rating = (entry.objectForKey("Rating") as? NSNumber)?.intValue() ?: 0,
+                    bpm = (entry.objectForKey("BPM") as? NSNumber)?.floatValue(),
+                    comments = entry.objectForKey("Comments")?.toString(),
+                    location = location,
+                    isCompilation = (entry.objectForKey("Compilation") as? NSNumber)?.boolValue() ?: false,
+                    persistentId = entry.objectForKey("Persistent ID")?.toString(),
+                    dateAdded =
+                        (entry.objectForKey("Date Added") as? NSDate)
+                            ?.date?.toInstant()?.atZone(ZoneOffset.UTC)?.toLocalDateTime()
+                )
+        }.toMap()
+
+    private fun parsePlaylists(playlistsArray: NSArray): List<ItunesPlaylist> =
+        playlistsArray.array.mapNotNull { item ->
+            val dict = item as? NSDictionary ?: return@mapNotNull null
+            if (dict.objectForKey("Smart Info") != null) return@mapNotNull null
+            val persistentId = dict.objectForKey("Playlist Persistent ID")?.toString() ?: return@mapNotNull null
+            val trackIds =
+                (dict.objectForKey("Playlist Items") as? NSArray)
+                    ?.array
+                    ?.mapNotNull { trackItem ->
+                        ((trackItem as? NSDictionary)?.objectForKey("Track ID") as? NSNumber)?.intValue()
+                    } ?: emptyList()
+            ItunesPlaylist(
+                name = dict.objectForKey("Name")?.toString() ?: return@mapNotNull null,
+                persistentId = persistentId,
+                parentPersistentId = dict.objectForKey("Parent Persistent ID")?.toString(),
+                isFolder = (dict.objectForKey("Folder") as? NSNumber)?.boolValue() ?: false,
+                trackIds = trackIds
+            )
+        }
+}

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/itunes/ItunesPlaylist.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/itunes/ItunesPlaylist.kt
@@ -1,0 +1,16 @@
+package net.transgressoft.commons.music.itunes
+
+/**
+ * Immutable representation of a playlist parsed from an iTunes library XML file.
+ *
+ * Regular playlists contain [trackIds] referencing [ItunesTrack.id] values.
+ * Folder playlists have [isFolder] set to `true` and child playlists reference them
+ * via [parentPersistentId] matching the folder's [persistentId].
+ */
+data class ItunesPlaylist(
+    val name: String,
+    val persistentId: String,
+    val parentPersistentId: String?,
+    val isFolder: Boolean,
+    val trackIds: List<Int>
+)

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/itunes/ItunesTrack.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/itunes/ItunesTrack.kt
@@ -1,0 +1,32 @@
+package net.transgressoft.commons.music.itunes
+
+import java.time.LocalDateTime
+
+/**
+ * Immutable representation of a single track parsed from an iTunes library XML file.
+ *
+ * All fields are extracted from the plist `Tracks` dictionary. Fields absent from the XML
+ * default to empty/zero values. The [location] field stores the raw `file://` URI as found
+ * in the XML; callers convert it to a [java.nio.file.Path] before import.
+ */
+data class ItunesTrack(
+    val id: Int,
+    val title: String,
+    val artist: String,
+    val albumArtist: String,
+    val album: String,
+    val genre: String?,
+    val year: Short?,
+    val trackNumber: Short?,
+    val discNumber: Short?,
+    val totalTimeMs: Long,
+    val bitRate: Int,
+    val playCount: Short,
+    val rating: Int,
+    val bpm: Float?,
+    val comments: String?,
+    val location: String,
+    val isCompilation: Boolean,
+    val persistentId: String?,
+    val dateAdded: LocalDateTime?
+)

--- a/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/itunes/ItunesImportServiceTest.kt
+++ b/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/itunes/ItunesImportServiceTest.kt
@@ -6,6 +6,7 @@ import net.transgressoft.lirp.event.ReactiveScope
 import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.ints.shouldBeLessThan
 import io.kotest.matchers.optional.shouldBePresent
 import io.kotest.matchers.shouldBe
 import org.jaudiotagger.audio.AudioFileIO
@@ -265,8 +266,6 @@ internal class ItunesImportServiceTest : StringSpec({
         val result = service.importAsync(listOf(playlist), library, policy).get()
 
         result.importedCount shouldBe 1
-        val item = musicLibrary.audioLibrary().search { true }.first()
-        item.writeMetadata().join()
         val audioFile = AudioFileIO.read(tmpFile)
         audioFile.tag.getFirst(FieldKey.TITLE) shouldBe "Written Title"
         audioFile.tag.getFirst(FieldKey.ARTIST) shouldBe "Written Artist"
@@ -295,7 +294,8 @@ internal class ItunesImportServiceTest : StringSpec({
             (e.cause is CancellationException || e.cause is kotlinx.coroutines.CancellationException) shouldBe true
         }
 
-        musicLibrary.audioLibrary().size() shouldBe (musicLibrary.audioLibrary().size())
+        // Cancellation is proven by the exception above; the library should have fewer than all 20 tracks
+        musicLibrary.audioLibrary().size() shouldBeLessThan 20
     }
 
     "ItunesImportService imports playlist with suffix when name already exists" {

--- a/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/itunes/ItunesImportServiceTest.kt
+++ b/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/itunes/ItunesImportServiceTest.kt
@@ -1,0 +1,343 @@
+package net.transgressoft.commons.music.itunes
+
+import net.transgressoft.commons.music.MusicLibrary
+import net.transgressoft.commons.music.audio.AudioFileType
+import net.transgressoft.lirp.event.ReactiveScope
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.optional.shouldBePresent
+import io.kotest.matchers.shouldBe
+import org.jaudiotagger.audio.AudioFileIO
+import org.jaudiotagger.tag.FieldKey
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.nio.file.StandardCopyOption
+import java.time.LocalDateTime
+import java.util.concurrent.CancellationException
+import java.util.concurrent.CompletableFuture
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+
+@OptIn(ExperimentalCoroutinesApi::class)
+private fun testResourcePath(resource: String): Path {
+    val url = ItunesImportServiceTest::class.java.getResource(resource)!!
+    return when (url.protocol) {
+        "file" -> Paths.get(url.toURI())
+        else -> {
+            val extension = resource.substringAfterLast('.')
+            val tmp = File.createTempFile("test-resource-", ".$extension").also { it.deleteOnExit() }
+            ItunesImportServiceTest::class.java.getResourceAsStream(resource)!!.use { input ->
+                Files.copy(input, tmp.toPath(), StandardCopyOption.REPLACE_EXISTING)
+            }
+            tmp.toPath()
+        }
+    }
+}
+
+@ExperimentalCoroutinesApi
+@DisplayName("ItunesImportService")
+internal class ItunesImportServiceTest : StringSpec({
+
+    val testDispatcher = UnconfinedTestDispatcher()
+    val testScope = CoroutineScope(testDispatcher)
+
+    lateinit var musicLibrary: MusicLibrary
+    lateinit var service: ItunesImportService
+
+    val mp3File = testResourcePath("/testfiles/testeable.mp3")
+    val flacFile = testResourcePath("/testfiles/testeable.flac")
+
+    fun trackFor(
+        id: Int,
+        path: Path,
+        title: String = "iTunes Title",
+        artist: String = "iTunes Artist",
+        album: String = "iTunes Album"
+    ): ItunesTrack =
+        ItunesTrack(
+            id = id,
+            title = title,
+            artist = artist,
+            albumArtist = artist,
+            album = album,
+            genre = "Rock",
+            year = 2020,
+            trackNumber = 1,
+            discNumber = 1,
+            totalTimeMs = 180000L,
+            bitRate = 320,
+            playCount = 5,
+            rating = 80,
+            bpm = 120f,
+            comments = "Test comment",
+            location = path.toUri().toString(),
+            isCompilation = false,
+            persistentId = "TRACK-$id",
+            dateAdded = LocalDateTime.of(2020, 1, 1, 0, 0)
+        )
+
+    fun playlistFor(
+        name: String,
+        persistentId: String,
+        trackIds: List<Int> = emptyList(),
+        isFolder: Boolean = false,
+        parentId: String? = null
+    ): ItunesPlaylist =
+        ItunesPlaylist(name = name, persistentId = persistentId, parentPersistentId = parentId, isFolder = isFolder, trackIds = trackIds)
+
+    beforeSpec {
+        ReactiveScope.flowScope = testScope
+        ReactiveScope.ioScope = testScope
+    }
+
+    afterSpec {
+        ReactiveScope.resetDefaultFlowScope()
+        ReactiveScope.resetDefaultIoScope()
+    }
+
+    beforeEach {
+        musicLibrary = MusicLibrary.builder().build()
+        service = ItunesImportService(musicLibrary)
+    }
+
+    afterEach {
+        musicLibrary.close()
+    }
+
+    "ItunesImportService imports tracks with useFileMetadata=true using createFromFile" {
+        val track1 = trackFor(1, mp3File)
+        val track2 = trackFor(2, flacFile)
+        val playlist = playlistFor("My Playlist", "PL1", listOf(1, 2))
+        val library = ItunesLibrary(mapOf(1 to track1, 2 to track2), listOf(playlist))
+        val policy = ItunesImportPolicy(useFileMetadata = true, holdPlayCount = false, writeMetadata = false)
+
+        val result = service.importAsync(listOf(playlist), library, policy).get()
+
+        result.importedCount shouldBe 2
+        result.skippedCount shouldBe 0
+        result.errorCount shouldBe 0
+        musicLibrary.audioLibrary().size() shouldBe 2
+    }
+
+    "ItunesImportService imports tracks with useFileMetadata=false using iTunes metadata" {
+        val track = trackFor(1, mp3File, title = "iTunes Title Override", artist = "iTunes Artist Override", album = "iTunes Album Override")
+        val playlist = playlistFor("PL", "PL1", listOf(1))
+        val library = ItunesLibrary(mapOf(1 to track), listOf(playlist))
+        val policy = ItunesImportPolicy(useFileMetadata = false, holdPlayCount = false, writeMetadata = false)
+
+        val result = service.importAsync(listOf(playlist), library, policy).get()
+
+        result.importedCount shouldBe 1
+        result.errorCount shouldBe 0
+        val items = musicLibrary.audioLibrary().search { true }
+        items shouldHaveSize 1
+        val item = items.first()
+        item.title shouldBe "iTunes Title Override"
+        item.artist.name shouldBe "iTunes Artist Override"
+        item.album.name shouldBe "iTunes Album Override"
+    }
+
+    "ItunesImportService applies holdPlayCount from iTunes data" {
+        val track = trackFor(1, mp3File).copy(playCount = 42)
+        val playlist = playlistFor("PL", "PL1", listOf(1))
+        val library = ItunesLibrary(mapOf(1 to track), listOf(playlist))
+        val policy = ItunesImportPolicy(useFileMetadata = false, holdPlayCount = true, writeMetadata = false)
+
+        val result = service.importAsync(listOf(playlist), library, policy).get()
+
+        result.importedCount shouldBe 1
+        musicLibrary.audioLibrary().search { true }.first().playCount shouldBe 42.toShort()
+    }
+
+    "ItunesImportService applies holdPlayCount with useFileMetadata=true" {
+        val track = trackFor(1, mp3File).copy(playCount = 10)
+        val playlist = playlistFor("PL", "PL1", listOf(1))
+        val library = ItunesLibrary(mapOf(1 to track), listOf(playlist))
+        val policy = ItunesImportPolicy(useFileMetadata = true, holdPlayCount = true, writeMetadata = false)
+
+        val result = service.importAsync(listOf(playlist), library, policy).get()
+
+        result.importedCount shouldBe 1
+        musicLibrary.audioLibrary().search { true }.first().playCount shouldBe 10.toShort()
+    }
+
+    "ItunesImportService skips tracks with missing files when ignoreNotFound=true" {
+        val track = trackFor(1, Paths.get("/non/existent/file.mp3"))
+        val playlist = playlistFor("PL", "PL1", listOf(1))
+        val library = ItunesLibrary(mapOf(1 to track), listOf(playlist))
+        val policy = ItunesImportPolicy(ignoreNotFound = true, writeMetadata = false)
+
+        val result = service.importAsync(listOf(playlist), library, policy).get()
+
+        result.skippedCount shouldBe 1
+        result.importedCount shouldBe 0
+    }
+
+    "ItunesImportService creates playlists from selected playlists" {
+        val track = trackFor(1, mp3File)
+        val playlist = playlistFor("My Import Playlist", "PL1", listOf(1))
+        val library = ItunesLibrary(mapOf(1 to track), listOf(playlist))
+        val policy = ItunesImportPolicy(useFileMetadata = true, writeMetadata = false)
+
+        val result = service.importAsync(listOf(playlist), library, policy).get()
+
+        result.playlistsCreated shouldBe 1
+        musicLibrary.findPlaylistByName("My Import Playlist") shouldBePresent { it.name shouldBe "My Import Playlist" }
+    }
+
+    "ItunesImportService creates folder directories and wires child playlists" {
+        val track = trackFor(1, mp3File)
+        val folder = playlistFor("My Folder", "FOLDER1", isFolder = true)
+        val child = playlistFor("Child Playlist", "CHILD1", listOf(1), parentId = "FOLDER1")
+        val library = ItunesLibrary(mapOf(1 to track), listOf(folder, child))
+        val policy = ItunesImportPolicy(useFileMetadata = true, writeMetadata = false)
+
+        val result = service.importAsync(listOf(folder, child), library, policy).get()
+
+        result.playlistsCreated shouldBe 2
+        musicLibrary.findPlaylistByName("My Folder").shouldBePresent().isDirectory shouldBe true
+        musicLibrary.findPlaylistByName("Child Playlist") shouldBePresent { it.name shouldBe "Child Playlist" }
+    }
+
+    "ItunesImportService wires nested folder playlists recursively" {
+        val track = trackFor(1, mp3File)
+        val grandparent = playlistFor("Root Folder", "GF1", isFolder = true)
+        val parent = playlistFor("Sub Folder", "PF1", isFolder = true, parentId = "GF1")
+        val child = playlistFor("Leaf Playlist", "CHILD1", listOf(1), parentId = "PF1")
+        val library = ItunesLibrary(mapOf(1 to track), listOf(grandparent, parent, child))
+        val policy = ItunesImportPolicy(useFileMetadata = true, writeMetadata = false)
+
+        val result = service.importAsync(listOf(grandparent, parent, child), library, policy).get()
+
+        result.playlistsCreated shouldBe 3
+        musicLibrary.findPlaylistByName("Root Folder").shouldBePresent().isDirectory shouldBe true
+        musicLibrary.findPlaylistByName("Sub Folder").shouldBePresent().isDirectory shouldBe true
+        musicLibrary.findPlaylistByName("Leaf Playlist") shouldBePresent { it.name shouldBe "Leaf Playlist" }
+    }
+
+    "ItunesImportService reports progress via callback" {
+        val track1 = trackFor(1, mp3File)
+        val track2 = trackFor(2, flacFile)
+        val playlist = playlistFor("PL", "PL1", listOf(1, 2))
+        val library = ItunesLibrary(mapOf(1 to track1, 2 to track2), listOf(playlist))
+        val policy = ItunesImportPolicy(useFileMetadata = true, writeMetadata = false)
+
+        val progressSnapshots = mutableListOf<ImportProgress>()
+        service.importAsync(listOf(playlist), library, policy) { progress ->
+            progressSnapshots.add(progress)
+        }.get()
+
+        progressSnapshots shouldHaveSize 2
+        progressSnapshots.last().itemsProcessed shouldBe 2
+        progressSnapshots.last().totalItems shouldBe 2
+    }
+
+    "ItunesImportService skips tracks with unsupported file types" {
+        val track = trackFor(1, Paths.get("/music/song.ogg"))
+        val playlist = playlistFor("PL", "PL1", listOf(1))
+        val library = ItunesLibrary(mapOf(1 to track), listOf(playlist))
+        val policy =
+            ItunesImportPolicy(
+                acceptedFileTypes = setOf(AudioFileType.MP3),
+                ignoreNotFound = true,
+                writeMetadata = false
+            )
+
+        val result = service.importAsync(listOf(playlist), library, policy).get()
+
+        result.skippedCount shouldBe 1
+        result.importedCount shouldBe 0
+    }
+
+    "ItunesImportService writes iTunes metadata to file tags when writeMetadata=true" {
+        val tmpFile = File.createTempFile("itunes-write-test-", ".mp3").also { it.deleteOnExit() }
+        Files.copy(mp3File, tmpFile.toPath(), StandardCopyOption.REPLACE_EXISTING)
+
+        val track = trackFor(1, tmpFile.toPath(), title = "Written Title", artist = "Written Artist", album = "Written Album")
+        val playlist = playlistFor("PL", "PL1", listOf(1))
+        val library = ItunesLibrary(mapOf(1 to track), listOf(playlist))
+        val policy = ItunesImportPolicy(useFileMetadata = false, holdPlayCount = false, writeMetadata = true)
+
+        val result = service.importAsync(listOf(playlist), library, policy).get()
+
+        result.importedCount shouldBe 1
+        val item = musicLibrary.audioLibrary().search { true }.first()
+        item.writeMetadata().join()
+        val audioFile = AudioFileIO.read(tmpFile)
+        audioFile.tag.getFirst(FieldKey.TITLE) shouldBe "Written Title"
+        audioFile.tag.getFirst(FieldKey.ARTIST) shouldBe "Written Artist"
+        audioFile.tag.getFirst(FieldKey.ALBUM) shouldBe "Written Album"
+    }
+
+    "ItunesImportService cancellation stops import via CompletableFuture cancel" {
+        val tracks = (1..20).associateWith { i -> trackFor(i, mp3File, title = "Track $i") }
+        val playlist = playlistFor("PL", "PL1", (1..20).toList())
+        val library = ItunesLibrary(tracks, listOf(playlist))
+        val policy = ItunesImportPolicy(useFileMetadata = true, writeMetadata = false)
+
+        var future: CompletableFuture<ItunesImportResult>? = null
+        future =
+            service.importAsync(listOf(playlist), library, policy) { progress ->
+                if (progress.itemsProcessed >= 1) {
+                    future?.cancel(true)
+                }
+            }
+
+        try {
+            future.get()
+        } catch (_: CancellationException) {
+            // Expected — future was cancelled
+        } catch (e: java.util.concurrent.ExecutionException) {
+            (e.cause is CancellationException || e.cause is kotlinx.coroutines.CancellationException) shouldBe true
+        }
+
+        musicLibrary.audioLibrary().size() shouldBe (musicLibrary.audioLibrary().size())
+    }
+
+    "ItunesImportService imports playlist with suffix when name already exists" {
+        val track = trackFor(1, mp3File)
+        val playlist = playlistFor("Existing Playlist", "PL1", listOf(1))
+        val library = ItunesLibrary(mapOf(1 to track), listOf(playlist))
+        val policy = ItunesImportPolicy(useFileMetadata = true, writeMetadata = false)
+
+        musicLibrary.createPlaylist("Existing Playlist")
+        val result = service.importAsync(listOf(playlist), library, policy).get()
+
+        result.importedCount shouldBe 1
+        result.playlistsCreated shouldBe 1
+        musicLibrary.findPlaylistByName("Existing Playlist_1") shouldBePresent { it.name shouldBe "Existing Playlist_1" }
+    }
+
+    "ItunesImportService increments suffix when multiple collisions exist" {
+        val track = trackFor(1, mp3File)
+        val playlist = playlistFor("Duped", "PL1", listOf(1))
+        val library = ItunesLibrary(mapOf(1 to track), listOf(playlist))
+        val policy = ItunesImportPolicy(useFileMetadata = true, writeMetadata = false)
+
+        musicLibrary.createPlaylist("Duped")
+        musicLibrary.createPlaylist("Duped_1")
+        val result = service.importAsync(listOf(playlist), library, policy).get()
+
+        result.playlistsCreated shouldBe 1
+        musicLibrary.findPlaylistByName("Duped_2") shouldBePresent { it.name shouldBe "Duped_2" }
+    }
+
+    "ItunesImportService imports folder directory with suffix when name already exists" {
+        val track = trackFor(1, mp3File)
+        val folder = playlistFor("My Folder", "FOLDER1", isFolder = true)
+        val child = playlistFor("Child", "CHILD1", listOf(1), parentId = "FOLDER1")
+        val library = ItunesLibrary(mapOf(1 to track), listOf(folder, child))
+        val policy = ItunesImportPolicy(useFileMetadata = true, writeMetadata = false)
+
+        musicLibrary.createPlaylistDirectory("My Folder")
+        val result = service.importAsync(listOf(folder, child), library, policy).get()
+
+        result.playlistsCreated shouldBe 2
+        musicLibrary.findPlaylistByName("My Folder_1").shouldBePresent().isDirectory shouldBe true
+        musicLibrary.findPlaylistByName("Child") shouldBePresent { it.name shouldBe "Child" }
+    }
+})

--- a/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/itunes/ItunesLibraryParserTest.kt
+++ b/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/itunes/ItunesLibraryParserTest.kt
@@ -1,0 +1,94 @@
+package net.transgressoft.commons.music.itunes
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import java.nio.file.Paths
+
+/**
+ * Tests for [ItunesLibraryParser] covering parsing of tracks, playlists, smart playlist
+ * filtering, missing location filtering, folder hierarchy, NSDate handling, and error cases.
+ */
+@DisplayName("ItunesLibraryParser")
+internal class ItunesLibraryParserTest : StringSpec({
+
+    val fixturePath = Paths.get(ItunesLibraryParserTest::class.java.getResource("/testfiles/itunes-library.xml")!!.toURI())
+
+    "ItunesLibraryParser parses tracks from valid iTunes XML" {
+        val library = ItunesLibraryParser.parse(fixturePath)
+
+        library.tracks.size shouldBe 3
+        val track = library.tracks[100]
+        track.shouldNotBeNull()
+        track.title shouldBe "Test Song"
+        track.artist shouldBe "Test Artist"
+        track.album shouldBe "Test Album"
+        track.genre shouldBe "Rock"
+        track.trackNumber shouldBe 1.toShort()
+        track.totalTimeMs shouldBe 240000L
+        track.location shouldBe "file:///music/test-song.mp3"
+        track.playCount shouldBe 5.toShort()
+    }
+
+    "ItunesLibraryParser parses playlists from valid iTunes XML" {
+        val library = ItunesLibraryParser.parse(fixturePath)
+
+        library.playlists shouldHaveSize 4
+        val playlist = library.playlists.find { it.name == "My Playlist" }
+        playlist.shouldNotBeNull()
+        playlist.persistentId shouldBe "PL001"
+        playlist.trackIds shouldHaveSize 2
+        playlist.trackIds[0] shouldBe 100
+        playlist.trackIds[1] shouldBe 101
+    }
+
+    "ItunesLibraryParser skips smart playlists" {
+        val library = ItunesLibraryParser.parse(fixturePath)
+
+        library.playlists.none { it.name == "Smart Playlist" }.shouldBeTrue()
+        library.playlists.none { it.persistentId == "PL003" }.shouldBeTrue()
+    }
+
+    "ItunesLibraryParser skips tracks without file location" {
+        val library = ItunesLibraryParser.parse(fixturePath)
+
+        library.tracks.containsKey(102) shouldBe false
+        library.tracks.size shouldBe 3
+    }
+
+    "ItunesLibraryParser parses folder playlists with parentPersistentId" {
+        val library = ItunesLibraryParser.parse(fixturePath)
+
+        val folder = library.playlists.find { it.persistentId == "PL004" }
+        folder.shouldNotBeNull()
+        folder.isFolder.shouldBeTrue()
+
+        val child = library.playlists.find { it.persistentId == "PL005" }
+        child.shouldNotBeNull()
+        child.parentPersistentId shouldBe "PL004"
+    }
+
+    "ItunesLibraryParser handles NSDate for dateAdded field" {
+        val library = ItunesLibraryParser.parse(fixturePath)
+
+        val track = library.tracks[100]
+        track.shouldNotBeNull()
+        val dateAdded = track.dateAdded
+        dateAdded.shouldNotBeNull()
+        dateAdded.year shouldBe 2020
+        dateAdded.monthValue shouldBe 6
+        dateAdded.dayOfMonth shouldBe 15
+    }
+
+    "ItunesLibraryParser throws on non-existent file" {
+        val nonExistentPath = Paths.get("/tmp/does-not-exist-itunes-library.xml")
+
+        shouldThrow<IllegalArgumentException> {
+            ItunesLibraryParser.parse(nonExistentPath)
+        }
+    }
+})

--- a/music-commons-core/src/test/resources/testfiles/itunes-library.xml
+++ b/music-commons-core/src/test/resources/testfiles/itunes-library.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Major Version</key><integer>1</integer>
+    <key>Minor Version</key><integer>1</integer>
+    <key>Tracks</key>
+    <dict>
+        <key>100</key>
+        <dict>
+            <key>Track ID</key><integer>100</integer>
+            <key>Name</key><string>Test Song</string>
+            <key>Artist</key><string>Test Artist</string>
+            <key>Album Artist</key><string>Test Artist</string>
+            <key>Album</key><string>Test Album</string>
+            <key>Genre</key><string>Rock</string>
+            <key>Year</key><integer>2020</integer>
+            <key>Track Number</key><integer>1</integer>
+            <key>Disc Number</key><integer>1</integer>
+            <key>Total Time</key><integer>240000</integer>
+            <key>Bit Rate</key><integer>320</integer>
+            <key>Play Count</key><integer>5</integer>
+            <key>Rating</key><integer>80</integer>
+            <key>BPM</key><integer>120</integer>
+            <key>Persistent ID</key><string>ABC123</string>
+            <key>Location</key><string>file:///music/test-song.mp3</string>
+            <key>Date Added</key><date>2020-06-15T10:30:00Z</date>
+        </dict>
+        <key>101</key>
+        <dict>
+            <key>Track ID</key><integer>101</integer>
+            <key>Name</key><string>Minimal Track</string>
+            <key>Artist</key><string>Unknown</string>
+            <key>Album</key><string></string>
+            <key>Total Time</key><integer>180000</integer>
+            <key>Bit Rate</key><integer>128</integer>
+            <key>Location</key><string>file:///music/minimal.flac</string>
+        </dict>
+        <key>102</key>
+        <dict>
+            <key>Track ID</key><integer>102</integer>
+            <key>Name</key><string>No Location Track</string>
+            <key>Artist</key><string>Some Artist</string>
+            <key>Album</key><string>Some Album</string>
+            <key>Total Time</key><integer>200000</integer>
+            <key>Bit Rate</key><integer>256</integer>
+        </dict>
+        <key>103</key>
+        <dict>
+            <key>Track ID</key><integer>103</integer>
+            <key>Name</key><string>Another Song</string>
+            <key>Artist</key><string>Another Artist</string>
+            <key>Album Artist</key><string>Another Artist</string>
+            <key>Album</key><string>Another Album</string>
+            <key>Genre</key><string>Pop</string>
+            <key>Year</key><integer>2021</integer>
+            <key>Track Number</key><integer>2</integer>
+            <key>Total Time</key><integer>300000</integer>
+            <key>Bit Rate</key><integer>256</integer>
+            <key>Play Count</key><integer>10</integer>
+            <key>Rating</key><integer>100</integer>
+            <key>Persistent ID</key><string>DEF456</string>
+            <key>Location</key><string>file:///music/another.m4a</string>
+            <key>Date Added</key><date>2021-03-20T08:00:00Z</date>
+        </dict>
+    </dict>
+    <key>Playlists</key>
+    <array>
+        <dict>
+            <key>Name</key><string>My Playlist</string>
+            <key>Playlist Persistent ID</key><string>PL001</string>
+            <key>Playlist Items</key>
+            <array>
+                <dict><key>Track ID</key><integer>100</integer></dict>
+                <dict><key>Track ID</key><integer>101</integer></dict>
+            </array>
+        </dict>
+        <dict>
+            <key>Name</key><string>Second Playlist</string>
+            <key>Playlist Persistent ID</key><string>PL002</string>
+            <key>Playlist Items</key>
+            <array>
+                <dict><key>Track ID</key><integer>103</integer></dict>
+            </array>
+        </dict>
+        <dict>
+            <key>Name</key><string>Smart Playlist</string>
+            <key>Playlist Persistent ID</key><string>PL003</string>
+            <key>Smart Info</key>
+            <data>
+            AQEAAwAAAAIAAAAZAAAAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+            AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+            </data>
+            <key>Playlist Items</key>
+            <array>
+                <dict><key>Track ID</key><integer>100</integer></dict>
+            </array>
+        </dict>
+        <dict>
+            <key>Name</key><string>My Folder</string>
+            <key>Playlist Persistent ID</key><string>PL004</string>
+            <key>Folder</key><true/>
+        </dict>
+        <dict>
+            <key>Name</key><string>Child Playlist</string>
+            <key>Playlist Persistent ID</key><string>PL005</string>
+            <key>Parent Persistent ID</key><string>PL004</string>
+            <key>Playlist Items</key>
+            <array>
+                <dict><key>Track ID</key><integer>100</integer></dict>
+            </array>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/audio/FXAudioItem.kt
+++ b/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/audio/FXAudioItem.kt
@@ -399,6 +399,10 @@ class FXAudioItem internal constructor(override val path: Path, override val id:
                 logger.debug { "Metadata of $this successfully written to file" }
             }
 
+        override fun setPlayCount(count: Short) {
+            withEventsDisabled { _playCountProperty.set(count.toInt()) }
+        }
+
         internal fun incrementPlayCount() {
             mutateAndPublish {
                 _playCountProperty.set(_playCountProperty.get() + 1)

--- a/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/audio/FXAudioItem.kt
+++ b/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/audio/FXAudioItem.kt
@@ -400,6 +400,7 @@ class FXAudioItem internal constructor(override val path: Path, override val id:
             }
 
         override fun setPlayCount(count: Short) {
+            require(count >= 0) { "Play count cannot be negative" }
             withEventsDisabled { _playCountProperty.set(count.toInt()) }
         }
 


### PR DESCRIPTION
## Summary

**Phase 23: iTunes Library XML Import**
**Goal:** Provide a reusable import engine that parses an iTunes `library.xml` file, extracts tracks and playlists, and imports them into an `AudioLibrary`/`MusicLibrary` with configurable metadata policies.

Adds a complete iTunes library XML import engine to `music-commons-core`. Consumers parse the XML via `ItunesLibraryParser`, select playlists, then call `ItunesImportService.importAsync()` with an `ItunesImportPolicy` to control metadata source, play count transfer, tag write-back, and file filtering. The import runs asynchronously via `CompletableFuture` with progress callbacks and cancellation support.

Closes #57

## Changes

### Plan 23-01: iTunes domain model and parser
- dd-plist 1.29 added to Gradle version catalog
- `ItunesTrack`, `ItunesPlaylist`, `ItunesLibrary` data classes
- `ItunesLibraryParser` using dd-plist `PropertyListParser` — skips smart playlists and cloud-only tracks, decodes `file://` URIs, parses folder hierarchies

### Plan 23-02: Import service with metadata policies
- `ItunesImportPolicy` — configurable `useFileMetadata`, `holdPlayCount`, `writeMetadata`, `ignoreNotFound`, `acceptedFileTypes`
- `ItunesImportService` — async import with track-level progress and `CompletableFuture.cancel()` support
- `useFileMetadata=false` path: constructs `MutableAudioItem` with iTunes user-facing fields + technical metadata from file tags
- `writeMetadata=true`: writes metadata to file via `audioItem.writeMetadata()`
- Playlist creation: folders first, regular playlists second, parent wiring third
- Duplicate playlist names resolved with `_1`, `_2` suffixes
- Recursive folder-in-folder nesting supported

### API addition: `ReactiveAudioItem.setPlayCount(count)`
- New method on the `ReactiveAudioItem` interface for bulk play count transfer
- Implemented in `MutableAudioItem` (core) and `FXAudioItem` (FX) — enables import with both `MusicLibrary` and `FXMusicLibrary`

**Key files created:**
- `music-commons-core/src/main/kotlin/net/transgressoft/commons/music/itunes/ItunesLibraryParser.kt`
- `music-commons-core/src/main/kotlin/net/transgressoft/commons/music/itunes/ItunesImportService.kt`
- `music-commons-core/src/main/kotlin/net/transgressoft/commons/music/itunes/ItunesImportPolicy.kt`
- `music-commons-core/src/main/kotlin/net/transgressoft/commons/music/itunes/ItunesTrack.kt`
- `music-commons-core/src/main/kotlin/net/transgressoft/commons/music/itunes/ItunesPlaylist.kt`
- `music-commons-core/src/main/kotlin/net/transgressoft/commons/music/itunes/ItunesLibrary.kt`
- `music-commons-core/src/main/kotlin/net/transgressoft/commons/music/itunes/ImportProgress.kt`
- `music-commons-core/src/main/kotlin/net/transgressoft/commons/music/itunes/ItunesImportResult.kt`

**Key files modified:**
- `music-commons-api/src/main/kotlin/net/transgressoft/commons/music/audio/ReactiveAudioItem.kt` — added `setPlayCount()`
- `music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/MutableAudioItem.kt` — `setPlayCount` now overrides interface
- `music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/DefaultAudioLibrary.kt` — added `nextAudioItemId()`
- `music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/audio/FXAudioItem.kt` — added `setPlayCount()`
- `gradle/libs.versions.toml` — dd-plist dependency
- `music-commons-core/build.gradle` — dd-plist dependency

## Verification

- [x] `gradle compileKotlin compileTestKotlin` — all modules compile
- [x] `gradle ktlintCheck` — no style violations
- [x] `gradle test` — all tests pass (18 iTunes tests + full suite)
- [x] Parser tests: tracks, playlists, smart playlist skip, missing location skip, folder hierarchy, NSDate
- [x] Import tests: useFileMetadata true/false, holdPlayCount, ignoreNotFound, playlist creation, folder wiring, recursive nesting, progress callback, cancellation, writeMetadata, name collision suffixes

## Decisions (from CONTEXT.md D-01 through D-11)

| Decision | Implementation |
|----------|---------------|
| D-01: dd-plist library | `com.googlecode.plist:dd-plist:1.29` |
| D-02: Core only | All types in `music-commons-core` |
| D-03: Dedicated service | `ItunesImportService` class |
| D-04: CompletableFuture | `importAsync()` returns `CompletableFuture<ItunesImportResult>` |
| D-05: Rich domain model | `ItunesLibrary`, `ItunesTrack`, `ItunesPlaylist` |
| D-06: useFileMetadata=false | Technical-only file read + iTunes user fields |
| D-07: useFileMetadata=true | Delegates to `createFromFile()` |
| D-08: writeMetadata independent | Uses `audioItem.writeMetadata()` |
| D-09: holdPlayCount | Via `ReactiveAudioItem.setPlayCount()` |
| D-10: Progress callback | `onProgress: (ImportProgress) -> Unit` |
| D-11: Cancellation | `CompletableFuture.cancel()` + `ensureActive()` |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added iTunes library import functionality to parse and import playlists and tracks from iTunes library files
  * Implemented customizable import policies to control metadata sources, play count handling, and file type filtering
  * Added progress reporting and error tracking during import operations

* **Documentation**
  * Updated README with iTunes library import usage guide and available configuration options

* **Tests**
  * Added comprehensive test coverage for iTunes import functionality and library parsing

* **Chores**
  * Added required dependency for plist file parsing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->