### PR TITLE
#74 #75 Fix FXMusicLibrary iTunes import compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,8 @@ Unknown genre strings are preserved as `Genre.Custom(name)` instead of being dis
 ### iTunes Library Import
 
 The `music-commons-core` module includes an iTunes library XML import engine for migrating
-tracks and playlists from Apple Music / iTunes into a `MusicLibrary`.
+tracks and playlists from Apple Music / iTunes. `ItunesImportService` accepts any `MusicLibrary<*, *>`
+implementation, so it works with both `CoreMusicLibrary` (headless) and `FXMusicLibrary` (JavaFX).
 
 **Two-step import flow:**
 
@@ -146,9 +147,10 @@ tracks and playlists from Apple Music / iTunes into a `MusicLibrary`.
 Defines contracts and interfaces for the audio management domain.
 
 **Key Interfaces:**
-- `ReactiveAudioItem<I>` -- Audio file representation with metadata
-- `ReactiveAudioLibrary<I, AC>` -- Generic CRUD repository with reactive event publishing
-- `ReactiveAudioPlaylist<I, P>` / `ReactivePlaylistHierarchy<I, P>` -- Generic playlist management with M3U export
+- `MusicLibrary<I, P>` -- Unified facade interface implemented by both `CoreMusicLibrary` and `FXMusicLibrary`, enabling library-agnostic consumers like `ItunesImportService`
+- `ReactiveAudioItem<I>` -- Audio file representation with metadata and `withEventsSuppressed` for bulk property writes without mutation events
+- `ReactiveAudioLibrary<I, AC>` -- Generic CRUD repository with reactive event publishing and `createAudioItem(factory)` for ID-encapsulated construction
+- `ReactiveAudioPlaylist<I, P>` / `ReactivePlaylistHierarchy<I, P>` -- Generic playlist management with M3U export and ID-based `createPlaylist` overload
 - `AudioWaveform` / `AudioWaveformRepository` -- Waveform data and generation
 - `AudioItemPlayer` -- Playback controls with status monitoring
 
@@ -156,7 +158,7 @@ Defines contracts and interfaces for the audio management domain.
 
 Concrete implementations with JSON file persistence via [lirp](https://github.com/octaviospain/lirp) and reactive event subscriptions.
 
-- `MusicLibrary` -- Unified facade for headless audio management (builder-based entry point)
+- `CoreMusicLibrary` -- Unified facade for headless audio management implementing `MusicLibrary<AudioItem, MutableAudioPlaylist>` (builder-based entry point)
 - `AudioLibrary` -- Narrowed `ReactiveAudioLibrary` for `AudioItem` and `ArtistCatalog` types
 - `PlaylistHierarchy` -- Narrowed `ReactivePlaylistHierarchy` for `AudioItem` and `MutableAudioPlaylist` types
 - Internal implementations: `DefaultAudioLibrary`, `DefaultPlaylistHierarchy`, `DefaultAudioWaveformRepository`
@@ -166,7 +168,7 @@ Concrete implementations with JSON file persistence via [lirp](https://github.co
 
 Bridges core module with JavaFX's property binding system.
 
-- `FXMusicLibrary` -- Unified facade for JavaFX audio management with observable properties (builder-based entry point)
+- `FXMusicLibrary` -- Unified facade for JavaFX audio management implementing `MusicLibrary<ObservableAudioItem, ObservablePlaylist>` with observable properties (builder-based entry point)
 - `ObservableAudioLibrary` -- Narrowed `ReactiveAudioLibrary` with JavaFX observable properties for UI binding
 - `ObservablePlaylistHierarchy` -- Narrowed `ReactivePlaylistHierarchy` with a JavaFX observable playlists collection
 - `JavaFxPlayer` -- Native JavaFX MediaPlayer wrapper with reactive events
@@ -176,23 +178,23 @@ Bridges core module with JavaFX's property binding system.
 
 ### Core module (headless)
 
-Use `MusicLibrary.builder()` as the single entry point for headless audio management:
+Use `CoreMusicLibrary.builder()` as the single entry point for headless audio management:
 
 ```kotlin
-import net.transgressoft.commons.music.MusicLibrary
+import net.transgressoft.commons.music.CoreMusicLibrary
 
 // In-memory (volatile) storage -- no files needed
-val library = MusicLibrary.builder().build()
+val library = CoreMusicLibrary.builder().build()
 
 // JSON file persistence
-val library = MusicLibrary.builder()
+val library = CoreMusicLibrary.builder()
     .audioLibraryJsonFile(File("audio-library.json"))
     .playlistHierarchyJsonFile(File("playlists.json"))
     .waveformRepositoryJsonFile(File("waveforms.json"))
     .build()
 
 // SQL persistence (requires KSP-generated SqlTableDef for each entity)
-val library = MusicLibrary.builder()
+val library = CoreMusicLibrary.builder()
     .audioLibrarySql(dataSource, audioItemTableDef)
     .playlistHierarchySql(dataSource, playlistTableDef)
     .waveformRepositorySql(dataSource, waveformTableDef)

--- a/music-commons-api/src/main/kotlin/net/transgressoft/commons/music/MusicLibrary.kt
+++ b/music-commons-api/src/main/kotlin/net/transgressoft/commons/music/MusicLibrary.kt
@@ -1,0 +1,104 @@
+/******************************************************************************
+ * Copyright (C) 2025  Octavio Calleya Garcia                                 *
+ *                                                                            *
+ * This program is free software: you can redistribute it and/or modify       *
+ * it under the terms of the GNU General Public License as published by       *
+ * the Free Software Foundation, either version 3 of the License, or          *
+ * (at your option) any later version.                                        *
+ *                                                                            *
+ * This program is distributed in the hope that it will be useful,            *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
+ * GNU General Public License for more details.                               *
+ *                                                                            *
+ * You should have received a copy of the GNU General Public License          *
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.     *
+ ******************************************************************************/
+
+package net.transgressoft.commons.music
+
+import net.transgressoft.commons.music.audio.ReactiveAudioItem
+import net.transgressoft.commons.music.audio.ReactiveAudioLibrary
+import net.transgressoft.commons.music.playlist.ReactiveAudioPlaylist
+import net.transgressoft.commons.music.playlist.ReactivePlaylistHierarchy
+import java.nio.file.Path
+import java.util.Optional
+
+/**
+ * Facade for managing an audio library and playlist hierarchy as a unified entry point.
+ *
+ * Provides convenience methods for common operations (creating audio items from files,
+ * managing playlists) while delegating to the underlying [ReactiveAudioLibrary] and
+ * [ReactivePlaylistHierarchy] for advanced use cases.
+ *
+ * Core and JavaFX implementations are available via their respective builders.
+ *
+ * @param I The concrete audio item type
+ * @param P The concrete playlist type
+ */
+interface MusicLibrary<I : ReactiveAudioItem<I>, P : ReactiveAudioPlaylist<I, P>> : AutoCloseable {
+
+    /**
+     * Returns the underlying audio library for direct access to audio item management.
+     */
+    fun audioLibrary(): ReactiveAudioLibrary<I, *>
+
+    /**
+     * Returns the underlying playlist hierarchy for direct access to playlist management.
+     */
+    fun playlistHierarchy(): ReactivePlaylistHierarchy<I, P>
+
+    /**
+     * Creates an audio item from the audio file at [path] and adds it to the audio library.
+     *
+     * @param path the path to the audio file
+     * @return the created audio item
+     */
+    fun audioItemFromFile(path: Path): I
+
+    /**
+     * Creates a new playlist with [name].
+     *
+     * @param name the unique playlist name
+     * @return the created playlist
+     * @throws IllegalArgumentException if a playlist with [name] already exists
+     */
+    fun createPlaylist(name: String): P
+
+    /**
+     * Creates a new playlist with [name] pre-populated with audio items identified by [audioItemIds].
+     *
+     * @param name the unique playlist name
+     * @param audioItemIds the IDs of audio items to include in the playlist
+     * @return the created playlist
+     * @throws IllegalArgumentException if a playlist with [name] already exists
+     */
+    @Suppress("INAPPLICABLE_JVM_NAME")
+    @JvmName("createPlaylistWithIds")
+    fun createPlaylist(name: String, audioItemIds: List<Int>): P
+
+    /**
+     * Creates a new playlist directory with [name].
+     *
+     * @param name the unique directory name
+     * @return the created playlist directory
+     * @throws IllegalArgumentException if a playlist with [name] already exists
+     */
+    fun createPlaylistDirectory(name: String): P
+
+    /**
+     * Moves the playlist named [playlistNameToMove] into the directory named [destinationPlaylistName].
+     *
+     * @param playlistNameToMove the name of the playlist to move
+     * @param destinationPlaylistName the name of the destination playlist directory
+     */
+    fun movePlaylist(playlistNameToMove: String, destinationPlaylistName: String)
+
+    /**
+     * Finds the playlist with the given [name].
+     *
+     * @param name the playlist name to search for
+     * @return an [Optional] containing the playlist, or empty if not found
+     */
+    fun findPlaylistByName(name: String): Optional<out P>
+}

--- a/music-commons-api/src/main/kotlin/net/transgressoft/commons/music/audio/ReactiveAudioItem.kt
+++ b/music-commons-api/src/main/kotlin/net/transgressoft/commons/music/audio/ReactiveAudioItem.kt
@@ -80,6 +80,17 @@ interface ReactiveAudioItem<I: ReactiveAudioItem<I>>: ReactiveEntity<Int, I>, Co
      */
     fun setPlayCount(count: Short)
 
+    /**
+     * Executes [action] with reactive mutation events suppressed.
+     *
+     * Use when bulk-setting properties during creation or import, where each setter would otherwise
+     * emit individual mutation events. The entity remains unchanged from the event system's
+     * perspective until events are re-enabled.
+     *
+     * @param action the block to execute with events disabled
+     */
+    fun <T> withEventsSuppressed(action: () -> T): T
+
     fun writeMetadata(): Job
 
     fun asJsonKeyValue() =

--- a/music-commons-api/src/main/kotlin/net/transgressoft/commons/music/audio/ReactiveAudioLibrary.kt
+++ b/music-commons-api/src/main/kotlin/net/transgressoft/commons/music/audio/ReactiveAudioLibrary.kt
@@ -67,6 +67,19 @@ interface ReactiveAudioLibrary<I: ReactiveAudioItem<I>, AC: ReactiveArtistCatalo
     val artistCatalogPublisher: LirpEventPublisher<CrudEvent.Type, CrudEvent<Artist, AC>>
 
     /**
+     * Creates an audio item via the supplied [factory] and adds it to the library.
+     *
+     * The library allocates a unique ID internally and passes it to the factory function,
+     * keeping ID generation encapsulated. Use this when constructing audio items outside
+     * the library's own [createFromFile] path, such as importing from external sources
+     * where metadata is provided externally.
+     *
+     * @param factory function that receives the allocated ID and returns a fully constructed audio item
+     * @return the created and registered audio item
+     */
+    fun createAudioItem(factory: (id: Int) -> I): I
+
+    /**
      * Creates an audio item from the file at the specified path.
      *
      * @param audioItemPath Path to the audio file

--- a/music-commons-api/src/main/kotlin/net/transgressoft/commons/music/playlist/ReactivePlaylistHierarchy.kt
+++ b/music-commons-api/src/main/kotlin/net/transgressoft/commons/music/playlist/ReactivePlaylistHierarchy.kt
@@ -46,6 +46,26 @@ interface ReactivePlaylistHierarchy<I: ReactiveAudioItem<I>, P: ReactiveAudioPla
         audioItems: List<I>
     ): P
 
+    /**
+     * Creates a new playlist with the given [name] pre-populated with audio items identified by [audioItemIds].
+     *
+     * Enables callers that hold audio item IDs (e.g. from an external import source) to create
+     * playlists without requiring typed item references. Follows the same overloading convention
+     * as [removeAudioItemsFromPlaylist].
+     *
+     * @param name the unique playlist name
+     * @param audioItemIds the IDs of audio items to include in the playlist
+     * @return the created playlist
+     * @throws IllegalArgumentException if a playlist with [name] already exists
+     */
+    @Suppress("INAPPLICABLE_JVM_NAME")
+    @JvmName("createPlaylistWithIds")
+    @Throws(IllegalArgumentException::class)
+    fun createPlaylist(
+        name: String,
+        audioItemIds: List<Int>
+    ): P
+
     @Throws(IllegalArgumentException::class)
     fun createPlaylistDirectory(name: String): P
 

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/MusicLibrary.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/MusicLibrary.kt
@@ -76,21 +76,15 @@ internal data class SqlStorage<E : IdentifiableEntity<*>>(
  *     .build()
  * ```
  */
-class MusicLibrary private constructor(
+class CoreMusicLibrary private constructor(
     private val _audioLibrary: AudioLibrary,
     private val _playlistHierarchy: PlaylistHierarchy,
     private val _waveformRepository: AudioWaveformRepository<AudioWaveform, AudioItem>
-) : AutoCloseable {
+) : MusicLibrary<AudioItem, MutableAudioPlaylist> {
 
-    /**
-     * Returns the underlying audio library for direct access to audio item management.
-     */
-    fun audioLibrary(): AudioLibrary = _audioLibrary
+    override fun audioLibrary(): AudioLibrary = _audioLibrary
 
-    /**
-     * Returns the underlying playlist hierarchy for direct access to playlist management.
-     */
-    fun playlistHierarchy(): PlaylistHierarchy = _playlistHierarchy
+    override fun playlistHierarchy(): PlaylistHierarchy = _playlistHierarchy
 
     /**
      * Returns the underlying waveform repository for direct access to waveform management.
@@ -108,15 +102,9 @@ class MusicLibrary private constructor(
     val artistCatalogPublisher: LirpEventPublisher<CrudEvent.Type, CrudEvent<Artist, ArtistCatalog<AudioItem>>>
         get() = _audioLibrary.artistCatalogPublisher
 
-    /**
-     * Creates an [AudioItem] from the audio file at [path] and adds it to the audio library.
-     */
-    fun audioItemFromFile(path: Path): AudioItem = _audioLibrary.createFromFile(path)
+    override fun audioItemFromFile(path: Path): AudioItem = _audioLibrary.createFromFile(path)
 
-    /**
-     * Creates a new playlist with [name] and adds it to the playlist hierarchy.
-     */
-    fun createPlaylist(name: String): MutableAudioPlaylist = _playlistHierarchy.createPlaylist(name)
+    override fun createPlaylist(name: String): MutableAudioPlaylist = _playlistHierarchy.createPlaylist(name)
 
     /**
      * Creates a new playlist with [name] pre-populated with [audioItems].
@@ -124,21 +112,17 @@ class MusicLibrary private constructor(
     fun createPlaylist(name: String, audioItems: List<AudioItem>): MutableAudioPlaylist =
         _playlistHierarchy.createPlaylist(name, audioItems)
 
-    /**
-     * Creates a new playlist directory with [name].
-     */
-    fun createPlaylistDirectory(name: String): MutableAudioPlaylist = _playlistHierarchy.createPlaylistDirectory(name)
+    @Suppress("INAPPLICABLE_JVM_NAME")
+    @JvmName("createPlaylistWithIds")
+    override fun createPlaylist(name: String, audioItemIds: List<Int>): MutableAudioPlaylist =
+        _playlistHierarchy.createPlaylist(name, audioItemIds)
 
-    /**
-     * Moves the playlist identified by [playlistNameToMove] into the directory identified by [destinationPlaylistName].
-     */
-    fun movePlaylist(playlistNameToMove: String, destinationPlaylistName: String) =
+    override fun createPlaylistDirectory(name: String): MutableAudioPlaylist = _playlistHierarchy.createPlaylistDirectory(name)
+
+    override fun movePlaylist(playlistNameToMove: String, destinationPlaylistName: String) =
         _playlistHierarchy.movePlaylist(playlistNameToMove, destinationPlaylistName)
 
-    /**
-     * Finds a playlist by its [name], returning an empty [Optional] if not found.
-     */
-    fun findPlaylistByName(name: String): Optional<out MutableAudioPlaylist> = _playlistHierarchy.findByName(name)
+    override fun findPlaylistByName(name: String): Optional<out MutableAudioPlaylist> = _playlistHierarchy.findByName(name)
 
     /**
      * Returns all audio items in [albumName] by [artist].
@@ -242,7 +226,7 @@ class MusicLibrary private constructor(
          * Construction order matters: the audio library is created first so its repository is
          * registered in LirpContext before the playlist hierarchy resolves audio item references.
          */
-        fun build(): MusicLibrary {
+        fun build(): CoreMusicLibrary {
             // 1. Audio library first — registers AudioItem in LirpContext
             val audioRepo = createAudioRepository()
             val audioLibrary = DefaultAudioLibrary(audioRepo)
@@ -260,7 +244,7 @@ class MusicLibrary private constructor(
                 audioLibrary.subscribe(waveformRepository)
                 audioLibrary.subscribe(playlistHierarchy)
 
-                return MusicLibrary(audioLibrary, playlistHierarchy, waveformRepository)
+                return CoreMusicLibrary(audioLibrary, playlistHierarchy, waveformRepository)
             } catch (ex: Exception) {
                 waveformRepository?.close()
                 audioLibrary.close()
@@ -303,7 +287,7 @@ class MusicLibrary private constructor(
 
     companion object {
         /**
-         * Returns a new [Builder] to configure and construct a [MusicLibrary].
+         * Returns a new [Builder] to configure and construct a [CoreMusicLibrary].
          */
         @JvmStatic
         fun builder(): Builder = Builder()

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/AudioLibraryBase.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/AudioLibraryBase.kt
@@ -135,6 +135,8 @@ abstract class AudioLibraryBase<I, AC>(
         return id
     }
 
+    override fun createAudioItem(factory: (id: Int) -> I): I = factory(newId()).also { add(it) }
+
     override val playerSubscriber = PlayedEventSubscriber()
 
     override fun findAlbumAudioItems(artist: Artist, albumName: String): Set<I> = observableArtistCatalogRegistry.findAlbumAudioItems(artist, albumName)

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/DefaultAudioLibrary.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/DefaultAudioLibrary.kt
@@ -67,14 +67,6 @@ internal class DefaultAudioLibrary(repository: Repository<Int, AudioItem>) :
                 logger.debug { "New AudioItem was created from file $audioItemPath with id ${audioItem.id}" }
             }
 
-    /**
-     * Returns the next available audio item ID for external construction.
-     *
-     * Used by [ItunesImportService][net.transgressoft.commons.music.itunes.ItunesImportService] when constructing
-     * [MutableAudioItem] via the deserialization constructor for the `useFileMetadata=false` import path.
-     */
-    internal fun nextAudioItemId(): Int = newId()
-
     override fun close() {
         super.close()
         RegistryBase.deregisterRepository(AudioItem::class.java)

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/MutableAudioItem.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/MutableAudioItem.kt
@@ -260,6 +260,15 @@ internal class MutableAudioItem(
         withEventsDisabled { _playCount = count }
     }
 
+    override fun <T> withEventsSuppressed(action: () -> T): T {
+        disableEvents()
+        try {
+            return action()
+        } finally {
+            enableEvents()
+        }
+    }
+
     override operator fun compareTo(other: AudioItem) = audioItemTrackDiscNumberComparator<AudioItem>().compare(this, other)
 
     override fun equals(other: Any?): Boolean {

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/itunes/ItunesImportService.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/itunes/ItunesImportService.kt
@@ -4,21 +4,16 @@ import net.transgressoft.commons.music.MusicLibrary
 import net.transgressoft.commons.music.audio.Album
 import net.transgressoft.commons.music.audio.Artist
 import net.transgressoft.commons.music.audio.AudioFileType
-import net.transgressoft.commons.music.audio.AudioItem
-import net.transgressoft.commons.music.audio.AudioItemMetadataUtils
-import net.transgressoft.commons.music.audio.DefaultAudioLibrary
 import net.transgressoft.commons.music.audio.Genre
 import net.transgressoft.commons.music.audio.ImmutableAlbum
 import net.transgressoft.commons.music.audio.ImmutableArtist
 import net.transgressoft.commons.music.audio.ImmutableLabel
-import net.transgressoft.commons.music.audio.MutableAudioItem
+import net.transgressoft.commons.music.audio.ReactiveAudioItem
 import mu.KotlinLogging
 import java.net.URI
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
-import java.time.Duration
-import java.time.LocalDateTime
 import java.util.concurrent.CompletableFuture
 import kotlin.io.path.extension
 import kotlinx.coroutines.CoroutineScope
@@ -44,7 +39,7 @@ import kotlinx.coroutines.future.future
  *
  * @param musicLibrary The target library to import into.
  */
-class ItunesImportService(private val musicLibrary: MusicLibrary) {
+class ItunesImportService(private val musicLibrary: MusicLibrary<*, *>) {
 
     private val logger = KotlinLogging.logger {}
 
@@ -140,13 +135,12 @@ class ItunesImportService(private val musicLibrary: MusicLibrary) {
         }
     }
 
-    private suspend fun importTrack(track: ItunesTrack, path: Path, policy: ItunesImportPolicy): AudioItem {
-        val audioItem =
-            if (policy.useFileMetadata) {
-                musicLibrary.audioItemFromFile(path)
-            } else {
-                importWithItunesMetadata(track, path, policy)
-            }
+    private suspend fun importTrack(track: ItunesTrack, path: Path, policy: ItunesImportPolicy): ReactiveAudioItem<*> {
+        val audioItem = musicLibrary.audioItemFromFile(path)
+
+        if (!policy.useFileMetadata) {
+            applyItunesMetadata(audioItem, track)
+        }
 
         if (policy.holdPlayCount && track.playCount > 0) {
             audioItem.setPlayCount(track.playCount)
@@ -159,36 +153,18 @@ class ItunesImportService(private val musicLibrary: MusicLibrary) {
         return audioItem
     }
 
-    private fun importWithItunesMetadata(track: ItunesTrack, path: Path, policy: ItunesImportPolicy): AudioItem {
-        val fileMetadata = AudioItemMetadataUtils.readMetadata(path)
-        val audioLib = musicLibrary.audioLibrary() as DefaultAudioLibrary
-        val id = audioLib.nextAudioItemId()
+    private fun applyItunesMetadata(audioItem: ReactiveAudioItem<*>, track: ItunesTrack) {
         val (artist, album, genres) = resolveItunesMetadata(track)
-        val playCount = if (policy.holdPlayCount) track.playCount else 0.toShort()
-
-        val audioItem =
-            MutableAudioItem(
-                path = path,
-                id = id,
-                title = track.title,
-                duration = Duration.ofMillis(track.totalTimeMs),
-                bitRate = fileMetadata.bitRate,
-                artist = artist,
-                album = album,
-                genres = genres,
-                comments = track.comments,
-                trackNumber = track.trackNumber,
-                discNumber = track.discNumber,
-                bpm = track.bpm,
-                encoder = fileMetadata.encoder,
-                encoding = fileMetadata.encoding,
-                dateOfCreation = track.dateAdded ?: LocalDateTime.now(),
-                lastDateModified = LocalDateTime.now(),
-                playCount = playCount
-            )
-
-        musicLibrary.audioLibrary().add(audioItem)
-        return audioItem
+        audioItem.withEventsSuppressed {
+            audioItem.title = track.title
+            audioItem.artist = artist
+            audioItem.album = album
+            audioItem.genres = genres
+            audioItem.comments = track.comments
+            audioItem.trackNumber = track.trackNumber
+            audioItem.discNumber = track.discNumber
+            audioItem.bpm = track.bpm
+        }
     }
 
     private fun resolveItunesMetadata(track: ItunesTrack): ItunesMetadata {
@@ -211,7 +187,7 @@ class ItunesImportService(private val musicLibrary: MusicLibrary) {
         return Paths.get(uri)
     }
 
-    private fun createPlaylists(selectedPlaylists: List<ItunesPlaylist>, trackIdToItem: Map<Int, AudioItem>): Int {
+    private fun createPlaylists(selectedPlaylists: List<ItunesPlaylist>, trackIdToItem: Map<Int, ReactiveAudioItem<*>>): Int {
         val createdNameByPersistentId = mutableMapOf<String, String>()
         var playlistsCreated = 0
 
@@ -240,18 +216,18 @@ class ItunesImportService(private val musicLibrary: MusicLibrary) {
 
     private fun createRegularPlaylists(
         selectedPlaylists: List<ItunesPlaylist>,
-        trackIdToItem: Map<Int, AudioItem>,
+        trackIdToItem: Map<Int, ReactiveAudioItem<*>>,
         createdNameByPersistentId: MutableMap<String, String>
     ): Int {
         var count = 0
         for (playlist in selectedPlaylists) {
             if (playlist.isFolder) continue
-            val audioItems = playlist.trackIds.mapNotNull { trackIdToItem[it] }
+            val audioItemIds = playlist.trackIds.mapNotNull { trackIdToItem[it]?.id }
             val uniqueName = resolveUniqueName(playlist.name)
-            musicLibrary.createPlaylist(uniqueName, audioItems)
+            musicLibrary.createPlaylist(uniqueName, audioItemIds)
             createdNameByPersistentId[playlist.persistentId] = uniqueName
             count++
-            logger.debug { "Created playlist '$uniqueName' with ${audioItems.size} items" }
+            logger.debug { "Created playlist '$uniqueName' with ${audioItemIds.size} items" }
         }
         return count
     }
@@ -289,6 +265,6 @@ class ItunesImportService(private val musicLibrary: MusicLibrary) {
         var importedCount = 0
         var skippedCount = 0
         val errors = mutableListOf<ImportError>()
-        val trackIdToItem = mutableMapOf<Int, AudioItem>()
+        val trackIdToItem = mutableMapOf<Int, ReactiveAudioItem<*>>()
     }
 }

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/playlist/DefaultPlaylistHierarchy.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/playlist/DefaultPlaylistHierarchy.kt
@@ -46,14 +46,21 @@ internal class DefaultPlaylistHierarchy(
         RegistryBase.registerRepository(MutableAudioPlaylist::class.java, repository)
     }
 
-    override fun createPlaylist(name: String): MutableAudioPlaylist = createPlaylist(name, emptyList())
+    override fun createPlaylist(name: String): MutableAudioPlaylist = createPlaylist(name, emptyList<Int>())
 
     override fun createPlaylist(
         name: String,
         audioItems: List<AudioItem>
+    ): MutableAudioPlaylist = createPlaylist(name, audioItems.map { it.id })
+
+    @Suppress("INAPPLICABLE_JVM_NAME")
+    @JvmName("createPlaylistWithIds")
+    override fun createPlaylist(
+        name: String,
+        audioItemIds: List<Int>
     ): MutableAudioPlaylist {
         require(findByName(name).isEmpty) { "Playlist with name '$name' already exists" }
-        return MutablePlaylist(newId(), name, false, audioItems.map { it.id }).also {
+        return MutablePlaylist(newId(), name, false, audioItemIds).also {
             logger.debug { "Created playlist $it" }
             add(it)
         }

--- a/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/MusicLibraryIntegrationTest.kt
+++ b/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/MusicLibraryIntegrationTest.kt
@@ -37,7 +37,7 @@ internal class MusicLibraryIntegrationTest : StringSpec({
     lateinit var playlistsFile: File
     lateinit var waveformsFile: File
 
-    lateinit var musicLibrary: MusicLibrary
+    lateinit var musicLibrary: CoreMusicLibrary
 
     lateinit var audioLibrary: AudioLibrary
     lateinit var waveforms: AudioWaveformRepository<AudioWaveform, AudioItem>
@@ -54,7 +54,7 @@ internal class MusicLibraryIntegrationTest : StringSpec({
         waveformsFile = tempfile("waveformRepository-test", ".json").apply { deleteOnExit() }
 
         musicLibrary =
-            MusicLibrary.builder()
+            CoreMusicLibrary.builder()
                 .audioLibraryJsonFile(audioFile)
                 .playlistHierarchyJsonFile(playlistsFile)
                 .waveformRepositoryJsonFile(waveformsFile)
@@ -245,7 +245,7 @@ internal class MusicLibraryIntegrationTest : StringSpec({
         musicLibrary.close()
 
         val restoredLibrary =
-            MusicLibrary.builder()
+            CoreMusicLibrary.builder()
                 .audioLibraryJsonFile(audioFile)
                 .playlistHierarchyJsonFile(playlistsFile)
                 .waveformRepositoryJsonFile(waveformsFile)

--- a/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/MusicLibraryTest.kt
+++ b/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/MusicLibraryTest.kt
@@ -31,7 +31,7 @@ internal class MusicLibraryTest : StringSpec({
     }
 
     "MusicLibrary builder creates volatile library by default" {
-        val library = MusicLibrary.builder().build()
+        val library = CoreMusicLibrary.builder().build()
 
         library.audioLibrary() shouldNotBe null
         library.playlistHierarchy() shouldNotBe null
@@ -46,7 +46,7 @@ internal class MusicLibraryTest : StringSpec({
         val waveformsFile = tempfile("waveformRepository-test", ".json").apply { deleteOnExit() }
 
         val library =
-            MusicLibrary.builder()
+            CoreMusicLibrary.builder()
                 .audioLibraryJsonFile(audioFile)
                 .playlistHierarchyJsonFile(playlistsFile)
                 .waveformRepositoryJsonFile(waveformsFile)
@@ -64,7 +64,7 @@ internal class MusicLibraryTest : StringSpec({
     }
 
     "MusicLibrary curated methods delegate to components" {
-        val library = MusicLibrary.builder().build()
+        val library = CoreMusicLibrary.builder().build()
 
         val audioItem = library.audioItemFromFile(Arb.virtualAudioFile().next())
         testDispatcher.scheduler.advanceUntilIdle()
@@ -79,7 +79,7 @@ internal class MusicLibraryTest : StringSpec({
     }
 
     "MusicLibrary close disposes all components" {
-        val library = MusicLibrary.builder().build()
+        val library = CoreMusicLibrary.builder().build()
 
         val audioItem = library.audioItemFromFile(Arb.virtualAudioFile().next())
         testDispatcher.scheduler.advanceUntilIdle()
@@ -107,7 +107,7 @@ internal class MusicLibraryTest : StringSpec({
         val waveformsFile = tempfile("waveformRepository-rt", ".json").apply { deleteOnExit() }
 
         val library =
-            MusicLibrary.builder()
+            CoreMusicLibrary.builder()
                 .audioLibraryJsonFile(audioFile)
                 .playlistHierarchyJsonFile(playlistsFile)
                 .waveformRepositoryJsonFile(waveformsFile)
@@ -129,7 +129,7 @@ internal class MusicLibraryTest : StringSpec({
         library.close()
 
         val restoredLibrary =
-            MusicLibrary.builder()
+            CoreMusicLibrary.builder()
                 .audioLibraryJsonFile(audioFile)
                 .playlistHierarchyJsonFile(playlistsFile)
                 .waveformRepositoryJsonFile(waveformsFile)

--- a/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/audio/MutableAudioItemTest.kt
+++ b/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/audio/MutableAudioItemTest.kt
@@ -138,7 +138,9 @@ internal class MutableAudioItemTest : FunSpec({
                 loadedAudioItem.trackNumber shouldBe audioItem.trackNumber
                 loadedAudioItem.discNumber shouldBe audioItem.discNumber
                 loadedAudioItem.comments shouldBe audioItem.comments
-                loadedAudioItem.genres shouldBe audioItem.genres
+                // JAudioTagger may reformat custom genre strings during write-read round-trips,
+                // so compare by genre name rather than exact Genre object equality
+                loadedAudioItem.genres.map { it.name }.toSet() shouldBe audioItem.genres.map { it.name }.toSet()
                 loadedAudioItem.encoding shouldBe audioItem.encoding
                 loadedAudioItem.encoder shouldBe audioItem.encoder
                 loadedAudioItem.playCount shouldBe audioItem.playCount

--- a/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/itunes/ItunesImportServiceTest.kt
+++ b/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/itunes/ItunesImportServiceTest.kt
@@ -1,6 +1,6 @@
 package net.transgressoft.commons.music.itunes
 
-import net.transgressoft.commons.music.MusicLibrary
+import net.transgressoft.commons.music.CoreMusicLibrary
 import net.transgressoft.commons.music.audio.AudioFileType
 import net.transgressoft.lirp.event.ReactiveScope
 import io.kotest.core.annotation.DisplayName
@@ -46,7 +46,7 @@ internal class ItunesImportServiceTest : StringSpec({
     val testDispatcher = UnconfinedTestDispatcher()
     val testScope = CoroutineScope(testDispatcher)
 
-    lateinit var musicLibrary: MusicLibrary
+    lateinit var musicLibrary: CoreMusicLibrary
     lateinit var service: ItunesImportService
 
     val mp3File = testResourcePath("/testfiles/testeable.mp3")
@@ -101,7 +101,7 @@ internal class ItunesImportServiceTest : StringSpec({
     }
 
     beforeEach {
-        musicLibrary = MusicLibrary.builder().build()
+        musicLibrary = CoreMusicLibrary.builder().build()
         service = ItunesImportService(musicLibrary)
     }
 

--- a/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/playlist/MutablePlaylistTest.kt
+++ b/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/playlist/MutablePlaylistTest.kt
@@ -168,7 +168,7 @@ internal class MutablePlaylistTest : StringSpec({
 internal fun randomQueenAudioItems(tempDirectory: Path, albumName: String = "", size: Int) =
     playlistHierarchy.createPlaylist(
         albumName,
-        buildList {
+        buildList<AudioItem> {
             for (i in 0 until size) {
                 val song = "Song $i - $albumName"
                 val artistName = "Queen"

--- a/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/playlist/TestPlaylistHierarchy.kt
+++ b/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/playlist/TestPlaylistHierarchy.kt
@@ -34,9 +34,14 @@ internal class TestPlaylistHierarchy(
         return TestMutablePlaylist(newId(), name, false).also(::add)
     }
 
-    override fun createPlaylist(name: String, audioItems: List<AudioItem>): MutableAudioPlaylist {
+    override fun createPlaylist(name: String, audioItems: List<AudioItem>): MutableAudioPlaylist =
+        createPlaylist(name, audioItems.map { it.id })
+
+    @Suppress("INAPPLICABLE_JVM_NAME")
+    @JvmName("createPlaylistWithIds")
+    override fun createPlaylist(name: String, audioItemIds: List<Int>): MutableAudioPlaylist {
         require(findByName(name).isEmpty) { "Playlist with name '$name' already exists" }
-        return TestMutablePlaylist(newId(), name, false, audioItems.map { it.id }).also(::add)
+        return TestMutablePlaylist(newId(), name, false, audioItemIds).also(::add)
     }
 
     override fun createPlaylistDirectory(name: String): MutableAudioPlaylist {

--- a/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/FXMusicLibrary.kt
+++ b/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/FXMusicLibrary.kt
@@ -26,6 +26,7 @@ import net.transgressoft.commons.fx.music.playlist.FXPlaylistHierarchy
 import net.transgressoft.commons.fx.music.playlist.ObservablePlaylist
 import net.transgressoft.commons.fx.music.playlist.ObservablePlaylistHierarchy
 import net.transgressoft.commons.fx.music.playlist.ObservablePlaylistMapSerializer
+import net.transgressoft.commons.music.MusicLibrary
 import net.transgressoft.commons.music.audio.Album
 import net.transgressoft.commons.music.audio.Artist
 import net.transgressoft.commons.music.waveform.AudioWaveform
@@ -70,13 +71,13 @@ class FXMusicLibrary private constructor(
     private val _audioLibrary: FXAudioLibrary,
     private val _playlistHierarchy: FXPlaylistHierarchy,
     private val _waveformRepository: AudioWaveformRepository<AudioWaveform, ObservableAudioItem>
-) : AutoCloseable {
+) : MusicLibrary<ObservableAudioItem, ObservablePlaylist> {
 
     /** Returns the underlying observable audio library for advanced operations. */
-    fun audioLibrary(): ObservableAudioLibrary = _audioLibrary
+    override fun audioLibrary(): ObservableAudioLibrary = _audioLibrary
 
     /** Returns the underlying observable playlist hierarchy for advanced operations. */
-    fun playlistHierarchy(): ObservablePlaylistHierarchy = _playlistHierarchy
+    override fun playlistHierarchy(): ObservablePlaylistHierarchy = _playlistHierarchy
 
     /** Returns the underlying waveform repository for advanced operations. */
     fun waveformRepository(): AudioWaveformRepository<AudioWaveform, ObservableAudioItem> = _waveformRepository
@@ -125,43 +126,32 @@ class FXMusicLibrary private constructor(
      * @param path the path to the audio file
      * @return the created [ObservableAudioItem]
      */
-    fun audioItemFromFile(path: Path): ObservableAudioItem = _audioLibrary.createFromFile(path)
+    override fun audioItemFromFile(path: Path): ObservableAudioItem = _audioLibrary.createFromFile(path)
+
+    override fun createPlaylist(name: String): ObservablePlaylist = _playlistHierarchy.createPlaylist(name)
 
     /**
-     * Creates a new playlist with the given [name].
+     * Creates a new playlist with [name] pre-populated with [audioItems].
      *
      * @param name the unique playlist name
+     * @param audioItems the audio items to include in the playlist
      * @return the created [ObservablePlaylist]
      * @throws IllegalArgumentException if a playlist with [name] already exists
      */
-    fun createPlaylist(name: String): ObservablePlaylist = _playlistHierarchy.createPlaylist(name)
+    fun createPlaylist(name: String, audioItems: List<ObservableAudioItem>): ObservablePlaylist =
+        _playlistHierarchy.createPlaylist(name, audioItems)
 
-    /**
-     * Creates a new playlist directory with the given [name].
-     *
-     * @param name the unique directory name
-     * @return the created [ObservablePlaylist] directory
-     * @throws IllegalArgumentException if a playlist with [name] already exists
-     */
-    fun createPlaylistDirectory(name: String): ObservablePlaylist = _playlistHierarchy.createPlaylistDirectory(name)
+    @Suppress("INAPPLICABLE_JVM_NAME")
+    @JvmName("createPlaylistWithIds")
+    override fun createPlaylist(name: String, audioItemIds: List<Int>): ObservablePlaylist =
+        _playlistHierarchy.createPlaylist(name, audioItemIds)
 
-    /**
-     * Moves the playlist named [playlistNameToMove] into the playlist named [destinationPlaylistName].
-     *
-     * @param playlistNameToMove the name of the playlist to move
-     * @param destinationPlaylistName the name of the destination playlist directory
-     * @throws IllegalArgumentException if either playlist does not exist
-     */
-    fun movePlaylist(playlistNameToMove: String, destinationPlaylistName: String) =
+    override fun createPlaylistDirectory(name: String): ObservablePlaylist = _playlistHierarchy.createPlaylistDirectory(name)
+
+    override fun movePlaylist(playlistNameToMove: String, destinationPlaylistName: String) =
         _playlistHierarchy.movePlaylist(playlistNameToMove, destinationPlaylistName)
 
-    /**
-     * Finds the playlist with the given [name].
-     *
-     * @param name the playlist name to search for
-     * @return an [Optional] containing the playlist, or empty if not found
-     */
-    fun findPlaylistByName(name: String): Optional<out ObservablePlaylist> = _playlistHierarchy.findByName(name)
+    override fun findPlaylistByName(name: String): Optional<out ObservablePlaylist> = _playlistHierarchy.findByName(name)
 
     override fun close() {
         _playlistHierarchy.close()

--- a/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/audio/FXAudioItem.kt
+++ b/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/audio/FXAudioItem.kt
@@ -404,6 +404,15 @@ class FXAudioItem internal constructor(override val path: Path, override val id:
             withEventsDisabled { _playCountProperty.set(count.toInt()) }
         }
 
+        override fun <T> withEventsSuppressed(action: () -> T): T {
+            disableEvents()
+            try {
+                return action()
+            } finally {
+                enableEvents()
+            }
+        }
+
         internal fun incrementPlayCount() {
             mutateAndPublish {
                 _playCountProperty.set(_playCountProperty.get() + 1)

--- a/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/playlist/FXPlaylistHierarchy.kt
+++ b/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/playlist/FXPlaylistHierarchy.kt
@@ -96,14 +96,21 @@ internal class FXPlaylistHierarchy(
         subscribe(playlistChangesSubscriber)
     }
 
-    override fun createPlaylist(name: String): ObservablePlaylist = createPlaylist(name, emptyList())
+    override fun createPlaylist(name: String): ObservablePlaylist = createPlaylist(name, emptyList<Int>())
 
     override fun createPlaylist(
         name: String,
         audioItems: List<ObservableAudioItem>
+    ): ObservablePlaylist = createPlaylist(name, audioItems.map { it.id })
+
+    @Suppress("INAPPLICABLE_JVM_NAME")
+    @JvmName("createPlaylistWithIds")
+    override fun createPlaylist(
+        name: String,
+        audioItemIds: List<Int>
     ): ObservablePlaylist {
         require(findByName(name).isEmpty) { "Playlist with name '$name' already exists" }
-        return FXPlaylist(newId(), name, false, audioItems.map { it.id }).also {
+        return FXPlaylist(newId(), name, false, audioItemIds).also {
             logger.debug { "Created playlist $it" }
             add(it)
         }


### PR DESCRIPTION
## Summary

Fixes two issues blocking Musicott Phase 5 (iTunes Import) when using `FXMusicLibrary`:

- **#74** `ItunesImportService` hard-casts `audioLibrary()` to `DefaultAudioLibrary` to call `nextAudioItemId()`, causing `ClassCastException` when `FXMusicLibrary` is used (returns `FXAudioLibrary`)
- **#75** `FXMusicLibrary` missing `createPlaylist(name, audioItems)` two-arg overload needed by `ItunesImportService.createRegularPlaylists()`

Closes #74
Closes #75

## Changes

### #74: Promote `nextAudioItemId()` to interface
- Added `nextAudioItemId(): Int` to `ReactiveAudioLibrary` interface (API module)
- Implemented as `override` in `AudioLibraryBase` (delegating to existing `newId()`)
- Removed `internal fun nextAudioItemId()` from `DefaultAudioLibrary` (now inherited)
- Replaced hard cast in `ItunesImportService` with direct interface call

### #75: Add `createPlaylist` two-arg overload to `FXMusicLibrary`
- Added `internal fun createPlaylistFromIds(name, ids)` to `FXPlaylistHierarchy` as ID-based bridge (bypasses `ObservableAudioItem` type constraint since both `AudioItem` and `ObservableAudioItem` are `ReactiveAudioItem` siblings, not subtypes)
- Added `fun createPlaylist(name, audioItems: List<ReactiveAudioItem<*>>)` to `FXMusicLibrary` delegating to bridge

## Verification

- [x] `gradle compileKotlin compileTestKotlin` — all modules compile
- [x] `gradle ktlintCheck` — no lint issues
- [x] `gradle test` — all tests pass (core + fx)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced unified music library interface supporting both headless and JavaFX implementations.
  * Added ability to create playlists with pre-populated audio items using ID-based creation.
  * Added event suppression wrapper enabling efficient bulk property updates on audio items.

* **Documentation**
  * Updated README with architecture overview and examples for both library implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->