### PR TITLE
#56 PlayableWaveformPane — wrapper component with progress, seek, and playhead

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Unknown genre strings are preserved as `Genre.Custom(name)` instead of being dis
 - **Repository caching**: Waveforms are cached and reused across requests
 - **Normalized amplitude caching**: Serialized waveforms cache normalized amplitudes with their display width — same-width requests return instantly without audio file I/O, and height-only changes apply linear scaling from cache
 - **JavaFX component**: Custom `WaveformPane` canvas with automatic redraw on resize
+- **Playback-aware visualization**: `PlayableWaveformPane` adds two-color progress fill, playhead line, click-to-seek with drag-to-scrub, and a shimmer loading animation
 
 ### Audio Playback
 
@@ -102,7 +103,7 @@ Unknown genre strings are preserved as `Genre.Custom(name)` instead of being dis
 
 - **Observable properties**: Direct binding to JavaFX TableView, ListView, and other controls
 - **Thread safety**: Audio item collections use `FxAggregateList` delegates that auto-dispatch listener notifications to the JavaFX Application Thread; artist catalog and album properties are updated via `Platform.runLater` from CRUD subscriptions
-- **Custom controls**: `WaveformPane` component for waveform visualization
+- **Custom controls**: `WaveformPane` for static waveforms, `PlayableWaveformPane` for playback-aware visualization with seek
 
 ### iTunes Library Import
 
@@ -173,7 +174,9 @@ Bridges core module with JavaFX's property binding system.
 - `ObservableAudioLibrary` -- Narrowed `ReactiveAudioLibrary` with JavaFX observable properties for UI binding
 - `ObservablePlaylistHierarchy` -- Narrowed `ReactivePlaylistHierarchy` with a JavaFX observable playlists collection
 - `JavaFxPlayer` -- Native JavaFX MediaPlayer wrapper with reactive events
-- `WaveformPane` -- Custom Canvas component for waveform visualization
+- `WaveformPane` -- Custom Canvas component for static waveform visualization
+- `PlayableWaveformPane` -- Region component with progress fill, playhead, seek, and shimmer loading
+- `SeekEvent` -- Custom JavaFX event fired on click-to-seek and drag-to-scrub interactions
 
 ## Usage Examples
 
@@ -290,11 +293,33 @@ player.dispose()
 import net.transgressoft.commons.fx.music.waveform.WaveformPane
 import javafx.scene.paint.Color
 
+// Static waveform (no playback controls)
 val waveformPane = WaveformPane()
 waveformPane.drawWaveformAsync(waveform, Color.CYAN, Color.BLACK)
-
-// Add to scene -- auto-redraws on resize
 stackPane.children.add(waveformPane)
+```
+
+#### Playback-Aware Waveform
+
+`PlayableWaveformPane` adds progress visualization, seek interaction, and a shimmer loading animation:
+
+```kotlin
+import net.transgressoft.commons.fx.music.waveform.PlayableWaveformPane
+import net.transgressoft.commons.fx.music.waveform.SeekEvent
+
+val playablePane = PlayableWaveformPane()
+playablePane.loadWaveform(waveform)
+
+// Bind progress to player (0.0-1.0)
+player.currentTimeProperty.addListener { _, _, newTime ->
+    val total = player.totalDuration.toMillis()
+    if (total > 0) playablePane.progressProperty.set(newTime.toMillis() / total)
+}
+
+// Handle seek events (fires on mouse release)
+playablePane.addEventHandler(SeekEvent.SEEK) { event ->
+    player.seek(event.seekRatio * player.totalDuration.toMillis())
+}
 ```
 
 ## Building the Project

--- a/build.gradle
+++ b/build.gradle
@@ -99,10 +99,10 @@ subprojects {
         implementation platform(libs.kotlin.bom.get())
         api platform(libs.coroutines.bom.get())
         api libs.kotlin.stdlib.get()
+        api libs.lirp.api.get()
 
         implementation libs.nv.i18n.get()
         implementation libs.kotlin.logging.get()
-        implementation libs.lirp.api.get()
         implementation libs.kotlinx.serialization.json.get()
 
         testImplementation libs.logback.core.get()

--- a/music-commons-fx/build.gradle
+++ b/music-commons-fx/build.gradle
@@ -17,6 +17,13 @@ tasks.register('runWaveformPaneDemo', JavaExec) {
     mainClass = "net.transgressoft.commons.fx.music.waveform.WaveformPaneDemo"
 }
 
+tasks.register('runPlayableWaveformPaneDemo', JavaExec) {
+    group = "Execution"
+    description = "Run PlayableWaveformPaneDemo"
+    classpath = sourceSets.test.runtimeClasspath
+    mainClass = "net.transgressoft.commons.fx.music.waveform.PlayableWaveformPaneDemo"
+}
+
 test {
     useJUnitPlatform()
 

--- a/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/waveform/PlayableWaveformPane.kt
+++ b/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/waveform/PlayableWaveformPane.kt
@@ -1,0 +1,243 @@
+/******************************************************************************
+ * Copyright (C) 2025  Octavio Calleya Garcia                                 *
+ *                                                                            *
+ * This program is free software: you can redistribute it and/or modify       *
+ * it under the terms of the GNU General Public License as published by       *
+ * the Free Software Foundation, either version 3 of the License, or          *
+ * (at your option) any later version.                                        *
+ *                                                                            *
+ * This program is distributed in the hope that it will be useful,            *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
+ * GNU General Public License for more details.                               *
+ *                                                                            *
+ * You should have received a copy of the GNU General Public License          *
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.     *
+ ******************************************************************************/
+
+package net.transgressoft.commons.fx.music.waveform
+
+import net.transgressoft.commons.music.waveform.AudioWaveform
+import javafx.animation.AnimationTimer
+import javafx.beans.property.DoubleProperty
+import javafx.beans.property.ObjectProperty
+import javafx.beans.property.SimpleDoubleProperty
+import javafx.beans.property.SimpleObjectProperty
+import javafx.event.Event
+import javafx.scene.Cursor
+import javafx.scene.canvas.Canvas
+import javafx.scene.layout.Region
+import javafx.scene.paint.Color
+import javafx.scene.paint.CycleMethod
+import javafx.scene.paint.LinearGradient
+import javafx.scene.paint.Stop
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.javafx.JavaFx
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+/**
+ * Playback-aware waveform visualization component for JavaFX.
+ *
+ * Renders audio amplitude data as a two-pass waveform split at the current playback
+ * position: bars before [progressProperty] use [playedColorProperty] and bars after use
+ * [waveformColorProperty]. A playhead vertical line is drawn at the split position when
+ * progress > 0. While amplitude data is being computed asynchronously, a shimmer animation
+ * sweeps left-to-right to indicate loading state.
+ *
+ * Mouse interaction supports click-to-seek and drag-to-scrub. Visual position updates
+ * immediately on press and drag; a [SeekEvent] fires on mouse release with the final seek
+ * ratio clamped to [0.0, 1.0]. [progressProperty] is not mutated during drag.
+ *
+ * Consumers bind [progressProperty] to their player's current time and register a
+ * [SeekEvent.SEEK] handler to relay seek commands to the player.
+ */
+class PlayableWaveformPane : Region() {
+
+    private val canvas = Canvas()
+
+    private val _progressProperty = SimpleDoubleProperty(this, "progress", 0.0)
+    val progressProperty: DoubleProperty get() = _progressProperty
+
+    private val _waveformColorProperty = SimpleObjectProperty<Color>(this, "waveformColor", Color.WHITE)
+    val waveformColorProperty: ObjectProperty<Color> get() = _waveformColorProperty
+
+    private val _playedColorProperty = SimpleObjectProperty<Color>(this, "playedColor", Color.GREEN)
+    val playedColorProperty: ObjectProperty<Color> get() = _playedColorProperty
+
+    private val _backgroundColorProperty = SimpleObjectProperty<Color>(this, "backgroundColor", Color.BLACK)
+    val backgroundColorProperty: ObjectProperty<Color> get() = _backgroundColorProperty
+
+    private val job: Job = Job()
+    private val scope = CoroutineScope(Dispatchers.Main + job)
+    private var amplitudesTask: Job? = null
+    private var cachedAmplitudes: FloatArray? = null
+    private var waveform: AudioWaveform? = null
+
+    private var isDragging = false
+    private var visualProgress = 0.0
+
+    private companion object {
+        const val SHIMMER_CYCLE_MS = 1200.0
+    }
+
+    private var shimmerTimer: AnimationTimer? = null
+    private var shimmerStartTime = 0L
+
+    init {
+        children.add(canvas)
+        canvas.widthProperty().bind(widthProperty())
+        canvas.heightProperty().bind(heightProperty())
+
+        _progressProperty.addListener { _, _, newValue ->
+            if (!isDragging) {
+                cachedAmplitudes?.let { drawWaveform(it, newValue.toDouble()) }
+            }
+        }
+        _waveformColorProperty.addListener { _, _, _ ->
+            cachedAmplitudes?.let { drawWaveform(it, _progressProperty.value) }
+        }
+        _playedColorProperty.addListener { _, _, _ ->
+            cachedAmplitudes?.let { drawWaveform(it, _progressProperty.value) }
+        }
+        _backgroundColorProperty.addListener { _, _, _ ->
+            cachedAmplitudes?.let { drawWaveform(it, _progressProperty.value) }
+        }
+
+        widthProperty().addListener { _, _, newWidth ->
+            if (newWidth.toDouble() > 0) {
+                waveform?.let { loadWaveform(it) }
+            }
+        }
+        heightProperty().addListener { _, _, newHeight ->
+            if (newHeight.toDouble() > 0) {
+                waveform?.let { loadWaveform(it) }
+            }
+        }
+
+        canvas.setOnMousePressed { e ->
+            cursor = Cursor.CROSSHAIR
+            isDragging = true
+            visualProgress = (e.x / width).coerceIn(0.0, 1.0)
+            cachedAmplitudes?.let { drawWaveform(it, visualProgress) }
+        }
+        canvas.setOnMouseDragged { e ->
+            if (isDragging) {
+                visualProgress = (e.x / width).coerceIn(0.0, 1.0)
+                cachedAmplitudes?.let { drawWaveform(it, visualProgress) }
+            }
+        }
+        canvas.setOnMouseReleased { e ->
+            cursor = Cursor.HAND
+            isDragging = false
+            val seekRatio = (e.x / width).coerceIn(0.0, 1.0)
+            visualProgress = seekRatio
+            cachedAmplitudes?.let { drawWaveform(it, seekRatio) }
+            Event.fireEvent(this, SeekEvent(this, this, seekRatio))
+        }
+    }
+
+    /**
+     * Loads the given [waveform] asynchronously. A shimmer animation starts immediately;
+     * it stops and the waveform is drawn when amplitude data arrives.
+     *
+     * Any previously pending amplitude computation is cancelled before the new one begins.
+     */
+    fun loadWaveform(waveform: AudioWaveform) {
+        this.waveform = waveform
+        amplitudesTask?.cancel()
+        startShimmer()
+
+        amplitudesTask =
+            scope.launch {
+                if (width > 0 && height > 0) {
+                    val amplitudes = waveform.amplitudes(width.toInt(), height.toInt())
+                    withContext(Dispatchers.JavaFx) {
+                        stopShimmer()
+                        cachedAmplitudes = amplitudes
+                        drawWaveform(amplitudes, _progressProperty.value)
+                    }
+                } else {
+                    withContext(Dispatchers.JavaFx) { stopShimmer() }
+                }
+            }
+    }
+
+    private fun drawWaveform(amplitudes: FloatArray, progress: Double) {
+        val gc = canvas.graphicsContext2D
+        gc.fill = _backgroundColorProperty.value
+        gc.fillRect(0.0, 0.0, width, height)
+
+        val splitX = (progress * width).toInt().coerceIn(0, amplitudes.size)
+
+        gc.lineWidth = 1.0
+        for (i in amplitudes.indices) {
+            val value = amplitudes[i]
+            val y1 = (height - 2 * value) / 2
+            val y2 = y1 + 2 * value
+            gc.stroke = if (i < splitX) _playedColorProperty.value else _waveformColorProperty.value
+            gc.strokeLine(i.toDouble(), y1, i.toDouble(), y2)
+        }
+
+        if (progress > 0.0 && splitX > 0) {
+            gc.stroke = _playedColorProperty.value
+            gc.lineWidth = 2.0
+            gc.strokeLine(splitX.toDouble(), 0.0, splitX.toDouble(), height)
+            gc.lineWidth = 1.0
+        }
+    }
+
+    private fun startShimmer() {
+        shimmerTimer?.stop()
+        shimmerStartTime = 0L
+        cursor = Cursor.DEFAULT
+        shimmerTimer =
+            object : AnimationTimer() {
+                override fun handle(now: Long) {
+                    if (shimmerStartTime == 0L) shimmerStartTime = now
+                    val elapsed = (now - shimmerStartTime) / 1_000_000.0
+                    val fraction = (elapsed % SHIMMER_CYCLE_MS) / SHIMMER_CYCLE_MS
+                    drawShimmer(fraction)
+                }
+            }
+        shimmerTimer?.start()
+    }
+
+    private fun stopShimmer() {
+        shimmerTimer?.stop()
+        shimmerTimer = null
+        cursor = Cursor.HAND
+    }
+
+    private fun drawShimmer(elapsedFraction: Double) {
+        val gc = canvas.graphicsContext2D
+        val bandWidth = width * 0.15
+        val bandCenter = elapsedFraction * (width + bandWidth) - bandWidth / 2
+        val startStop = ((bandCenter - bandWidth / 2) / width).coerceIn(0.0, 1.0)
+        val centerStop = (bandCenter / width).coerceIn(0.0, 1.0)
+        val endStop = ((bandCenter + bandWidth / 2) / width).coerceIn(0.0, 1.0)
+
+        val bg = _backgroundColorProperty.value
+        val highlight = bg.brighter().brighter()
+        val gradient =
+            LinearGradient(
+                0.0, 0.0, width, 0.0, false, CycleMethod.NO_CYCLE,
+                Stop(startStop, bg),
+                Stop(centerStop, highlight),
+                Stop(endStop, bg)
+            )
+        gc.fill = gradient
+        gc.fillRect(0.0, 0.0, width, height)
+    }
+
+    /**
+     * Cancels the shimmer animation and the coroutine scope. Must be called when the
+     * component is no longer needed to release resources.
+     */
+    fun dispose() {
+        stopShimmer()
+        job.cancel()
+    }
+}

--- a/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/waveform/SeekEvent.kt
+++ b/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/waveform/SeekEvent.kt
@@ -1,0 +1,47 @@
+/******************************************************************************
+ * Copyright (C) 2025  Octavio Calleya Garcia                                 *
+ *                                                                            *
+ * This program is free software: you can redistribute it and/or modify       *
+ * it under the terms of the GNU General Public License as published by       *
+ * the Free Software Foundation, either version 3 of the License, or          *
+ * (at your option) any later version.                                        *
+ *                                                                            *
+ * This program is distributed in the hope that it will be useful,            *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
+ * GNU General Public License for more details.                               *
+ *                                                                            *
+ * You should have received a copy of the GNU General Public License          *
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.     *
+ ******************************************************************************/
+
+package net.transgressoft.commons.fx.music.waveform
+
+import javafx.event.Event
+import javafx.event.EventTarget
+import javafx.event.EventType
+
+/**
+ * JavaFX event fired by [PlayableWaveformPane] when the user commits a seek gesture
+ * (mouse release after press or drag). Routes through the standard JavaFX event
+ * dispatch chain; consumers attach handlers via
+ * `addEventHandler(SeekEvent.SEEK) { e -> player.seek(e.seekRatio * totalDuration) }`.
+ *
+ * [seekRatio] is always clamped to [0.0, 1.0] before the event is constructed.
+ */
+class SeekEvent(
+    source: Any,
+    target: EventTarget,
+    val seekRatio: Double
+) : Event(source, target, SEEK) {
+
+    companion object {
+
+        /**
+         * The event type for seek gestures. Namespaced to avoid collisions with
+         * other libraries that may register an event type named "SEEK".
+         */
+        val SEEK: EventType<SeekEvent> =
+            EventType(Event.ANY, "net.transgressoft.commons.fx.music.waveform.SEEK")
+    }
+}

--- a/music-commons-fx/src/test/kotlin/net/transgressoft/commons/fx/music/waveform/PlayableWaveformPaneDemo.kt
+++ b/music-commons-fx/src/test/kotlin/net/transgressoft/commons/fx/music/waveform/PlayableWaveformPaneDemo.kt
@@ -1,0 +1,78 @@
+package net.transgressoft.commons.fx.music.waveform
+
+import net.transgressoft.commons.fx.music.FXMusicLibrary
+import net.transgressoft.commons.fx.music.audio.ObservableAudioItem
+import net.transgressoft.commons.fx.music.player.JavaFxPlayer
+import net.transgressoft.commons.music.waveform.ScalableAudioWaveform
+import javafx.application.Application
+import javafx.scene.Scene
+import javafx.scene.control.Button
+import javafx.scene.layout.BorderPane
+import javafx.scene.layout.HBox
+import javafx.stage.Stage
+import java.io.File
+
+/**
+ * Interactive demo application for [PlayableWaveformPane].
+ *
+ * Launches a JavaFX window showing the waveform component bound to a [JavaFxPlayer].
+ * Demonstrates progress binding, seek-on-click, drag-to-scrub, playhead rendering,
+ * and the shimmer loading animation. Use [runPlayableWaveformPaneDemo] Gradle task to run.
+ */
+class PlayableWaveformPaneDemo : Application() {
+
+    private lateinit var playableWaveformPane: PlayableWaveformPane
+    private val player = JavaFxPlayer()
+
+    override fun start(primaryStage: Stage) {
+        playableWaveformPane = PlayableWaveformPane()
+        val borderPane = BorderPane(playableWaveformPane)
+        borderPane.setPrefSize(500.0, 200.0)
+
+        val flacUri = javaClass.getResource("/testfiles/testeable.flac")?.toURI()!!
+        val mp3Uri = javaClass.getResource("/testfiles/testeable.mp3")?.toURI()!!
+
+        player.currentTimeProperty.addListener { _, _, newTime ->
+            val total = player.totalDuration.toMillis()
+            if (total > 0) {
+                playableWaveformPane.progressProperty.set(newTime.toMillis() / total)
+            }
+        }
+
+        playableWaveformPane.addEventHandler(SeekEvent.SEEK) { event ->
+            player.seek(event.seekRatio * player.totalDuration.toMillis())
+        }
+
+        val library = FXMusicLibrary.builder().build()
+        val audioItem = library.audioItemFromFile(File(mp3Uri).toPath())
+
+        borderPane.bottom = buildControls(audioItem)
+        primaryStage.title = "PlayableWaveformPane Demo"
+        primaryStage.scene = Scene(borderPane)
+        primaryStage.show()
+
+        playableWaveformPane.loadWaveform(ScalableAudioWaveform(1, File(flacUri).toPath()))
+    }
+
+    private fun buildControls(audioItem: ObservableAudioItem): HBox {
+        val playButton = Button("Play").apply { setOnAction { player.play(audioItem) } }
+        val pauseButton = Button("Pause").apply { setOnAction { player.pause() } }
+        val resumeButton = Button("Resume").apply { setOnAction { player.resume() } }
+        val stopButton = Button("Stop").apply { setOnAction { player.stop() } }
+        return HBox(10.0, playButton, pauseButton, resumeButton, stopButton)
+    }
+
+    override fun stop() {
+        player.dispose()
+        playableWaveformPane.dispose()
+        super.stop()
+    }
+
+    companion object {
+
+        @JvmStatic
+        fun main(args: Array<String>) {
+            launch(PlayableWaveformPaneDemo::class.java, *args)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

**Phase 24: PlayableWaveformPane (#56)**
**Goal:** A new `PlayableWaveformPane` JavaFX component in `music-commons-fx` that wraps its own Canvas inside a Region and adds playback-aware features: two-pass progress visualization, click-to-seek with drag-to-scrub, a playhead indicator, shimmer loading animation, and a custom SeekEvent for consumer integration.

Closes #56

## Changes

### Plan 24-01: SeekEvent + PlayableWaveformPane
JavaFX Region waveform component with two-pass progress rendering, AnimationTimer shimmer, drag-to-scrub, and SeekEvent dispatch on mouse release.

**Key files created:**
- `music-commons-fx/src/main/kotlin/.../waveform/SeekEvent.kt` — Custom JavaFX event with namespaced EventType
- `music-commons-fx/src/main/kotlin/.../waveform/PlayableWaveformPane.kt` — Region component with Canvas, properties, and interaction handling

### Plan 24-02: PlayableWaveformPaneDemo + Gradle task
Interactive JavaFX demo wiring `JavaFxPlayer` progress and seek to `PlayableWaveformPane`, with MP3 playback controls and FLAC waveform display.

**Key files created/modified:**
- `music-commons-fx/src/test/kotlin/.../waveform/PlayableWaveformPaneDemo.kt` — Demo application
- `music-commons-fx/build.gradle` — `runPlayableWaveformPaneDemo` Gradle task

### Documentation
- `README.md` — Added PlayableWaveformPane feature description, usage example, and FX module type listing
- Wiki `Waveforms.md` — Full API reference with properties table, behavior docs, SeekEvent usage

## Verification

- [x] `gradle compileKotlin compileTestKotlin ktlintCheck test` — all pass
- [x] Visual verification: progress fill, playhead, seek, drag-to-scrub, shimmer, resize — all working
- [x] Three resize bugs found and fixed during visual verification (shimmer timer leak, height reload, demo layout)

## Key Decisions

- `PlayableWaveformPane` extends `Region` with its own `Canvas` — keeps `WaveformPane` unchanged for static use cases
- Two-pass rendering: bars before `splitX` in `playedColor`, bars after in `waveformColor`
- `SeekEvent` fires only on mouse release (not during drag) to avoid flooding the player
- Progress binding is decoupled (`DoubleProperty` 0.0-1.0) — no `AudioItemPlayer` dependency
- Shimmer uses `AnimationTimer` with gradient derived from `backgroundColor.brighter().brighter()`