### PR TITLE
#84 Hydrate cover image for JSON-loaded playlists

### DIFF
--- a/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/playlist/FXPlaylist.kt
+++ b/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/playlist/FXPlaylist.kt
@@ -131,14 +131,33 @@ internal class FXPlaylist(
     init {
         audioItemsAggregate.addListener(
             ListChangeListener {
-                replaceRecursiveAudioItems()
-                changePlaylistCover()
+                refreshDerivedState()
             }
         )
         playlistsAggregate.addListener { _: SetChangeListener.Change<out ObservablePlaylist> ->
-            replaceRecursiveAudioItems()
-            changePlaylistCover()
+            refreshDerivedState()
         }
+        // Best-effort initial computation. Effective only for non-hydrated paths where audio items
+        // are already resolvable at construction time. For JSON-hydrated playlists the aggregates
+        // bind to their registries after init runs; FXPlaylistHierarchy invokes
+        // [triggerCoverHydration] post-load to recompute the cover once aggregates are bound.
+        refreshDerivedState()
+    }
+
+    /**
+     * Recomputes the recursive audio item view and cover image after the aggregate registries
+     * have been bound and synchronized. Intended to be called by [FXPlaylistHierarchy] once
+     * JSON-hydrated playlists have completed their lirp registry binding pass — at that point
+     * the audio item aggregate can resolve its referenced entities and the cover image can be
+     * derived from them. No-op for playlists whose aggregates are already populated.
+     */
+    internal fun triggerCoverHydration() {
+        refreshDerivedState()
+    }
+
+    private fun refreshDerivedState() {
+        replaceRecursiveAudioItems()
+        changePlaylistCover()
     }
 
     private fun replaceRecursiveAudioItems() {

--- a/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/playlist/FXPlaylistHierarchy.kt
+++ b/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/playlist/FXPlaylistHierarchy.kt
@@ -78,14 +78,26 @@ internal class FXPlaylistHierarchy(
         RegistryBase.deregisterRepository(ObservablePlaylist::class.java)
         RegistryBase.registerRepository(ObservablePlaylist::class.java, repository)
 
-        // Re-sync self-referencing playlist aggregates after all entities are loaded.
-        // During repository load, entities are added one at a time, so forward references
-        // (e.g. ROOT playlist referencing CHILD playlist) cannot resolve because the
-        // referenced entity isn't in the repo yet. Now that all entities are loaded,
-        // syncLocalCache resolves the backing IDs to actual entities.
+        // Re-sync aggregates after all entities are loaded. During repository load, entities
+        // are added one at a time, so forward references (e.g. ROOT playlist referencing CHILD
+        // playlist) cannot resolve because the referenced entity isn't in the repo yet. Audio
+        // item aggregates also need re-sync because the audio repository is fully populated
+        // before the playlist hierarchy loads, but FXPlaylist.init runs before bindEntityRefs
+        // attaches the audio item registry. Now that all entities are loaded and bound,
+        // syncLocalCache materializes the backing IDs into the local FX-observable cache,
+        // and triggerCoverHydration recomputes cover/recursive properties from the freshly
+        // populated audio item aggregate.
         forEach { playlist ->
             if (playlist is FXPlaylist) {
+                val audioSyncResult = runCatching { playlist.audioItemsAggregate.syncLocalCache() }
                 playlist.playlistsAggregate.syncLocalCache()
+                if (audioSyncResult.isSuccess) {
+                    playlist.triggerCoverHydration()
+                } else {
+                    logger.warn(audioSyncResult.exceptionOrNull()) {
+                        "Skipping cover hydration because audioItemsAggregate sync failed for $playlist"
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
Closes #84.

## Summary

Fix `FXPlaylist`'s cover-image hydration on the JSON-load path. Without this fix, downstream consumers of `ObservablePlaylist.coverImageProperty` (e.g. Musicott's playlist sidebar) get `Optional.empty()` for any playlist hydrated from JSON, even when the playlist's audio items carry embedded artwork.

Root cause and reproduction are documented in #84.

## Changes

### `FXPlaylist.kt`
- Add trailing `replaceRecursiveAudioItems()` + `changePlaylistCover()` calls after the listener registration in `init` (best-effort, covers the synchronously-resolvable construction paths).
- New `internal fun triggerCoverHydration()` re-invokes the two private helpers — keeps `_coverImageProperty` private to `FXPlaylist` while letting the hierarchy drive the post-bind recompute.

### `FXPlaylistHierarchy.kt`
- Extend the existing post-load sync loop to call `audioItemsAggregate.syncLocalCache()` (wrapped in `runCatching` so the audio-library-less hydration path validated by `"Initializes from a non empty JsonFileRepository without AudioLibrary resolves to empty audio items"` keeps working) and `triggerCoverHydration()` on each `FXPlaylist` after lirp's `bindEntityRefs` has attached the audio item registry.

## Test plan

- [x] `gradle :music-commons-fx:test` — full music-commons-fx suite green
- [x] `gradle :music-commons-fx:test --tests "*FXPlaylist*" --tests "*ObservablePlaylist*"` — 22/22 PASSED
- [x] `gradle clean publishToMavenLocal` — BUILD SUCCESSFUL, artifact `0.5.0-fix-fxplaylist-cover-init-SNAPSHOT` published
- [x] Musicott downstream IT `PlaylistCoverHydrationIT` — PASSED end-to-end against the patched SNAPSHOT (writes a JSON-backed library with embedded artwork, rebuilds a fresh read library, asserts non-empty `coverImageProperty`)

## Open question for review

The `audioItemsAggregate.syncLocalCache()` call is defensively wrapped in `runCatching` to preserve the audio-library-less init path. An explicit `boundRegistryInternal() != null` check might be preferable to silent exception swallowing — happy to switch if you prefer that shape.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed playlist covers and audio item lists not displaying correctly when playlists are created or loaded from storage, ensuring they populate as expected during initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->