### PR TITLE
#87 Preserve iTunes folder hierarchy and cover image on partial-selection imports

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 kotlin = "2.3.0"
 coroutines = "1.10.2"
 kotest = "5.9.1"
-lirp = "2.4.0"
+lirp = "2.4.1"
 ksp = "2.3.6"
 guava = "33.5.0-jre"
 jaudiotagger = "3.0.1"

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/itunes/ItunesImportService.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/itunes/ItunesImportService.kt
@@ -42,6 +42,11 @@ import kotlinx.coroutines.future.future
  * When a playlist name already exists in the hierarchy, the import creates it with an
  * incremental suffix (e.g., `Playlist_1`, `Playlist_2`). Folder playlists support recursive nesting.
  *
+ * Hierarchy preservation: when a selected playlist references an ancestor folder via
+ * [ItunesPlaylist.parentPersistentId] but the ancestor is not itself in [selectedPlaylists],
+ * the missing ancestors are looked up in [ItunesLibrary.playlists] and imported automatically
+ * so the user's original folder structure is reproduced in the target library.
+ *
  * @param musicLibrary The target library to import into.
  */
 class ItunesImportService(private val musicLibrary: MusicLibrary<*, *>) {
@@ -58,6 +63,12 @@ class ItunesImportService(private val musicLibrary: MusicLibrary<*, *>) {
      * @param selectedPlaylists Playlists chosen by the consumer for import.
      * @param itunesLibrary The full parsed iTunes library (for track lookup).
      * @param policy Import configuration controlling metadata source, play count, write-back, etc.
+     * @param rootDirectoryName Optional name of an existing playlist directory to use as the
+     *  parent for top-level imported playlists (those whose iTunes
+     *  [ItunesPlaylist.parentPersistentId] is `null`). When provided, every top-level imported
+     *  playlist is wired as a child of the named directory. When `null` or when no playlist
+     *  with that name exists in the library, top-level imported playlists remain orphaned in
+     *  the hierarchy and the consumer is responsible for placing them.
      * @param onProgress Callback invoked after each track is processed.
      * @return A cancellable future completing with the import result.
      */
@@ -65,11 +76,13 @@ class ItunesImportService(private val musicLibrary: MusicLibrary<*, *>) {
         selectedPlaylists: List<ItunesPlaylist>,
         itunesLibrary: ItunesLibrary,
         policy: ItunesImportPolicy = ItunesImportPolicy(),
+        rootDirectoryName: String? = null,
         onProgress: (ImportProgress) -> Unit = {}
     ): CompletableFuture<ImportResult> =
         CoroutineScope(Dispatchers.IO).future {
-            val trackImportResult = importTracks(selectedPlaylists, itunesLibrary, policy, onProgress)
-            val rejectedNames = createPlaylists(selectedPlaylists, trackImportResult.trackIdToItem)
+            val effectivePlaylists = expandWithAncestors(selectedPlaylists, itunesLibrary)
+            val trackImportResult = importTracks(effectivePlaylists, itunesLibrary, policy, onProgress)
+            val rejectedNames = createPlaylists(effectivePlaylists, trackImportResult.trackIdToItem, rootDirectoryName)
 
             ImportResult(
                 imported = trackImportResult.imported.toList(),
@@ -77,6 +90,21 @@ class ItunesImportService(private val musicLibrary: MusicLibrary<*, *>) {
                 rejectedPlaylistNames = rejectedNames
             )
         }
+
+    private fun expandWithAncestors(
+        selectedPlaylists: List<ItunesPlaylist>,
+        itunesLibrary: ItunesLibrary
+    ): List<ItunesPlaylist> {
+        val byPersistentId = itunesLibrary.playlists.associateBy(ItunesPlaylist::persistentId)
+        val expanded = LinkedHashSet<ItunesPlaylist>()
+        for (playlist in selectedPlaylists) {
+            var current: ItunesPlaylist? = playlist
+            while (current != null && expanded.add(current)) {
+                current = current.parentPersistentId?.let(byPersistentId::get)
+            }
+        }
+        return expanded.toList()
+    }
 
     private suspend fun importTracks(
         selectedPlaylists: List<ItunesPlaylist>,
@@ -192,14 +220,15 @@ class ItunesImportService(private val musicLibrary: MusicLibrary<*, *>) {
 
     private fun createPlaylists(
         selectedPlaylists: List<ItunesPlaylist>,
-        trackIdToItem: Map<Int, ReactiveAudioItem<*>>
+        trackIdToItem: Map<Int, ReactiveAudioItem<*>>,
+        rootDirectoryName: String?
     ): List<RejectedPlaylistName> {
         val createdNameByPersistentId = mutableMapOf<String, String>()
         val rejected = mutableListOf<RejectedPlaylistName>()
 
         createFolderDirectories(selectedPlaylists, createdNameByPersistentId, rejected)
         createRegularPlaylists(selectedPlaylists, trackIdToItem, createdNameByPersistentId, rejected)
-        wirePlaylistHierarchy(selectedPlaylists, createdNameByPersistentId)
+        wirePlaylistHierarchy(selectedPlaylists, createdNameByPersistentId, rootDirectoryName)
 
         return rejected
     }
@@ -247,12 +276,20 @@ class ItunesImportService(private val musicLibrary: MusicLibrary<*, *>) {
 
     private fun wirePlaylistHierarchy(
         selectedPlaylists: List<ItunesPlaylist>,
-        createdNameByPersistentId: Map<String, String>
+        createdNameByPersistentId: Map<String, String>,
+        rootDirectoryName: String?
     ) {
+        val rootDirectoryExists =
+            rootDirectoryName != null && musicLibrary.findPlaylistByName(rootDirectoryName).isPresent
         for (playlist in selectedPlaylists) {
-            val parentId = playlist.parentPersistentId ?: continue
-            val parentName = createdNameByPersistentId[parentId] ?: continue
             val childName = createdNameByPersistentId[playlist.persistentId] ?: continue
+            val parentId = playlist.parentPersistentId
+            val parentName =
+                if (parentId == null) {
+                    if (rootDirectoryExists) rootDirectoryName else continue
+                } else {
+                    createdNameByPersistentId[parentId] ?: continue
+                }
             try {
                 musicLibrary.playlistHierarchy().addPlaylistsToDirectory(setOf(childName), parentName)
                 logger.debug { "Wired '$childName' to folder '$parentName'" }

--- a/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/itunes/ItunesImportServiceTest.kt
+++ b/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/itunes/ItunesImportServiceTest.kt
@@ -8,7 +8,9 @@ import net.transgressoft.lirp.event.ReactiveScope
 import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.ints.shouldBeLessThan
 import io.kotest.matchers.optional.shouldBePresent
 import io.kotest.matchers.shouldBe
@@ -206,6 +208,78 @@ internal class ItunesImportServiceTest : StringSpec({
         musicLibrary.findPlaylistByName("Root Folder").shouldBePresent().isDirectory shouldBe true
         musicLibrary.findPlaylistByName("Sub Folder").shouldBePresent().isDirectory shouldBe true
         musicLibrary.findPlaylistByName("Leaf Playlist") shouldBePresent { it.name shouldBe "Leaf Playlist" }
+    }
+
+    "ItunesImportService preserves ancestor folders when only leaf playlists are selected" {
+        val track = trackFor(1, mp3File)
+        val grandparent = playlistFor("Root Folder", "GF1", isFolder = true)
+        val parent = playlistFor("Sub Folder", "PF1", isFolder = true, parentId = "GF1")
+        val child = playlistFor("Leaf Playlist", "CHILD1", listOf(1), parentId = "PF1")
+        val library = ItunesLibrary(mapOf(1 to track), listOf(grandparent, parent, child))
+        val policy = ItunesImportPolicy(useFileMetadata = true, writeMetadata = false)
+
+        val result = service.importAsync(listOf(child), library, policy).get()
+
+        result.rejectedPlaylistNames shouldHaveSize 0
+        musicLibrary.findPlaylistByName("Root Folder").shouldBePresent().isDirectory shouldBe true
+        musicLibrary.findPlaylistByName("Sub Folder").shouldBePresent().isDirectory shouldBe true
+        musicLibrary.findPlaylistByName("Leaf Playlist") shouldBePresent { it.name shouldBe "Leaf Playlist" }
+    }
+
+    "ItunesImportService skips ancestor lookup when ancestor is missing from the library" {
+        val track = trackFor(1, mp3File)
+        val orphanLeaf = playlistFor("Orphan Leaf", "ORPHAN1", listOf(1), parentId = "MISSING_FOLDER")
+        val library = ItunesLibrary(mapOf(1 to track), listOf(orphanLeaf))
+        val policy = ItunesImportPolicy(useFileMetadata = true, writeMetadata = false)
+
+        val result = service.importAsync(listOf(orphanLeaf), library, policy).get()
+
+        result.rejectedPlaylistNames shouldHaveSize 0
+        musicLibrary.findPlaylistByName("Orphan Leaf") shouldBePresent { it.name shouldBe "Orphan Leaf" }
+    }
+
+    "ItunesImportService wires top-level imported playlists to the supplied rootDirectoryName" {
+        val track = trackFor(1, mp3File)
+        val track2 = trackFor(2, flacFile, title = "Other")
+        val rootContainer = musicLibrary.playlistHierarchy().createPlaylistDirectory("My Root")
+        val topLevelLeaf = playlistFor("Solo Leaf", "SOLO1", listOf(1))
+        val topLevelFolder = playlistFor("Top Folder", "TOP1", isFolder = true)
+        val nestedLeaf = playlistFor("Nested Leaf", "NEST1", listOf(2), parentId = "TOP1")
+        val library = ItunesLibrary(mapOf(1 to track, 2 to track2), listOf(topLevelLeaf, topLevelFolder, nestedLeaf))
+        val policy = ItunesImportPolicy(useFileMetadata = true, writeMetadata = false)
+
+        service.importAsync(listOf(topLevelLeaf, topLevelFolder, nestedLeaf), library, policy, rootDirectoryName = "My Root").get()
+
+        // Top-level imported playlists land inside My Root; the nested leaf stays inside its iTunes parent folder.
+        val rootChildren = rootContainer.playlists.map { it.name }
+        rootChildren shouldContain "Solo Leaf"
+        rootChildren shouldContain "Top Folder"
+        val topFolder = musicLibrary.findPlaylistByName("Top Folder").get()
+        topFolder.playlists.map { it.name } shouldContain "Nested Leaf"
+    }
+
+    "ItunesImportService leaves top-level imported playlists orphaned when rootDirectoryName is null" {
+        val track = trackFor(1, mp3File)
+        val rootContainer = musicLibrary.playlistHierarchy().createPlaylistDirectory("My Root")
+        val topLevelLeaf = playlistFor("Solo Leaf", "SOLO1", listOf(1))
+        val library = ItunesLibrary(mapOf(1 to track), listOf(topLevelLeaf))
+        val policy = ItunesImportPolicy(useFileMetadata = true, writeMetadata = false)
+
+        service.importAsync(listOf(topLevelLeaf), library, policy).get()
+
+        rootContainer.playlists.map { it.name } shouldNotContain "Solo Leaf"
+        musicLibrary.findPlaylistByName("Solo Leaf").isPresent shouldBe true
+    }
+
+    "ItunesImportService gracefully skips top-level wiring when rootDirectoryName does not exist in the library" {
+        val track = trackFor(1, mp3File)
+        val topLevelLeaf = playlistFor("Solo Leaf", "SOLO1", listOf(1))
+        val library = ItunesLibrary(mapOf(1 to track), listOf(topLevelLeaf))
+        val policy = ItunesImportPolicy(useFileMetadata = true, writeMetadata = false)
+
+        service.importAsync(listOf(topLevelLeaf), library, policy, rootDirectoryName = "NotInLibrary").get()
+
+        musicLibrary.findPlaylistByName("Solo Leaf").isPresent shouldBe true
     }
 
     "ItunesImportService reports progress via callback" {

--- a/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/playlist/FXPlaylistHierarchy.kt
+++ b/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/playlist/FXPlaylistHierarchy.kt
@@ -125,6 +125,11 @@ internal class FXPlaylistHierarchy(
         return FXPlaylist(newId(), name, false, audioItemIds).also {
             logger.debug { "Created playlist $it" }
             add(it)
+            // The FXPlaylist init runs refreshDerivedState before lirp registry binding completes,
+            // so its cover and audioItemsRecursive view are computed against an empty aggregate.
+            // After add() the aggregate delegates are bound — re-trigger the recompute so a
+            // playlist created with non-empty audioItemIds shows its cover image immediately.
+            it.triggerCoverHydration()
         }
     }
 
@@ -138,6 +143,7 @@ internal class FXPlaylistHierarchy(
         return FXPlaylist(newId(), name, true, audioItems.map { it.id }).also {
             logger.debug { "Created playlist $it" }
             add(it)
+            it.triggerCoverHydration()
         }
     }
 

--- a/music-commons-fx/src/test/kotlin/net/transgressoft/commons/fx/music/FXMusicLibraryTest.kt
+++ b/music-commons-fx/src/test/kotlin/net/transgressoft/commons/fx/music/FXMusicLibraryTest.kt
@@ -112,6 +112,27 @@ internal class FXMusicLibraryTest : StringSpec({
         library.close()
     }
 
+    "FXMusicLibrary createPlaylist with non-empty audioItemIds resolves the playlist cover image after lirp binding" {
+        val library = FXMusicLibrary.builder().build()
+
+        val audioPath = Arb.virtualAudioFile().next()
+        val audioItem = library.audioItemFromFile(audioPath)
+
+        testDispatcher.scheduler.advanceUntilIdle()
+        WaitForAsyncUtils.waitForFxEvents()
+
+        val playlist = library.playlistHierarchy().createPlaylist("Imported", listOf(audioItem.id))
+
+        testDispatcher.scheduler.advanceUntilIdle()
+        WaitForAsyncUtils.waitForFxEvents()
+
+        eventuallyAfterFxEvents {
+            playlist.coverImageProperty.get().isPresent shouldBe true
+        }
+
+        library.close()
+    }
+
     "FXMusicLibrary resolves playlist self-references after JSON deserialization" {
         val playlistFile = tempfile("playlist-self-ref-test", ".json").also { it.deleteOnExit() }
         playlistFile.writeText(


### PR DESCRIPTION
## Summary

- `ItunesImportService.expandWithAncestors` walks the parent chain of each selected playlist against the full `ItunesLibrary.playlists` and prepends any missing ancestor folders to the expanded selection. Consumers that send only leaves now reproduce the user's iTunes folder structure correctly.
- New `rootDirectoryName: String?` parameter on `importAsync` (default null). When set, top-level imported playlists are wired as children of the named directory; when null or unmatched, top-level imports stay orphaned (current behavior, fully backwards compatible).
- `FXPlaylistHierarchy.createPlaylist(name, audioItemIds)` and `createPlaylistDirectory(name, audioItems)` now call `it.triggerCoverHydration()` after `add(it)` — mirrors the existing JSON-load pattern and surfaces the cover image immediately for runtime-created playlists with a non-empty initial audio-item list.

Closes #87.

## Dependency

This branch transitively depends on lirp PR octaviospain/lirp#139 (`#138 FxAggregateSet change objects return null on absent side`) — without that fix, the FX-thread crash on the `SimpleSetProperty`-wrapped aggregate prevents downstream consumers (Musicott `PlaylistTreeView`) from reacting to the new top-level wiring this PR enables. The lirp fix is independent and can land first; this branch will be rebased to depend on the released lirp version before merge.

## Test plan

- [x] `gradle :music-commons-core:test --tests "*ItunesImportServiceTest*"` — 18/18 passing (5 new regression tests + 13 existing).
- [x] `gradle :music-commons-fx:test --tests "*FXMusicLibraryTest*"` — 7/7 passing (1 new cover-hydration regression test).
- [x] `gradle test` — full music-commons suite green.
- [x] Verified each new test fails on `main` (without the corresponding fix) and passes on this branch.
- [x] End-to-end verification in downstream Musicott: pick a deep-nested iTunes leaf in the import wizard, finish the import, confirm the sidebar shows the full `Folder ▸ Sub-folder ▸ Leaf` hierarchy and the leaf playlist's cover image is set to its first track's cover.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced iTunes import to preserve and organize playlist folder hierarchies automatically.
  * Added optional root directory assignment for imported top-level playlists.

* **Bug Fixes**
  * Fixed playlist cover images not loading immediately after creation.

* **Chores**
  * Updated dependency version to 2.4.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->