### PR TITLE
Propagate recursive audio item changes from descendant playlists to ancestors

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 kotlin = "2.3.0"
 coroutines = "1.10.2"
 kotest = "5.9.1"
-lirp = "2.4.1"
+lirp = "2.4.2"
 ksp = "2.3.6"
 guava = "33.5.0-jre"
 jaudiotagger = "3.0.1"

--- a/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/playlist/FXPlaylist.kt
+++ b/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/playlist/FXPlaylist.kt
@@ -128,20 +128,43 @@ internal class FXPlaylist(
 
     override val coverImageProperty: ReadOnlyObjectProperty<Optional<Image>> = _coverImageProperty
 
+    private val childRecursiveListener = ListChangeListener<ObservableAudioItem> { refreshDerivedState() }
+
+    private val attachedChildListeners = mutableMapOf<Int, ObservablePlaylist>()
+
     init {
         audioItemsAggregate.addListener(
             ListChangeListener {
                 refreshDerivedState()
             }
         )
-        playlistsAggregate.addListener { _: SetChangeListener.Change<out ObservablePlaylist> ->
+        playlistsAggregate.addListener { change: SetChangeListener.Change<out ObservablePlaylist> ->
+            if (change.wasAdded()) {
+                attachChildRecursiveListener(change.elementAdded)
+            }
+            if (change.wasRemoved()) {
+                detachChildRecursiveListener(change.elementRemoved)
+            }
             refreshDerivedState()
         }
+        // Attach listeners for any children present at construction time so that mutations to
+        // their recursive views (e.g. items added to an already-nested leaf) propagate up.
+        playlistsAggregate.forEach { attachChildRecursiveListener(it) }
         // Best-effort initial computation. Effective only for non-hydrated paths where audio items
         // are already resolvable at construction time. For JSON-hydrated playlists the aggregates
         // bind to their registries after init runs; FXPlaylistHierarchy invokes
         // [triggerCoverHydration] post-load to recompute the cover once aggregates are bound.
         refreshDerivedState()
+    }
+
+    private fun attachChildRecursiveListener(child: ObservablePlaylist) {
+        if (attachedChildListeners.putIfAbsent(child.id, child) == null) {
+            child.audioItemsRecursiveProperty.addListener(childRecursiveListener)
+        }
+    }
+
+    private fun detachChildRecursiveListener(child: ObservablePlaylist) {
+        attachedChildListeners.remove(child.id)?.audioItemsRecursiveProperty?.removeListener(childRecursiveListener)
     }
 
     /**
@@ -150,9 +173,25 @@ internal class FXPlaylist(
      * JSON-hydrated playlists have completed their lirp registry binding pass — at that point
      * the audio item aggregate can resolve its referenced entities and the cover image can be
      * derived from them. No-op for playlists whose aggregates are already populated.
+     *
+     * Also reconciles child-recursive listeners against the post-sync [playlistsAggregate]:
+     * `syncLocalCache` populates the underlying set without firing `SetChangeListener` events,
+     * so children added during JSON load do not flow through the [playlistsAggregate] listener
+     * that normally drives listener attachment. This pass picks them up and detaches any
+     * listeners for children that are no longer present.
      */
     internal fun triggerCoverHydration() {
+        reconcileChildRecursiveListeners()
         refreshDerivedState()
+    }
+
+    private fun reconcileChildRecursiveListeners() {
+        val currentChildIds = playlistsAggregate.map { it.id }.toSet()
+        val staleIds = attachedChildListeners.keys.toSet() - currentChildIds
+        staleIds.forEach { id ->
+            attachedChildListeners.remove(id)?.audioItemsRecursiveProperty?.removeListener(childRecursiveListener)
+        }
+        playlistsAggregate.forEach { attachChildRecursiveListener(it) }
     }
 
     private fun refreshDerivedState() {

--- a/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/playlist/FXPlaylist.kt
+++ b/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/playlist/FXPlaylist.kt
@@ -168,6 +168,19 @@ internal class FXPlaylist(
     }
 
     /**
+     * Detaches every child-recursive listener owned by this playlist. Invoked by
+     * [FXPlaylistHierarchy] when this playlist is removed from the repository so that
+     * descendants no longer hold a strong listener reference back to this instance and
+     * the deleted subtree can be garbage-collected cleanly.
+     */
+    internal fun detachAllChildRecursiveListeners() {
+        attachedChildListeners.values.forEach {
+            it.audioItemsRecursiveProperty.removeListener(childRecursiveListener)
+        }
+        attachedChildListeners.clear()
+    }
+
+    /**
      * Recomputes the recursive audio item view and cover image after the aggregate registries
      * have been bound and synchronized. Intended to be called by [FXPlaylistHierarchy] once
      * JSON-hydrated playlists have completed their lirp registry binding pass — at that point

--- a/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/playlist/FXPlaylistHierarchy.kt
+++ b/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/playlist/FXPlaylistHierarchy.kt
@@ -86,7 +86,9 @@ internal class FXPlaylistHierarchy(
         // attaches the audio item registry. Now that all entities are loaded and bound,
         // syncLocalCache materializes the backing IDs into the local FX-observable cache,
         // and triggerCoverHydration recomputes cover/recursive properties from the freshly
-        // populated audio item aggregate.
+        // populated audio item aggregate. FXPlaylist's child-recursive listener attaches
+        // during this pass, so any descendant whose triggerCoverHydration runs after its
+        // parent's still cascades the recursive aggregate up the chain.
         forEach { playlist ->
             if (playlist is FXPlaylist) {
                 val audioSyncResult = runCatching { playlist.audioItemsAggregate.syncLocalCache() }

--- a/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/playlist/FXPlaylistHierarchy.kt
+++ b/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/playlist/FXPlaylistHierarchy.kt
@@ -68,6 +68,9 @@ internal class FXPlaylistHierarchy(
                 }
             }
             addOnNextEventAction(DELETE) { event ->
+                event.entities.values.forEach { playlist ->
+                    if (playlist is FXPlaylist) playlist.detachAllChildRecursiveListeners()
+                }
                 synchronized(playlistsProperty) {
                     Platform.runLater { observablePlaylistsSet.removeAll(event.entities.values.toSet()) }
                 }
@@ -154,6 +157,9 @@ internal class FXPlaylistHierarchy(
      * then deregisters the playlist repository from LirpContext.
      */
     override fun close() {
+        forEach { playlist ->
+            if (playlist is FXPlaylist) playlist.detachAllChildRecursiveListeners()
+        }
         super.close()
         playlistChangesSubscriber.cancelSubscription()
         RegistryBase.deregisterRepository(ObservablePlaylist::class.java)

--- a/music-commons-fx/src/test/kotlin/net/transgressoft/commons/fx/music/playlist/ObservablePlaylistHierarchyTest.kt
+++ b/music-commons-fx/src/test/kotlin/net/transgressoft/commons/fx/music/playlist/ObservablePlaylistHierarchyTest.kt
@@ -940,7 +940,7 @@ internal class ObservablePlaylistHierarchyTest : StringSpec({
         val audioItemRepository = VolatileRepository<Int, ObservableAudioItem>()
         audioItemRepository.add(seed)
         audioItemRepository.add(seed2)
-        FXAudioLibrary(audioItemRepository)
+        val audioLibrary = FXAudioLibrary(audioItemRepository)
 
         val readHierarchy = FXPlaylistHierarchy(JsonFileRepository(jsonFile, ObservablePlaylistMapSerializer))
 
@@ -965,6 +965,8 @@ internal class ObservablePlaylistHierarchyTest : StringSpec({
         reloadedFolder.audioItemsRecursiveProperty.size shouldBe 3
 
         readHierarchy.close()
+        audioLibrary.close()
+        audioItemRepository.close()
     }
 
     "Recursive audio items property stops propagating after a child is removed" {

--- a/music-commons-fx/src/test/kotlin/net/transgressoft/commons/fx/music/playlist/ObservablePlaylistHierarchyTest.kt
+++ b/music-commons-fx/src/test/kotlin/net/transgressoft/commons/fx/music/playlist/ObservablePlaylistHierarchyTest.kt
@@ -852,6 +852,160 @@ internal class ObservablePlaylistHierarchyTest : StringSpec({
         hierarchy.close()
     }
 
+    "Recursive audio items property propagates when items are added to a nested child playlist" {
+        val hierarchy = FXPlaylistHierarchy()
+
+        val leaf: ObservablePlaylist = hierarchy.createPlaylist("Leaf")
+        val folder: ObservablePlaylist = hierarchy.createPlaylistDirectory("Folder")
+
+        folder.addPlaylist(leaf)
+
+        testDispatcher.scheduler.advanceUntilIdle()
+        WaitForAsyncUtils.waitForFxEvents()
+
+        folder.audioItemsRecursiveProperty.size shouldBe 0
+
+        val late1 = Arb.fxAudioItem { title = "Late1" }.next()
+        val late2 = Arb.fxAudioItem { title = "Late2" }.next()
+        leaf.addAudioItems(listOf(late1, late2))
+
+        testDispatcher.scheduler.advanceUntilIdle()
+        WaitForAsyncUtils.waitForFxEvents()
+
+        leaf.audioItemsRecursiveProperty.size shouldBe 2
+        folder.audioItemsRecursiveProperty.size shouldBe 2
+        folder.audioItemsRecursiveProperty.map { it: ObservableAudioItem -> it.title } shouldContainExactly listOf("Late1", "Late2")
+
+        leaf.removeAudioItems(listOf(late1))
+
+        testDispatcher.scheduler.advanceUntilIdle()
+        WaitForAsyncUtils.waitForFxEvents()
+
+        folder.audioItemsRecursiveProperty.size shouldBe 1
+        folder.audioItemsRecursiveProperty.map { it: ObservableAudioItem -> it.title } shouldContainExactly listOf("Late2")
+
+        hierarchy.close()
+    }
+
+    "Recursive audio items property propagates through grandchild updates" {
+        val hierarchy = FXPlaylistHierarchy()
+
+        val grandchild: ObservablePlaylist = hierarchy.createPlaylist("Grandchild")
+        val middle: ObservablePlaylist = hierarchy.createPlaylistDirectory("Middle")
+        val top: ObservablePlaylist = hierarchy.createPlaylistDirectory("Top")
+
+        middle.addPlaylist(grandchild)
+        top.addPlaylist(middle)
+
+        testDispatcher.scheduler.advanceUntilIdle()
+        WaitForAsyncUtils.waitForFxEvents()
+
+        top.audioItemsRecursiveProperty.size shouldBe 0
+
+        val deep = Arb.fxAudioItem { title = "Deep" }.next()
+        grandchild.addAudioItems(listOf(deep))
+
+        testDispatcher.scheduler.advanceUntilIdle()
+        WaitForAsyncUtils.waitForFxEvents()
+
+        middle.audioItemsRecursiveProperty.size shouldBe 1
+        top.audioItemsRecursiveProperty.size shouldBe 1
+        top.audioItemsRecursiveProperty.map { it: ObservableAudioItem -> it.title } shouldContainExactly listOf("Deep")
+
+        hierarchy.close()
+    }
+
+    "Recursive audio items property reflects nested descendants after JSON round-trip" {
+        val jsonFile = tempfile("observablePlaylistHierarchy-recursive-roundtrip", ".json").apply { deleteOnExit() }
+
+        val seed = Arb.fxAudioItem { title = "RoundtripSeed" }.next()
+        val seed2 = Arb.fxAudioItem { title = "RoundtripSeed2" }.next()
+
+        // Author phase: build folder + nested leaf with audio items, then persist.
+        val writeHierarchy = FXPlaylistHierarchy(JsonFileRepository(jsonFile, ObservablePlaylistMapSerializer))
+        val leaf = writeHierarchy.createPlaylist("Leaf")
+        val folder = writeHierarchy.createPlaylistDirectory("Folder")
+        folder.addPlaylist(leaf)
+        leaf.addAudioItems(listOf(seed, seed2))
+
+        testDispatcher.scheduler.advanceUntilIdle()
+        WaitForAsyncUtils.waitForFxEvents()
+
+        folder.audioItemsRecursiveProperty.size shouldBe 2
+
+        writeHierarchy.close()
+
+        // Reload phase: simulate app restart — the audio library must be available so the
+        // playlist hierarchy can resolve the persisted audio item ids back to entities.
+        val audioItemRepository = VolatileRepository<Int, ObservableAudioItem>()
+        audioItemRepository.add(seed)
+        audioItemRepository.add(seed2)
+        FXAudioLibrary(audioItemRepository)
+
+        val readHierarchy = FXPlaylistHierarchy(JsonFileRepository(jsonFile, ObservablePlaylistMapSerializer))
+
+        testDispatcher.scheduler.advanceUntilIdle()
+        WaitForAsyncUtils.waitForFxEvents()
+
+        val reloadedFolder = readHierarchy.findByName("Folder").get()
+        val reloadedLeaf = readHierarchy.findByName("Leaf").get()
+
+        reloadedLeaf.audioItemsRecursiveProperty.size shouldBe 2
+        reloadedFolder.audioItemsRecursiveProperty.size shouldBe 2
+        reloadedFolder.audioItemsRecursiveProperty.map { it: ObservableAudioItem -> it.title } shouldContainExactly listOf("RoundtripSeed", "RoundtripSeed2")
+
+        // Subsequent runtime mutations on the reloaded leaf must propagate to the reloaded folder.
+        val late = Arb.fxAudioItem { title = "RoundtripLate" }.next()
+        audioItemRepository.add(late)
+        reloadedLeaf.addAudioItems(listOf(late))
+
+        testDispatcher.scheduler.advanceUntilIdle()
+        WaitForAsyncUtils.waitForFxEvents()
+
+        reloadedFolder.audioItemsRecursiveProperty.size shouldBe 3
+
+        readHierarchy.close()
+    }
+
+    "Recursive audio items property stops propagating after a child is removed" {
+        val hierarchy = FXPlaylistHierarchy()
+
+        // Build the same shape as the surrounding tests use: create the leaf empty,
+        // nest it, then add items afterwards. This avoids the racy "create-with-items
+        // then nest" setup where the audio item aggregate binds asynchronously.
+        val leaf: ObservablePlaylist = hierarchy.createPlaylist("Leaf")
+        val folder: ObservablePlaylist = hierarchy.createPlaylistDirectory("Folder")
+
+        folder.addPlaylist(leaf)
+
+        val seed = Arb.fxAudioItem { title = "Seed" }.next()
+        leaf.addAudioItems(listOf(seed))
+
+        testDispatcher.scheduler.advanceUntilIdle()
+        WaitForAsyncUtils.waitForFxEvents()
+
+        folder.audioItemsRecursiveProperty.size shouldBe 1
+
+        folder.removePlaylist(leaf)
+
+        testDispatcher.scheduler.advanceUntilIdle()
+        WaitForAsyncUtils.waitForFxEvents()
+
+        folder.audioItemsRecursiveProperty.size shouldBe 0
+
+        // Items added to a former child after removal must not appear in the former parent.
+        val late = Arb.fxAudioItem { title = "Late" }.next()
+        leaf.addAudioItems(listOf(late))
+
+        testDispatcher.scheduler.advanceUntilIdle()
+        WaitForAsyncUtils.waitForFxEvents()
+
+        leaf.audioItemsRecursiveProperty.size shouldBe 2
+        folder.audioItemsRecursiveProperty.size shouldBe 0
+
+        hierarchy.close()
+    }
+
     "Repository subscription updates observable properties" {
         val hierarchy = FXPlaylistHierarchy()
 


### PR DESCRIPTION
## Summary

Make `FXPlaylist.audioItemsRecursiveProperty` reflect descendant audio item changes regardless of when they happen — at runtime after nesting, on grandchildren, and after a JSON reload.

Closes #89

## Why

`FXPlaylist.init` listens to its own `audioItemsAggregate` and `playlistsAggregate` but not to its children's `audioItemsRecursiveProperty`, so the recursive view goes stale whenever:

- An already-nested child gains or loses items.
- A grandchild's items change.
- The hierarchy is reloaded from JSON and `syncLocalCache` populates `playlistsAggregate` silently (no `SetChangeListener` events fire).

## What changed

`FXPlaylist`:

- Tracks attached child listeners in a `Map<Int, ObservablePlaylist>`.
- Attaches a `ListChangeListener<ObservableAudioItem>` to each child's `audioItemsRecursiveProperty` that triggers `refreshDerivedState()` on the parent. Cascades correctly through deeper nesting.
- Attaches on add, detaches on remove via the existing `playlistsAggregate.addListener`.
- `triggerCoverHydration` reconciles the listener set against the current `playlistsAggregate` so JSON-reloaded children (populated silently by `syncLocalCache`) get listeners attached.

`FXPlaylistHierarchy`:

- Comment update only — the existing single-pass forEach is now sufficient because the child-recursive listener cascades any descendant `triggerCoverHydration` up to ancestors regardless of iteration order.

`build.gradle` / `gradle/libs.versions.toml`:

- Adds `mavenLocal()` to `allprojects.repositories` (needed for the lirp SNAPSHOT pin during development).
- Pins `lirp` to `2.4.2-fix-registerrepository-rebind-SNAPSHOT` until the companion lirp PR merges and a real release is cut. **Revert to a real lirp release before merging this PR.**

## Test plan

- [x] `Recursive audio items property propagates when items are added to a nested child playlist` — new
- [x] `Recursive audio items property propagates through grandchild updates` — new
- [x] `Recursive audio items property stops propagating after a child is removed` — new
- [x] `Recursive audio items property reflects nested descendants after JSON round-trip` — new (exercises the load path end-to-end)
- [x] All existing `ObservablePlaylistHierarchyTest` cases pass (22/22)
- [x] Full `music-commons-fx` test suite green
- [x] UAT in a downstream consumer (Musicott): create folder, nest empty leaf, drop tracks into leaf — folder shows tracks immediately. Restart app — folder still shows tracks.

## Dependency

The JSON round-trip test requires octaviospain/lirp#142 to be merged; the runtime-propagation tests pass on `lirp 2.4.1` alone. **Block this PR's merge until lirp#142 lands and the lirp version pin here is updated to a real release.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated library dependencies to latest versions for improved stability and compatibility

* **Bug Fixes**
  * Improved tracking and management of child playlist updates in nested playlists to ensure accurate and timely audio item synchronization

* **Tests**
  * Added comprehensive test coverage for nested playlist hierarchies, including scenarios involving item additions, persistence, and playlist removal

<!-- end of auto-generated comment: release notes by coderabbit.ai -->