### PR TITLE
#94 Coalesce JavaFX observable library updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Unknown genre strings are preserved as `Genre.Custom(name)` instead of being dis
 ### JavaFX Integration
 
 - **Observable properties**: Direct binding to JavaFX TableView, ListView, and other controls
-- **Thread safety**: Audio item collections use `FxAggregateList` delegates that auto-dispatch listener notifications to the JavaFX Application Thread; artist catalog and album properties are updated via `Platform.runLater` from CRUD subscriptions
+- **Thread safety**: JavaFX-facing library and artist-catalog projections coalesce burst updates onto the JavaFX Application Thread, keeping large imports responsive while converging to the correct observable state
 - **Custom controls**: `WaveformPane` for static waveforms, `PlayableWaveformPane` for playback-aware visualization with seek
 
 ### Typed Path Validation Exceptions
@@ -306,6 +306,9 @@ val fxLibrary = FXMusicLibrary.builder()
 // Bind directly to JavaFX UI components
 tableView.itemsProperty().bind(fxLibrary.audioItemsProperty)
 label.textProperty().bind(fxLibrary.albumCountProperty.asString())
+
+// Large create bursts are coalesced before the FX-facing projections refresh,
+// so bound controls converge after import bursts instead of repainting per item.
 
 // Reactive playlist updates
 fxLibrary.playlistsProperty.addListener { _, _, _ -> /* refresh UI */ }

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/MutableArtistCatalog.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/MutableArtistCatalog.kt
@@ -137,7 +137,12 @@ internal class MutableArtistCatalog<I>(override val artist: Artist)
         synchronized(this) {
             mutateAndPublish {
                 val albumName = audioItem.album.name
-                val audioItems = audioItemsByAlbumName[albumName] ?: return@mutateAndPublish false
+                val audioItems =
+                    audioItemsByAlbumName[albumName]
+                        ?: audioItemsByAlbumName.values.firstOrNull { items ->
+                            items.any { it.uniqueId == audioItem.uniqueId }
+                        }
+                        ?: return@mutateAndPublish false
 
                 val removed = audioItems.removeIf { it.uniqueId == audioItem.uniqueId }
 
@@ -161,8 +166,7 @@ internal class MutableArtistCatalog<I>(override val artist: Artist)
      */
     internal fun containsAudioItem(audioItem: I): Boolean =
         synchronized(this) {
-            audioItemsByAlbumName[audioItem.album.name]?.contains(audioItem)
-                ?: return@synchronized false
+            artist == audioItem.artist && (audioItemsByAlbumName[audioItem.album.name]?.contains(audioItem) ?: false)
         }
 
     /**

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/MutableArtistCatalog.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/MutableArtistCatalog.kt
@@ -137,18 +137,21 @@ internal class MutableArtistCatalog<I>(override val artist: Artist)
         synchronized(this) {
             mutateAndPublish {
                 val albumName = audioItem.album.name
-                val audioItems =
+                val (resolvedAlbumName, audioItems) =
                     audioItemsByAlbumName[albumName]
-                        ?: audioItemsByAlbumName.values.firstOrNull { items ->
-                            items.any { it.uniqueId == audioItem.uniqueId }
-                        }
+                        ?.let { albumName to it }
+                        ?: audioItemsByAlbumName.entries
+                            .firstOrNull { (_, items) ->
+                                items.any { it.uniqueId == audioItem.uniqueId }
+                            }
+                            ?.let { (key, items) -> key to items }
                         ?: return@mutateAndPublish false
 
                 val removed = audioItems.removeIf { it.uniqueId == audioItem.uniqueId }
 
                 if (removed) {
                     if (audioItems.isEmpty()) {
-                        audioItemsByAlbumName.remove(albumName)
+                        audioItemsByAlbumName.remove(resolvedAlbumName)
                         logger.debug { "Album ${audioItem.album} was removed from artist catalog of $artist" }
                     } else {
                         logger.debug { "AudioItem $audioItem was removed from album ${audioItem.album}" }

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/itunes/ItunesImportService.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/itunes/ItunesImportService.kt
@@ -12,6 +12,8 @@ import net.transgressoft.commons.music.audio.ReactiveAudioItem
 import net.transgressoft.commons.music.audio.WindowsPathException
 import net.transgressoft.commons.music.audio.WindowsViolation
 import net.transgressoft.commons.music.common.WindowsPathValidator
+import net.transgressoft.commons.music.playlist.ReactiveAudioPlaylist
+import net.transgressoft.lirp.event.ReactiveMutationEvent
 import mu.KotlinLogging
 import java.net.URI
 import java.nio.file.Files
@@ -49,7 +51,9 @@ import kotlinx.coroutines.future.future
  *
  * @param musicLibrary The target library to import into.
  */
-class ItunesImportService(private val musicLibrary: MusicLibrary<*, *>) {
+class ItunesImportService<I, P>(private val musicLibrary: MusicLibrary<I, P>)
+    where I : ReactiveAudioItem<I>,
+          P : ReactiveAudioPlaylist<I, P> {
 
     private val logger = KotlinLogging.logger {}
 
@@ -162,7 +166,7 @@ class ItunesImportService(private val musicLibrary: MusicLibrary<*, *>) {
         return fileType == null || fileType !in policy.acceptedFileTypes
     }
 
-    private suspend fun importTrack(track: ItunesTrack, path: Path, policy: ItunesImportPolicy): ReactiveAudioItem<*> {
+    private suspend fun importTrack(track: ItunesTrack, path: Path, policy: ItunesImportPolicy): I {
         val audioItem = musicLibrary.audioItemFromFile(path)
 
         if (!policy.useFileMetadata) {
@@ -180,7 +184,9 @@ class ItunesImportService(private val musicLibrary: MusicLibrary<*, *>) {
         return audioItem
     }
 
-    private fun applyItunesMetadata(audioItem: ReactiveAudioItem<*>, track: ItunesTrack) {
+    private fun applyItunesMetadata(audioItem: I, track: ItunesTrack) {
+        @Suppress("UNCHECKED_CAST")
+        val audioItemBeforeUpdate = audioItem.clone() as I
         val (artist, album, genres) = resolveItunesMetadata(track)
         audioItem.withEventsDisabled {
             audioItem.title = track.title
@@ -192,6 +198,7 @@ class ItunesImportService(private val musicLibrary: MusicLibrary<*, *>) {
             audioItem.discNumber = track.discNumber
             audioItem.bpm = track.bpm
         }
+        audioItem.emitAsync(ReactiveMutationEvent(audioItem, audioItemBeforeUpdate))
     }
 
     private fun resolveItunesMetadata(track: ItunesTrack): ItunesMetadata {

--- a/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/audio/MutableArtistCatalogTest.kt
+++ b/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/audio/MutableArtistCatalogTest.kt
@@ -320,6 +320,17 @@ class MutableArtistCatalogTest : StringSpec({
         }
     }
 
+    "MutableArtistCatalog removes the resolved fallback album bucket when an item's album name changed before removal" {
+        val renamedAlbum = Arb.album().next()
+        val audioItem = createAudioItem(files.virtualAudioFile().next())
+        val catalog = MutableArtistCatalog(audioItem)
+
+        audioItem.album = renamedAlbum
+
+        catalog.removeAudioItem(audioItem) shouldBe true
+        catalog.albums shouldBe emptySet()
+    }
+
     "MUTATE event is published when removing audio item from one album leaves another album" {
         val album1 = files.virtualAlbumAudioFiles().next().map(::createAudioItem)
         val album2 = files.virtualAlbumAudioFiles().next().map(::createAudioItem)

--- a/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/itunes/ItunesImportServiceTest.kt
+++ b/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/itunes/ItunesImportServiceTest.kt
@@ -3,7 +3,10 @@ package net.transgressoft.commons.music.itunes
 import net.transgressoft.commons.music.CoreMusicLibrary
 import net.transgressoft.commons.music.audio.ArbitraryAudioFile
 import net.transgressoft.commons.music.audio.AudioFileType
+import net.transgressoft.commons.music.audio.AudioItem
+import net.transgressoft.commons.music.audio.ImmutableArtist
 import net.transgressoft.commons.music.common.OsDetector
+import net.transgressoft.commons.music.playlist.MutableAudioPlaylist
 import net.transgressoft.commons.music.testing.reactiveScope
 import io.kotest.core.annotation.DisplayName
 import io.kotest.core.annotation.Isolate
@@ -36,7 +39,7 @@ internal class ItunesImportServiceTest : StringSpec({
     val reactive = reactiveScope()
 
     lateinit var musicLibrary: CoreMusicLibrary
-    lateinit var service: ItunesImportService
+    lateinit var service: ItunesImportService<AudioItem, MutableAudioPlaylist>
 
     val mp3File = ArbitraryAudioFile.getResourceAsFile("/testfiles/testeable.mp3").toPath()
     val flacFile = ArbitraryAudioFile.getResourceAsFile("/testfiles/testeable.flac").toPath()
@@ -118,6 +121,12 @@ internal class ItunesImportServiceTest : StringSpec({
         item.title shouldBe "iTunes Title Override"
         item.artist.name shouldBe "iTunes Artist Override"
         item.album.name shouldBe "iTunes Album Override"
+        musicLibrary
+            .audioLibrary()
+            .getArtistCatalog(ImmutableArtist.of("iTunes Artist Override"))
+            .shouldBePresent { catalog ->
+                catalog.albums.map { it.albumName } shouldContain "iTunes Album Override"
+            }
     }
 
     "ItunesImportService applies holdPlayCount from iTunes data" {

--- a/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/itunes/ItunesLibraryTestFixtureTest.kt
+++ b/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/itunes/ItunesLibraryTestFixtureTest.kt
@@ -1,0 +1,36 @@
+package net.transgressoft.commons.music.itunes
+
+import com.dd.plist.NSDictionary
+import com.dd.plist.PropertyListParser
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import java.nio.file.Files
+
+@DisplayName("ItunesLibraryTestFixture")
+internal class ItunesLibraryTestFixtureTest : StringSpec({
+
+    "ItunesLibraryTestFixture materializes runtime audio locations" {
+        val tempDir = Files.createTempDirectory("itunes-fixture-")
+
+        val prepared =
+            ItunesLibraryTestFixture.prepare(
+                tempDir,
+                ItunesLibraryTestFixtureTest::class.java,
+                "/testfiles/itunes-library.xml"
+            )
+
+        val root = PropertyListParser.parse(prepared.xmlPath().toFile()) as NSDictionary
+        val tracks = root.objectForKey("Tracks") as NSDictionary
+        val firstTrack = tracks.objectForKey("100") as NSDictionary
+        val location = firstTrack.objectForKey("Location").toString()
+
+        Files.exists(prepared.xmlPath()) shouldBe true
+        location shouldContain tempDir.resolve("audio").toUri().toString()
+        Files.list(tempDir.resolve("audio")).use { files ->
+            files.map { it.fileName.toString() }.toList() shouldContain "track-100.mp3"
+        }
+    }
+})

--- a/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/itunes/SyntheticItunesLibraryGeneratorTest.kt
+++ b/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/itunes/SyntheticItunesLibraryGeneratorTest.kt
@@ -1,0 +1,53 @@
+package net.transgressoft.commons.music.itunes
+
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldContainAll
+import io.kotest.matchers.string.shouldContain
+import java.nio.file.Files
+import java.nio.file.Path
+
+@DisplayName("SyntheticItunesLibraryGenerator")
+internal class SyntheticItunesLibraryGeneratorTest : StringSpec({
+
+    "SyntheticItunesLibraryGenerator writes deterministic XML and expectations for nested audio files" {
+        val sourceRoot = Files.createTempDirectory("itunes-source-")
+        val outputDir = Files.createTempDirectory("itunes-output-")
+        writeAudioFile(sourceRoot.resolve("root song.mp3"))
+        writeAudioFile(sourceRoot.resolve("Album A").resolve("alpha.flac"))
+        writeAudioFile(sourceRoot.resolve("Album A").resolve("beta.m4a"))
+        writeAudioFile(sourceRoot.resolve("Album B").resolve("gamma.wav"))
+        Files.writeString(sourceRoot.resolve("ignore.txt"), "not audio")
+
+        SyntheticItunesLibraryGenerator.generate(sourceRoot, outputDir)
+
+        val xml = Files.readString(outputDir.resolve(SyntheticItunesLibraryGenerator.DEFAULT_LIBRARY_FILE))
+        val expectations = Files.readString(outputDir.resolve(SyntheticItunesLibraryGenerator.DEFAULT_EXPECTATIONS_FILE))
+
+        xml shouldContain "Phase18 Title Sentinel"
+        xml shouldContain "Phase18 Primary Artist"
+        xml shouldContain "Phase18 Album Sentinel"
+        xml shouldContain "root%20song.mp3"
+        xml shouldContain "Album A Tracks"
+        xml shouldContain "Album B Tracks"
+        expectations shouldContain "\"trackCount\": 4"
+        expectations shouldContain "\"playlistCount\": 6"
+    }
+
+    "SyntheticItunesLibraryGenerator writes custom output names" {
+        val sourceRoot = Files.createTempDirectory("itunes-source-custom-")
+        val outputDir = Files.createTempDirectory("itunes-output-custom-")
+        writeAudioFile(sourceRoot.resolve("song.mp3"))
+
+        SyntheticItunesLibraryGenerator.generate(sourceRoot, outputDir, "library.xml", "expectations.json")
+
+        Files.list(outputDir).use { files ->
+            files.map { it.fileName.toString() }.toList() shouldContainAll listOf("library.xml", "expectations.json")
+        }
+    }
+})
+
+private fun writeAudioFile(path: Path) {
+    Files.createDirectories(path.parent)
+    Files.write(path, byteArrayOf(0))
+}

--- a/music-commons-fx-test/src/main/kotlin/net/transgressoft/commons/fx/music/FxAudioItemTestFactory.kt
+++ b/music-commons-fx-test/src/main/kotlin/net/transgressoft/commons/fx/music/FxAudioItemTestFactory.kt
@@ -153,7 +153,7 @@ object FxAudioItemTestFactory {
             // Immutable test fixture: play count changes are not needed by current consumers.
         }
 
-        override fun writeMetadata(): Job = Job()
+        override fun writeMetadata(): Job = Job().apply { complete() }
 
         override fun compareTo(other: ObservableAudioItem): Int =
             audioItemTrackDiscNumberComparator<ObservableAudioItem>().compare(this, other)

--- a/music-commons-fx-test/src/main/kotlin/net/transgressoft/commons/fx/music/FxAudioItemTestFactory.kt
+++ b/music-commons-fx-test/src/main/kotlin/net/transgressoft/commons/fx/music/FxAudioItemTestFactory.kt
@@ -1,0 +1,186 @@
+package net.transgressoft.commons.fx.music
+
+import net.transgressoft.commons.fx.music.audio.ObservableAudioItem
+import net.transgressoft.commons.music.AudioUtils.audioItemTrackDiscNumberComparator
+import net.transgressoft.commons.music.audio.Album
+import net.transgressoft.commons.music.audio.Artist
+import net.transgressoft.commons.music.audio.AudioItemTestAttributes
+import net.transgressoft.commons.music.audio.Genre
+import net.transgressoft.commons.music.audio.audioAttributes
+import net.transgressoft.lirp.entity.ReactiveEntityBase
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.next
+import javafx.beans.property.FloatProperty
+import javafx.beans.property.IntegerProperty
+import javafx.beans.property.ObjectProperty
+import javafx.beans.property.ReadOnlyIntegerProperty
+import javafx.beans.property.ReadOnlyObjectProperty
+import javafx.beans.property.ReadOnlyProperty
+import javafx.beans.property.ReadOnlySetProperty
+import javafx.beans.property.SimpleFloatProperty
+import javafx.beans.property.SimpleIntegerProperty
+import javafx.beans.property.SimpleObjectProperty
+import javafx.beans.property.SimpleSetProperty
+import javafx.beans.property.SimpleStringProperty
+import javafx.beans.property.StringProperty
+import javafx.collections.FXCollections
+import javafx.scene.image.Image
+import java.nio.file.Path
+import java.time.Duration
+import java.time.LocalDateTime
+import java.util.Optional
+import java.util.function.Consumer
+import kotlinx.coroutines.Job
+
+/**
+ * Java-friendly factory methods for observable audio item test fixtures.
+ *
+ * This object delegates to the Kotlin fxAudioItem generator so Java tests can reuse the
+ * same mocked [ObservableAudioItem] construction path as Kotlin tests.
+ */
+object FxAudioItemTestFactory {
+
+    /**
+     * Creates an observable audio item with caller-supplied test attributes.
+     *
+     * @param attributes action that mutates the generated attributes before the item is built
+     * @return observable audio item backed by music-commons-fx-test mocks
+     */
+    @JvmStatic
+    fun createFxAudioItem(attributes: Consumer<AudioItemTestAttributes>): ObservableAudioItem =
+        Arb.fxAudioItem(attributes::accept).next()
+
+    /**
+     * Creates an observable audio item with an explicit involved-artist set.
+     *
+     * Use this overload for tests whose assertion depends on exact derived-artist membership and
+     * not on the title parser heuristics. It returns a lightweight concrete item with real JavaFX
+     * properties so UI tests do not depend on MockK-generated property subclasses at render time.
+     *
+     * @param attributes action that mutates the generated attributes before the item is built
+     * @param artistsInvolved exact artist set returned by the item and its JavaFX property
+     * @return observable audio item backed by music-commons-fx-test mocks
+     */
+    @JvmStatic
+    fun createFxAudioItem(attributes: Consumer<AudioItemTestAttributes>, artistsInvolved: Set<Artist>): ObservableAudioItem {
+        val generated = Arb.audioAttributes().next()
+        attributes.accept(generated)
+        return TestObservableAudioItem(generated, artistsInvolved)
+    }
+
+    private class TestObservableAudioItem(
+        attributes: AudioItemTestAttributes,
+        override val artistsInvolved: Set<Artist>
+    ) : ObservableAudioItem,
+        Comparable<ObservableAudioItem>,
+        ReactiveEntityBase<Int, ObservableAudioItem>() {
+
+        override val id: Int = attributes.id
+        override val uniqueId: String = "${attributes.path.fileName}-${attributes.title}-${attributes.id}"
+        override val path: Path = attributes.path
+        override val duration: Duration = attributes.duration
+        override val bitRate: Int = attributes.bitRate
+        override val encoder: String? = attributes.encoder
+        override val encoding: String? = attributes.encoding
+        override val dateOfCreation: LocalDateTime = attributes.dateOfCreation
+        override val playCount: Short = attributes.playCount
+        override val fileName: String = path.fileName.toString()
+        override val extension: String = path.fileName.toString().substringAfterLast('.', "")
+        override val length: Long = 0
+
+        override val titleProperty: StringProperty = SimpleStringProperty(this, "title", attributes.title)
+        override var title: String
+            get() = titleProperty.get()
+            set(value) = titleProperty.set(value)
+
+        override val artistProperty: ObjectProperty<Artist> = SimpleObjectProperty(this, "artist", attributes.artist)
+        override var artist: Artist
+            get() = artistProperty.get()
+            set(value) = artistProperty.set(value)
+
+        override val albumProperty: ObjectProperty<Album> = SimpleObjectProperty(this, "album", attributes.album)
+        override var album: Album
+            get() = albumProperty.get()
+            set(value) = albumProperty.set(value)
+
+        override val genresProperty: ObjectProperty<Set<Genre>> = SimpleObjectProperty(this, "genres", attributes.genres)
+        override var genres: Set<Genre>
+            get() = genresProperty.get()
+            set(value) = genresProperty.set(value)
+
+        override val commentsProperty: StringProperty = SimpleStringProperty(this, "comments", attributes.comments ?: "")
+        override var comments: String?
+            get() = commentsProperty.get()
+            set(value) = commentsProperty.set(value)
+
+        override val trackNumberProperty: IntegerProperty = SimpleIntegerProperty(this, "track number", attributes.trackNumber?.toInt() ?: 0)
+        override var trackNumber: Short?
+            get() = trackNumberProperty.get().takeIf { it > 0 }?.toShort()
+            set(value) = trackNumberProperty.set(value?.toInt() ?: 0)
+
+        override val discNumberProperty: IntegerProperty = SimpleIntegerProperty(this, "disc number", attributes.discNumber?.toInt() ?: 0)
+        override var discNumber: Short?
+            get() = discNumberProperty.get().takeIf { it > 0 }?.toShort()
+            set(value) = discNumberProperty.set(value?.toInt() ?: 0)
+
+        override val bpmProperty: FloatProperty = SimpleFloatProperty(this, "bpm", attributes.bpm ?: 0f)
+        override var bpm: Float?
+            get() = bpmProperty.get().takeIf { it > 0f }
+            set(value) = bpmProperty.set(value ?: 0f)
+
+        override val coverImageProperty: ReadOnlyObjectProperty<Optional<Image>> =
+            SimpleObjectProperty(this, "cover image", Optional.empty())
+
+        override val artistsInvolvedProperty: ReadOnlySetProperty<Artist> =
+            SimpleSetProperty(this, "artists involved", FXCollections.observableSet(artistsInvolved))
+
+        override val lastDateModifiedProperty: ReadOnlyObjectProperty<LocalDateTime> =
+            SimpleObjectProperty(this, "last date modified", attributes.lastDateModified)
+
+        override val dateOfCreationProperty: ReadOnlyProperty<LocalDateTime> =
+            SimpleObjectProperty(this, "date of creation", dateOfCreation)
+
+        override val playCountProperty: ReadOnlyIntegerProperty =
+            SimpleIntegerProperty(this, "play count", playCount.toInt())
+
+        override var coverImageBytes: ByteArray? = attributes.coverImageBytes?.copyOf()
+            get() = field?.copyOf()
+            set(value) {
+                field = value?.copyOf()
+            }
+
+        override fun setPlayCount(count: Short) {
+            // Immutable test fixture: play count changes are not needed by current consumers.
+        }
+
+        override fun writeMetadata(): Job = Job()
+
+        override fun compareTo(other: ObservableAudioItem): Int =
+            audioItemTrackDiscNumberComparator<ObservableAudioItem>().compare(this, other)
+
+        override fun clone(): ObservableAudioItem =
+            TestObservableAudioItem(
+                AudioItemTestAttributes(
+                    path = path,
+                    title = title,
+                    duration = duration,
+                    bitRate = bitRate,
+                    artist = artist,
+                    album = album,
+                    genres = genres,
+                    comments = comments,
+                    trackNumber = trackNumber,
+                    discNumber = discNumber,
+                    bpm = bpm,
+                    encoder = encoder,
+                    encoding = encoding,
+                    coverImageBytes = coverImageBytes,
+                    dateOfCreation = dateOfCreation,
+                    lastDateModified = lastDateModified,
+                    playCount = playCount,
+                    id = id
+                ),
+                artistsInvolved
+            )
+    }
+}

--- a/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/audio/FXArtistCatalog.kt
+++ b/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/audio/FXArtistCatalog.kt
@@ -23,6 +23,7 @@ import net.transgressoft.commons.music.audio.AlbumView
 import net.transgressoft.commons.music.audio.Artist
 import net.transgressoft.commons.music.audio.id
 import net.transgressoft.lirp.entity.ReactiveEntityBase
+import net.transgressoft.lirp.event.ReactiveScope
 import javafx.application.Platform
 import javafx.beans.property.ReadOnlyBooleanProperty
 import javafx.beans.property.ReadOnlyBooleanWrapper
@@ -40,14 +41,17 @@ import mu.KotlinLogging
 import java.util.*
 import java.util.Collections.synchronizedSortedMap
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 /**
  * JavaFX implementation of [ObservableArtistCatalog] that owns its audio item state directly.
  *
  * Maintains audio items organized by album in a synchronized sorted map, mirroring the
  * structure of the core [net.transgressoft.commons.music.audio.MutableArtistCatalog].
- * All mutations update both the internal data structure and the JavaFX observable properties,
- * with property updates dispatched on the JavaFX Application Thread via [Platform.runLater].
+ * Mutations update the internal data structure immediately and coalesce JavaFX observable-property
+ * refreshes so large import bursts do not dispatch one [Platform.runLater] task per audio item.
  * The dispatches intentionally omit error handling because they perform only simple property mutations;
  * any exception indicates a programming error that should surface through the default uncaught exception handler.
  *
@@ -61,7 +65,13 @@ internal class FXArtistCatalog(
 
     private val logger = KotlinLogging.logger {}
 
+    private companion object {
+        const val FX_REFRESH_DEBOUNCE_MILLIS = 16L
+    }
+
     private val audioItemsByAlbumName: MutableMap<String, MutableList<ObservableAudioItem>> = synchronizedSortedMap(sortedMapOf())
+    private val fxRefreshQueued = AtomicBoolean(false)
+    private val fxRefreshRequested = AtomicBoolean(false)
 
     private val _albumsProperty = SimpleSetProperty<Album>(this, "albums", observableSet())
     override val albumsProperty: ReadOnlySetProperty<Album> = _albumsProperty
@@ -130,7 +140,7 @@ internal class FXArtistCatalog(
                     val insertionPoint = -(existingIndex + 1)
                     audioItems.add(insertionPoint, audioItem)
                     logger.debug { "AudioItem $audioItem was added to album ${audioItem.album}" }
-                    Platform.runLater { updateFXProperties() }
+                    queueFxRefresh()
                     true
                 } else {
                     false
@@ -153,7 +163,7 @@ internal class FXArtistCatalog(
                     } else {
                         logger.debug { "AudioItem $audioItem was removed from album ${audioItem.album}" }
                     }
-                    Platform.runLater { updateFXProperties() }
+                    queueFxRefresh()
                 }
                 removed
             }
@@ -192,7 +202,7 @@ internal class FXArtistCatalog(
 
                 val reordered = insertionPoint != currentIndex
                 if (reordered) {
-                    Platform.runLater { updateFXProperties() }
+                    queueFxRefresh()
                 }
                 reordered
             }
@@ -205,6 +215,27 @@ internal class FXArtistCatalog(
         albumItemProperties.getOrPut(albumName) {
             SimpleListProperty(this, "album-$albumName", FXCollections.observableArrayList())
         }
+
+    private fun queueFxRefresh() {
+        fxRefreshRequested.set(true)
+        if (!fxRefreshQueued.compareAndSet(false, true)) {
+            return
+        }
+        ReactiveScope.flowScope.launch {
+            delay(FX_REFRESH_DEBOUNCE_MILLIS)
+            Platform.runLater {
+                try {
+                    fxRefreshRequested.set(false)
+                    updateFXProperties()
+                } finally {
+                    fxRefreshQueued.set(false)
+                    if (fxRefreshRequested.get()) {
+                        queueFxRefresh()
+                    }
+                }
+            }
+        }
+    }
 
     private fun updateFXProperties() {
         val currentAlbums = albums

--- a/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/audio/FXAudioLibrary.kt
+++ b/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/audio/FXAudioLibrary.kt
@@ -24,6 +24,7 @@ import net.transgressoft.commons.music.player.event.AudioItemPlayerEvent.Type.PL
 import net.transgressoft.lirp.event.CrudEvent.Type.CREATE
 import net.transgressoft.lirp.event.CrudEvent.Type.DELETE
 import net.transgressoft.lirp.event.CrudEvent.Type.UPDATE
+import net.transgressoft.lirp.event.ReactiveScope
 import net.transgressoft.lirp.persistence.LirpRepository
 import net.transgressoft.lirp.persistence.RegistryBase
 import net.transgressoft.lirp.persistence.Repository
@@ -41,17 +42,19 @@ import javafx.collections.FXCollections.observableSet
 import javafx.collections.ObservableSet
 import mu.KotlinLogging
 import java.nio.file.Path
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.CopyOnWriteArraySet
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 /**
  * JavaFX-compatible audio library with observable collections for UI binding.
  *
- * Maintains an [FxAggregateList] as the primary observable items collection. The [audioItemsProperty]
- * wraps this delegate directly. The [artistsProperty] tracks all artists from
- * each item's [ObservableAudioItem.artistsInvolved] set and is updated inline in the CRUD subscription.
- * The [artistCatalogsProperty] is backed by an [ObservableSet] updated from the catalog
- * subscription via [Platform.runLater], and album-level derived properties
- * ([albumsProperty], [albumCountProperty]) update via [Platform.runLater] from the same subscription.
+ * Maintains an [FxAggregateList] as the primary observable items collection. Repository and catalog
+ * events can arrive in large background bursts during directory imports, so JavaFX-facing collections
+ * are refreshed through coalesced [Platform.runLater] drains instead of one JavaFX task per entity.
  *
  * Registers its backing repository in [net.transgressoft.lirp.persistence.LirpContext] on construction
  * via [RegistryBase.registerRepository], enabling playlist hierarchies to resolve audio item references
@@ -71,8 +74,17 @@ internal class FXAudioLibrary(repository: Repository<Int, ObservableAudioItem>)
 
     private val logger = KotlinLogging.logger {}
 
+    private companion object {
+        const val FX_REFRESH_DEBOUNCE_MILLIS = 16L
+    }
+
     // Primary observable items collection -- populated from CRUD events, auto-dispatches to FX thread
     private val audioItems: FxAggregateList<Int, ObservableAudioItem> by fxAggregateList()
+    private val audioItemIds = ConcurrentHashMap.newKeySet<Int>()
+    private val pendingCreatedAudioItems = ConcurrentLinkedQueue<ObservableAudioItem>()
+    private val pendingDeletedAudioItemIds = ConcurrentLinkedQueue<Int>()
+    private val audioItemsRefreshQueued = AtomicBoolean(false)
+    private val recomputeArtistsRequested = AtomicBoolean(false)
 
     @get:JvmName("audioItemsProperty")
     override val audioItemsProperty: ReadOnlyListProperty<ObservableAudioItem> =
@@ -86,6 +98,8 @@ internal class FXAudioLibrary(repository: Repository<Int, ObservableAudioItem>)
 
     // Thread-safe backing for artist catalogs -- updated directly from catalog subscription
     private val artistCatalogBacking: CopyOnWriteArraySet<ObservableArtistCatalog> = CopyOnWriteArraySet()
+    private val catalogRefreshQueued = AtomicBoolean(false)
+    private val catalogRefreshRequested = AtomicBoolean(false)
 
     private val observableArtistCatalogSet: ObservableSet<ObservableArtistCatalog> = observableSet()
 
@@ -108,35 +122,22 @@ internal class FXAudioLibrary(repository: Repository<Int, ObservableAudioItem>)
     private val internalSubscription =
         subscribe(CREATE, UPDATE, DELETE) { event ->
             if (event.isDelete()) {
-                val idsToRemove = event.entities.keys
-                audioItems.removeAll(
-                    audioItems.filter { it.id in idsToRemove }
-                )
-                Platform.runLater {
-                    event.entities.values.forEach { removed ->
-                        removed.artistsInvolved.forEach { artist ->
-                            if (audioItems.none { item -> artist in item.artistsInvolved }) {
-                                artistsProperty.remove(artist)
-                            }
-                        }
-                    }
+                event.entities.keys.forEach { id ->
+                    audioItemIds.remove(id)
+                    pendingDeletedAudioItemIds.add(id)
                 }
+                recomputeArtistsRequested.set(true)
+                queueAudioItemsRefresh()
             } else if (event.isCreate()) {
                 event.entities.values.forEach { item ->
-                    if (audioItems.none { it.id == item.id }) {
-                        audioItems.add(item)
-                    }
-                    Platform.runLater {
-                        artistsProperty.addAll(item.artistsInvolved)
+                    if (audioItemIds.add(item.id)) {
+                        pendingCreatedAudioItems.add(item)
                     }
                 }
+                queueAudioItemsRefresh()
             } else {
-                // UPDATE — recompute the full artist set so removed artists are pruned
-                Platform.runLater {
-                    val allArtists = audioItems.flatMap { it.artistsInvolved }.toSet()
-                    artistsProperty.retainAll(allArtists)
-                    artistsProperty.addAll(allArtists)
-                }
+                recomputeArtistsRequested.set(true)
+                queueAudioItemsRefresh()
             }
         }
 
@@ -147,25 +148,7 @@ internal class FXAudioLibrary(repository: Repository<Int, ObservableAudioItem>)
             } else {
                 artistCatalogBacking.addAll(event.entities.values)
             }
-            // Update artistCatalogsProperty on the FX thread from backing set
-            Platform.runLater {
-                observableArtistCatalogSet.apply {
-                    clear()
-                    addAll(artistCatalogBacking)
-                }
-            }
-            // Auto-derive albums and album count from current catalog state
-            val allAlbums =
-                artistCatalogBacking.flatMap { catalog ->
-                    catalog.albums.map { it.first().album }
-                }.toSet()
-            Platform.runLater {
-                _albumsProperty.apply {
-                    clear()
-                    addAll(allAlbums)
-                }
-                _albumCountProperty.set(allAlbums.size)
-            }
+            queueCatalogRefresh()
         }
 
     init {
@@ -173,29 +156,18 @@ internal class FXAudioLibrary(repository: Repository<Int, ObservableAudioItem>)
         RegistryBase.registerRepository(ObservableAudioItem::class.java, repository)
 
         // Populate fxAggregateList and artistsProperty from existing items
-        forEach { item ->
-            audioItems.add(item)
-        }
-        Platform.runLater {
-            forEach { item ->
-                artistsProperty.addAll(item.artistsInvolved)
+        val initialAudioItems = toList()
+        audioItemIds.addAll(initialAudioItems.map { it.id })
+        if (initialAudioItems.isNotEmpty()) {
+            Platform.runLater {
+                audioItems.addAll(initialAudioItems)
+                artistsProperty.addAll(initialAudioItems.flatMap { it.artistsInvolved })
             }
         }
 
         // Populate catalog backing from registries created during AudioLibraryBase init
         observableArtistCatalogRegistry.forEach { artistCatalogBacking.add(it) }
-        Platform.runLater {
-            observableArtistCatalogSet.addAll(artistCatalogBacking)
-        }
-        // Auto-derive initial albums/albumCount
-        val allAlbums =
-            artistCatalogBacking.flatMap { catalog ->
-                catalog.albums.map { it.first().album }
-            }.toSet()
-        Platform.runLater {
-            _albumsProperty.addAll(allAlbums)
-            _albumCountProperty.set(allAlbums.size)
-        }
+        queueCatalogRefresh()
 
         // Subscribe to the player events to update the play count
         playerSubscriber.addOnNextEventAction(PLAYED) { event ->
@@ -205,6 +177,88 @@ internal class FXAudioLibrary(repository: Repository<Int, ObservableAudioItem>)
                 logger.debug { "Play count of audio item with id ${audioItem.id} increased to ${audioItem.playCount}" }
             }
         }
+    }
+
+    private fun queueAudioItemsRefresh() {
+        if (!audioItemsRefreshQueued.compareAndSet(false, true)) {
+            return
+        }
+        ReactiveScope.flowScope.launch {
+            delay(FX_REFRESH_DEBOUNCE_MILLIS)
+            Platform.runLater {
+                try {
+                    drainAudioItemChanges()
+                } finally {
+                    audioItemsRefreshQueued.set(false)
+                    if (hasPendingAudioItemRefresh()) {
+                        queueAudioItemsRefresh()
+                    }
+                }
+            }
+        }
+    }
+
+    private fun drainAudioItemChanges() {
+        val deletedIds = generateSequence { pendingDeletedAudioItemIds.poll() }.toSet()
+        if (deletedIds.isNotEmpty()) {
+            audioItems.removeAll(audioItems.filter { it.id in deletedIds })
+        }
+
+        val createdAudioItems =
+            generateSequence { pendingCreatedAudioItems.poll() }
+                .filter { it.id in audioItemIds }
+                .toList()
+        if (createdAudioItems.isNotEmpty()) {
+            audioItems.addAll(createdAudioItems)
+        }
+
+        if (recomputeArtistsRequested.getAndSet(false)) {
+            val allArtists = audioItems.flatMap { it.artistsInvolved }.toSet()
+            artistsProperty.retainAll(allArtists)
+            artistsProperty.addAll(allArtists)
+        } else if (createdAudioItems.isNotEmpty()) {
+            artistsProperty.addAll(createdAudioItems.flatMap { it.artistsInvolved })
+        }
+    }
+
+    private fun hasPendingAudioItemRefresh(): Boolean =
+        pendingCreatedAudioItems.isNotEmpty() || pendingDeletedAudioItemIds.isNotEmpty() || recomputeArtistsRequested.get()
+
+    private fun queueCatalogRefresh() {
+        catalogRefreshRequested.set(true)
+        if (!catalogRefreshQueued.compareAndSet(false, true)) {
+            return
+        }
+        ReactiveScope.flowScope.launch {
+            delay(FX_REFRESH_DEBOUNCE_MILLIS)
+            Platform.runLater {
+                try {
+                    catalogRefreshRequested.set(false)
+                    refreshCatalogProperties()
+                } finally {
+                    catalogRefreshQueued.set(false)
+                    if (catalogRefreshRequested.get()) {
+                        queueCatalogRefresh()
+                    }
+                }
+            }
+        }
+    }
+
+    private fun refreshCatalogProperties() {
+        observableArtistCatalogSet.apply {
+            clear()
+            addAll(artistCatalogBacking)
+        }
+        val allAlbums =
+            artistCatalogBacking.flatMap { catalog ->
+                catalog.albums.map { it.first().album }
+            }.toSet()
+        _albumsProperty.apply {
+            clear()
+            addAll(allAlbums)
+        }
+        _albumCountProperty.set(allAlbums.size)
     }
 
     /**
@@ -220,13 +274,15 @@ internal class FXAudioLibrary(repository: Repository<Int, ObservableAudioItem>)
 
     override fun clear() {
         super.clear()
-        audioItems.clear()
-        artistCatalogBacking.clear()
+        audioItemIds.clear()
+        pendingCreatedAudioItems.clear()
+        pendingDeletedAudioItemIds.clear()
         Platform.runLater {
-            observableArtistCatalogSet.clear()
-            _albumsProperty.clear()
-            _albumCountProperty.set(0)
+            audioItems.clear()
+            artistsProperty.clear()
         }
+        artistCatalogBacking.clear()
+        queueCatalogRefresh()
     }
 
     override fun createFromFile(audioItemPath: Path): FXAudioItem =

--- a/music-commons-fx/src/test/kotlin/net/transgressoft/commons/fx/music/audio/FXArtistCatalogTest.kt
+++ b/music-commons-fx/src/test/kotlin/net/transgressoft/commons/fx/music/audio/FXArtistCatalogTest.kt
@@ -9,6 +9,8 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.property.arbitrary.next
 import org.testfx.api.FxToolkit
+import org.testfx.util.WaitForAsyncUtils
+import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 
 /**
@@ -90,6 +92,28 @@ internal class FXArtistCatalogTest : StringSpec({
         catalog.addAudioItem(audioItem)
 
         cloneBefore shouldNotBe catalog
+    }
+
+    "FXArtistCatalog coalesces burst mutations into one JavaFX property refresh" {
+        val catalog = FXArtistCatalog(artist)
+        val sizeChangeCount = AtomicInteger()
+        catalog.sizeProperty.addListener { _, _, _ -> sizeChangeCount.incrementAndGet() }
+
+        repeat(50) {
+            val path =
+                files.virtualAudioFile {
+                    this.artist = artist
+                    this.album = album
+                }.next()
+            catalog.addAudioItem(FXAudioItem(path))
+        }
+
+        reactive.advance()
+        WaitForAsyncUtils.waitForFxEvents()
+
+        catalog.sizeProperty.get() shouldBe 50
+        catalog.albumCountProperty.get() shouldBe 1
+        sizeChangeCount.get() shouldBe 1
     }
 
     "FXArtistCatalog returns false for equals with different types or null" {

--- a/music-commons-fx/src/test/kotlin/net/transgressoft/commons/fx/music/audio/ObservableAudioLibraryTest.kt
+++ b/music-commons-fx/src/test/kotlin/net/transgressoft/commons/fx/music/audio/ObservableAudioLibraryTest.kt
@@ -22,9 +22,11 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContainOnlyOnce
 import io.kotest.property.arbitrary.next
+import javafx.collections.ListChangeListener
 import org.testfx.api.FxToolkit
 import org.testfx.util.WaitForAsyncUtils
 import java.io.File
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 
@@ -89,6 +91,9 @@ internal class ObservableAudioLibraryTest : StringSpec({
         foundItem.title shouldBe "New title"
 
         repository.remove(fxAudioItem)
+        reactive.advance()
+        WaitForAsyncUtils.waitForFxEvents()
+
         audioItemsProperty.isEmpty() shouldBe true
         repository.emptyLibraryProperty.get() shouldBe true
     }
@@ -149,6 +154,38 @@ internal class ObservableAudioLibraryTest : StringSpec({
         eventually(1.seconds) {
             repository.audioItemsProperty.size shouldBe 25
         }
+    }
+
+    "ObservableAudioLibrary coalesces create bursts while preserving derived observable state" {
+        val audioItemsChangeCount = AtomicInteger()
+        repository.audioItemsProperty.addListener(
+            ListChangeListener<ObservableAudioItem> {
+                audioItemsChangeCount.incrementAndGet()
+            }
+        )
+
+        val itemsByArtist =
+            repository.createItemsByArtist(
+                files,
+                mapOf("Burst Alpha" to 25, "Burst Beta" to 25, "Burst Gamma" to 25)
+            )
+        val expectedItems = itemsByArtist.values.flatten()
+        val expectedArtists = itemsByArtist.keys
+        val expectedAlbums = expectedItems.map { it.album }.toSet()
+
+        reactive.advance()
+        WaitForAsyncUtils.waitForFxEvents()
+
+        eventually(1.seconds) {
+            repository.audioItemsProperty.size shouldBe expectedItems.size
+            repository.audioItemsProperty.map { audioItem: ObservableAudioItem -> audioItem.id } shouldContainOnly expectedItems.toIds()
+            repository.artistsProperty shouldContainOnly expectedArtists
+            repository.artistCatalogsProperty.map { catalog: ObservableArtistCatalog -> catalog.artist }.toSet() shouldContainOnly expectedArtists
+            repository.albumsProperty shouldContainOnly expectedAlbums
+            repository.albumCountProperty.get() shouldBe expectedAlbums.size
+        }
+
+        audioItemsChangeCount.get() shouldBe 1
     }
 
     "ObservableAudioLibrary contains catalogs for all artists after adding items" {

--- a/music-commons-test/build.gradle
+++ b/music-commons-test/build.gradle
@@ -15,6 +15,7 @@ tasks.matching { it.name.startsWith("ktlint") || it.name.startsWith("jacoco")}.c
 
 dependencies {
     api project(path: ':music-commons-core')
+    api libs.dd.plist.get()
     // Vendored ReactiveScopeExtension references net.transgressoft.lirp.event.ReactiveScope on its
     // public surface, so lirp-core must be visible to consumer test classpaths.
     api libs.lirp.core.get()

--- a/music-commons-test/src/main/java/net/transgressoft/commons/music/itunes/ItunesLibraryTestFixture.java
+++ b/music-commons-test/src/main/java/net/transgressoft/commons/music/itunes/ItunesLibraryTestFixture.java
@@ -1,0 +1,121 @@
+package net.transgressoft.commons.music.itunes;
+
+import com.dd.plist.NSDictionary;
+import com.dd.plist.NSObject;
+import com.dd.plist.NSString;
+import com.dd.plist.PropertyListParser;
+
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+
+/**
+ * Materializes classpath iTunes XML fixtures against real temporary audio files.
+ *
+ * The helper rewrites every track {@code Location} to a copied audio sample so production import
+ * paths that require {@link Path#toFile()} can be exercised without depending on the developer's
+ * local music library.
+ */
+public final class ItunesLibraryTestFixture {
+
+    public static final String DEFAULT_SAMPLE_AUDIO_RESOURCE = "/testfiles/testeable.mp3";
+
+    private ItunesLibraryTestFixture() {
+    }
+
+    /**
+     * Prepares an iTunes XML fixture using the default MP3 sample from music-commons-test.
+     *
+     * @param tempDir directory where runtime files should be written
+     * @param resourceAnchor class used to locate the XML resource
+     * @param xmlResource classpath path to the source XML plist
+     * @return prepared runtime XML path
+     */
+    public static PreparedItunesLibrary prepare(Path tempDir, Class<?> resourceAnchor, String xmlResource) {
+        return prepare(tempDir, resourceAnchor, xmlResource, DEFAULT_SAMPLE_AUDIO_RESOURCE);
+    }
+
+    /**
+     * Prepares an iTunes XML fixture using the supplied audio sample resource.
+     *
+     * @param tempDir directory where runtime files should be written
+     * @param resourceAnchor class used to locate the XML resource
+     * @param xmlResource classpath path to the source XML plist
+     * @param sampleAudioResource classpath path to the audio sample copied for every track
+     * @return prepared runtime XML path
+     */
+    public static PreparedItunesLibrary prepare(
+            Path tempDir,
+            Class<?> resourceAnchor,
+            String xmlResource,
+            String sampleAudioResource) {
+        try {
+            Files.createDirectories(tempDir);
+            Path audioDir = tempDir.resolve("audio");
+            Files.createDirectories(audioDir);
+
+            NSDictionary root = readXmlResource(resourceAnchor, xmlResource);
+            NSDictionary tracks = tracksDictionary(root);
+            for (String trackKey : tracks.allKeys()) {
+                rebaseTrackLocation((NSDictionary) tracks.objectForKey(trackKey), audioDir, sampleAudioResource);
+            }
+
+            Path runtimeXml = tempDir.resolve("itunes-library-runtime.xml");
+            PropertyListParser.saveAsXML(root, runtimeXml.toFile());
+            return new PreparedItunesLibrary(runtimeXml);
+        } catch (Exception ex) {
+            throw new IllegalStateException("Could not prepare iTunes XML fixture " + xmlResource, ex);
+        }
+    }
+
+    private static NSDictionary readXmlResource(Class<?> resourceAnchor, String xmlResource) throws Exception {
+        try (InputStream input = resourceStream(resourceAnchor, xmlResource)) {
+            return (NSDictionary) PropertyListParser.parse(input);
+        }
+    }
+
+    private static NSDictionary tracksDictionary(NSDictionary root) {
+        NSObject tracks = root.objectForKey("Tracks");
+        if (tracks instanceof NSDictionary tracksDictionary) {
+            return tracksDictionary;
+        }
+        throw new IllegalStateException("Fixture XML does not contain a Tracks dictionary");
+    }
+
+    private static void rebaseTrackLocation(NSDictionary track, Path audioDir, String sampleAudioResource) {
+        try {
+            String trackId = text(track, "Track ID");
+            Path generated = audioDir.resolve("track-" + trackId + ".mp3");
+            try (InputStream input = resourceStream(ItunesLibraryTestFixture.class, sampleAudioResource)) {
+                Files.copy(input, generated, StandardCopyOption.REPLACE_EXISTING);
+            }
+            track.put("Location", new NSString(generated.toUri().toString()));
+        } catch (Exception ex) {
+            throw new IllegalStateException("Could not materialize audio file for track " + text(track, "Track ID"), ex);
+        }
+    }
+
+    private static InputStream resourceStream(Class<?> resourceAnchor, String resourcePath) {
+        String normalized = resourcePath.startsWith("/") ? resourcePath : "/" + resourcePath;
+        InputStream input = resourceAnchor.getResourceAsStream(normalized);
+        if (input == null) {
+            input = resourceAnchor.getClassLoader().getResourceAsStream(normalized.substring(1));
+        }
+        if (input == null) {
+            throw new IllegalStateException("Could not locate " + resourcePath);
+        }
+        return input;
+    }
+
+    private static String text(NSDictionary track, String key) {
+        NSObject value = track.objectForKey(key);
+        return value == null ? "" : value.toString();
+    }
+
+    /**
+     * Runtime iTunes XML prepared for an import test.
+     */
+    public record PreparedItunesLibrary(Path xmlPath) {
+    }
+}

--- a/music-commons-test/src/main/java/net/transgressoft/commons/music/itunes/SyntheticItunesLibraryGenerator.java
+++ b/music-commons-test/src/main/java/net/transgressoft/commons/music/itunes/SyntheticItunesLibraryGenerator.java
@@ -1,0 +1,316 @@
+package net.transgressoft.commons.music.itunes;
+
+import net.transgressoft.commons.music.audio.AudioFileType;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+
+/**
+ * Generates a deterministic iTunes XML fixture from an existing directory tree.
+ *
+ * The generator writes a synthetic XML library and a JSON sidecar with broad filter sentinels.
+ * Track metadata is intentionally deterministic so large end-to-end tests can assert import and
+ * search behavior without depending on embedded tags from the source files.
+ */
+public final class SyntheticItunesLibraryGenerator {
+
+    public static final String DEFAULT_LIBRARY_FILE = "compilations-library.xml";
+    public static final String DEFAULT_EXPECTATIONS_FILE = "compilations-library-expectations.json";
+    private static final String PLACEHOLDER_ROOT = "file:///__MUSIC_LIBRARY_FIXTURE__/";
+    private static final Set<String> SUPPORTED_EXTENSIONS = Arrays.stream(AudioFileType.values())
+            .map(AudioFileType::getExtension)
+            .collect(Collectors.toUnmodifiableSet());
+
+    private SyntheticItunesLibraryGenerator() {
+    }
+
+    /**
+     * Generates XML and expectation sidecar files into the output directory.
+     *
+     * @param sourceRoot root directory containing audio files
+     * @param outputDir directory where generated files are written
+     * @throws Exception if the directory cannot be scanned or written
+     */
+    public static void generate(Path sourceRoot, Path outputDir) throws Exception {
+        generate(sourceRoot, outputDir, DEFAULT_LIBRARY_FILE, DEFAULT_EXPECTATIONS_FILE);
+    }
+
+    /**
+     * Generates XML and expectation sidecar files into the output directory.
+     *
+     * @param sourceRoot root directory containing audio files
+     * @param outputDir directory where generated files are written
+     * @param libraryFile output XML file name
+     * @param expectationsFile output JSON sidecar file name
+     * @throws Exception if the directory cannot be scanned or written
+     */
+    public static void generate(Path sourceRoot, Path outputDir, String libraryFile, String expectationsFile) throws Exception {
+        Files.createDirectories(outputDir);
+        List<Path> files = findAudioFiles(sourceRoot);
+        List<TrackEntry> tracks = new ArrayList<>();
+        for (int i = 0; i < files.size(); i++) {
+            tracks.add(trackEntry(i + 1, sourceRoot, files.get(i)));
+        }
+        List<PlaylistEntry> playlists = playlistEntries(tracks);
+        Files.writeString(outputDir.resolve(libraryFile), xml(tracks, playlists));
+        Files.writeString(outputDir.resolve(expectationsFile), expectations(tracks, playlists));
+    }
+
+    private static List<Path> findAudioFiles(Path sourceRoot) throws IOException {
+        try (var paths = Files.walk(sourceRoot)) {
+            return paths
+                    .filter(Files::isRegularFile)
+                    .filter(path -> SUPPORTED_EXTENSIONS.contains(extension(path)))
+                    .sorted(Comparator.comparing(path -> sourceRoot.relativize(path).toString()))
+                    .toList();
+        }
+    }
+
+    private static TrackEntry trackEntry(int id, Path sourceRoot, Path file) {
+        Path relative = sourceRoot.relativize(file);
+        String title = "%04d %s".formatted(id, stripExtension(file.getFileName().toString()));
+        String album = relative.getNameCount() > 1 ? relative.getName(0).toString() : "Compilations";
+        String artist = "Compilations Artist %03d".formatted((id % 97) + 1);
+        String albumArtist = "Compilations";
+        String genre = "Fixture Genre";
+        String comments = "Generated from " + relative;
+
+        if (id == 1) {
+            title = "Phase18 Title Sentinel";
+        } else if (id == 2) {
+            artist = "Phase18 Primary Artist";
+        } else if (id == 3) {
+            title = "Phase18 Neutral Track featuring Phase18 Guest Artist";
+        } else if (id == 4) {
+            album = "Phase18 Album Sentinel";
+        } else if (id == 5) {
+            comments = "Phase18 Related Metadata Sentinel";
+        }
+
+        return new TrackEntry(
+                id,
+                title,
+                artist,
+                albumArtist,
+                album,
+                genre,
+                comments,
+                PLACEHOLDER_ROOT + encodePath(relative),
+                persistentId("track-" + id + "-" + relative),
+                relative.getParent() == null ? Path.of("") : relative.getParent());
+    }
+
+    private static List<PlaylistEntry> playlistEntries(List<TrackEntry> tracks) {
+        Map<Path, List<Integer>> trackIdsByDirectory = new TreeMap<>();
+        for (TrackEntry track : tracks) {
+            trackIdsByDirectory.computeIfAbsent(track.directory(), ignored -> new ArrayList<>()).add(track.id());
+        }
+
+        Map<Path, PlaylistEntry> folders = new LinkedHashMap<>();
+        folders.put(Path.of(""), new PlaylistEntry(
+                "Compilations", persistentId("folder-root"), null, true, List.of()));
+
+        for (Path directory : trackIdsByDirectory.keySet()) {
+            Path current = Path.of("");
+            for (Path segment : directory) {
+                Path parent = current;
+                current = current.resolve(segment.toString());
+                Path path = current;
+                folders.computeIfAbsent(path, ignored -> new PlaylistEntry(
+                        path.getFileName().toString(),
+                        persistentId("folder-" + path),
+                        folders.get(parent).persistentId(),
+                        true,
+                        List.of()));
+            }
+        }
+
+        List<PlaylistEntry> playlists = new ArrayList<>(folders.values());
+        for (Map.Entry<Path, List<Integer>> entry : trackIdsByDirectory.entrySet()) {
+            Path directory = entry.getKey();
+            PlaylistEntry folder = folders.get(directory);
+            String name = directory.getFileName() == null ? "Compilations Tracks" : directory.getFileName() + " Tracks";
+            playlists.add(new PlaylistEntry(
+                    name,
+                    persistentId("playlist-" + directory),
+                    folder.persistentId(),
+                    false,
+                    List.copyOf(entry.getValue())));
+        }
+        return playlists;
+    }
+
+    private static String xml(List<TrackEntry> tracks, List<PlaylistEntry> playlists) {
+        StringBuilder xml = new StringBuilder("""
+                <?xml version="1.0" encoding="UTF-8"?>
+                <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+                <plist version="1.0">
+                <dict>
+                    <key>Tracks</key>
+                    <dict>
+                """);
+        for (TrackEntry track : tracks) {
+            xml.append("        <key>").append(track.id()).append("</key>\n");
+            xml.append("        <dict>\n");
+            keyInteger(xml, "Track ID", track.id());
+            keyString(xml, "Name", track.title());
+            keyString(xml, "Artist", track.artist());
+            keyString(xml, "Album Artist", track.albumArtist());
+            keyString(xml, "Album", track.album());
+            keyString(xml, "Genre", track.genre());
+            keyInteger(xml, "Year", 2026);
+            keyInteger(xml, "Track Number", track.id());
+            keyInteger(xml, "Disc Number", 1);
+            keyInteger(xml, "Total Time", 180000);
+            keyInteger(xml, "Bit Rate", 320);
+            keyInteger(xml, "Play Count", track.id() % 11);
+            keyString(xml, "Comments", track.comments());
+            keyInteger(xml, "Compilation", 1);
+            keyString(xml, "Persistent ID", track.persistentId());
+            keyString(xml, "Date Added", LocalDateTime.of(2026, 1, 1, 0, 0)
+                    .format(DateTimeFormatter.ISO_DATE_TIME) + "Z");
+            keyString(xml, "Location", track.location());
+            xml.append("        </dict>\n");
+        }
+        xml.append("""
+                    </dict>
+                    <key>Playlists</key>
+                    <array>
+                """);
+        for (PlaylistEntry playlist : playlists) {
+            xml.append("        <dict>\n");
+            keyString(xml, "Name", playlist.name());
+            keyString(xml, "Playlist Persistent ID", playlist.persistentId());
+            if (playlist.parentPersistentId() != null) {
+                keyString(xml, "Parent Persistent ID", playlist.parentPersistentId());
+            }
+            if (playlist.folder()) {
+                keyInteger(xml, "Folder", 1);
+            }
+            if (!playlist.trackIds().isEmpty()) {
+                xml.append("            <key>Playlist Items</key>\n");
+                xml.append("            <array>\n");
+                for (Integer trackId : playlist.trackIds()) {
+                    xml.append("                <dict><key>Track ID</key><integer>")
+                            .append(trackId)
+                            .append("</integer></dict>\n");
+                }
+                xml.append("            </array>\n");
+            }
+            xml.append("        </dict>\n");
+        }
+        xml.append("""
+                    </array>
+                </dict>
+                </plist>
+                """);
+        return xml.toString();
+    }
+
+    private static String expectations(List<TrackEntry> tracks, List<PlaylistEntry> playlists) {
+        return """
+                {
+                  "trackCount": %d,
+                  "playlistCount": %d,
+                  "allTracksFilters": [
+                    { "name": "title", "query": "Phase18 Title Sentinel", "expectedCount": 1 },
+                    { "name": "artist", "query": "Phase18 Primary Artist", "expectedCount": 1 },
+                    { "name": "artistInvolved", "query": "Phase18 Guest Artist", "expectedCount": 1 },
+                    { "name": "album", "query": "Phase18 Album Sentinel", "expectedCount": 1 },
+                    { "name": "relatedMetadata", "query": "Phase18 Related Metadata Sentinel", "expectedCount": 1 }
+                  ],
+                  "artistsFilters": [
+                    { "name": "artist", "query": "Phase18 Primary Artist", "expectedCount": 1 },
+                    { "name": "title", "query": "Phase18 Title Sentinel", "expectedCount": 1 },
+                    { "name": "artistInvolved", "query": "Phase18 Guest Artist", "expectedCount": 2 },
+                    { "name": "album", "query": "Phase18 Album Sentinel", "expectedCount": 1 },
+                    { "name": "relatedMetadata", "query": "Phase18 Related Metadata Sentinel", "expectedCount": 1 }
+                  ]
+                }
+                """.formatted(tracks.size(), playlists.size());
+    }
+
+    private static void keyString(StringBuilder xml, String key, String value) {
+        xml.append("            <key>").append(key).append("</key><string>")
+                .append(escapeXml(value))
+                .append("</string>\n");
+    }
+
+    private static void keyInteger(StringBuilder xml, String key, int value) {
+        xml.append("            <key>").append(key).append("</key><integer>")
+                .append(value)
+                .append("</integer>\n");
+    }
+
+    private static String persistentId(String input) {
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-1").digest(input.getBytes());
+            StringBuilder hex = new StringBuilder();
+            for (int i = 0; i < 8; i++) {
+                hex.append("%02X".formatted(digest[i]));
+            }
+            return hex.toString();
+        } catch (Exception ex) {
+            throw new IllegalStateException("Could not compute persistent id", ex);
+        }
+    }
+
+    private static String extension(Path path) {
+        String fileName = path.getFileName().toString();
+        int dot = fileName.lastIndexOf('.');
+        return dot < 0 ? "" : fileName.substring(dot + 1).toLowerCase(Locale.ROOT);
+    }
+
+    private static String stripExtension(String fileName) {
+        int dot = fileName.lastIndexOf('.');
+        return dot < 0 ? fileName : fileName.substring(0, dot);
+    }
+
+    private static String encodePath(Path path) {
+        return path.toString().replace('\\', '/').replace(" ", "%20");
+    }
+
+    private static String escapeXml(String value) {
+        return value
+                .replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\"", "&quot;")
+                .replace("'", "&apos;");
+    }
+
+    private record TrackEntry(
+            int id,
+            String title,
+            String artist,
+            String albumArtist,
+            String album,
+            String genre,
+            String comments,
+            String location,
+            String persistentId,
+            Path directory) {
+    }
+
+    private record PlaylistEntry(
+            String name,
+            String persistentId,
+            String parentPersistentId,
+            boolean folder,
+            List<Integer> trackIds) {
+    }
+}

--- a/music-commons-test/src/main/java/net/transgressoft/commons/music/itunes/SyntheticItunesLibraryGenerator.java
+++ b/music-commons-test/src/main/java/net/transgressoft/commons/music/itunes/SyntheticItunesLibraryGenerator.java
@@ -3,6 +3,7 @@ package net.transgressoft.commons.music.itunes;
 import net.transgressoft.commons.music.audio.AudioFileType;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.MessageDigest;
@@ -258,7 +259,7 @@ public final class SyntheticItunesLibraryGenerator {
 
     private static String persistentId(String input) {
         try {
-            byte[] digest = MessageDigest.getInstance("SHA-1").digest(input.getBytes());
+            byte[] digest = MessageDigest.getInstance("SHA-1").digest(input.getBytes(StandardCharsets.UTF_8));
             StringBuilder hex = new StringBuilder();
             for (int i = 0; i < 8; i++) {
                 hex.append("%02X".formatted(digest[i]));

--- a/music-commons-test/src/main/kotlin/net/transgressoft/commons/music/audio/AudioItemTestFactory.kt
+++ b/music-commons-test/src/main/kotlin/net/transgressoft/commons/music/audio/AudioItemTestFactory.kt
@@ -56,7 +56,7 @@ object AudioItemTestFactory {
     @JvmStatic
     @JvmOverloads
     fun createAlbum(name: String? = null, albumArtist: Artist? = null, isCompilation: Boolean? = null, year: Short? = null, label: Label? = null): Album =
-        Arb.album(name, albumArtist, isCompilation, year).next()
+        Arb.album(name, albumArtist, isCompilation, year, label).next()
 
     @JvmStatic
     @JvmOverloads


### PR DESCRIPTION
## Summary
- coalesce `FXAudioLibrary` and `FXArtistCatalog` JavaFX refreshes during bursty import events
- add regression coverage for bounded FX updates and preserve final observable state
- add shared iTunes E2E fixture support and import/catalog consistency fixes needed for Musicott validation
- document the new FX bulk-update behavior

## Verification
- `gradle compileKotlin compileTestKotlin :music-commons-fx:test ktlintCheck --quiet`
- `gradle :music-commons-core:test --tests "net.transgressoft.commons.music.itunes.ItunesImportServiceTest" --quiet`
- manual Musicott validation of the original approximately 1000-file import scenario: UI remained responsive and the import completed successfully

Closes #94