### PR TITLE
Stream CoreAudioItemPlayer Playback

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Defines contracts and interfaces for the audio management domain.
 - `ReactiveAudioLibrary<I, AC>` -- Generic CRUD repository with reactive event publishing and `createAudioItem(factory)` for ID-encapsulated construction
 - `ReactiveAudioPlaylist<I, P>` / `ReactivePlaylistHierarchy<I, P>` -- Generic playlist management with M3U export and ID-based `createPlaylist` overload
 - `AudioWaveform` / `AudioWaveformRepository` -- Waveform data and generation
-- `AudioItemPlayer` -- Playback controls with status monitoring
+- `AudioItemPlayer` -- Playback controls with status monitoring, including `STALLED` for sustained streaming starvation
 
 ### music-commons-core
 
@@ -224,7 +224,7 @@ Bridges core module with JavaFX's property binding system.
 - `FXMusicLibrary` -- Unified facade for JavaFX audio management implementing `MusicLibrary<ObservableAudioItem, ObservablePlaylist>` with observable properties (builder-based entry point)
 - `ObservableAudioLibrary` -- Narrowed `ReactiveAudioLibrary` with JavaFX observable properties for UI binding
 - `ObservablePlaylistHierarchy` -- Narrowed `ReactivePlaylistHierarchy` with a JavaFX observable playlists collection
-- `FXAudioItemPlayer` -- JavaFX wrapper around `CoreAudioItemPlayer` exposing volume, status, and current-time as observable properties
+- `FXAudioItemPlayer` -- JavaFX wrapper around the bounded-streaming `CoreAudioItemPlayer`, exposing volume, status, and current-time as observable properties
 - `WaveformPane` -- Custom Canvas component for static waveform visualization
 - `PlayableWaveformPane` -- Region component with progress fill, playhead, seek, and shimmer loading
 - `SeekEvent` -- Custom JavaFX event fired on click-to-seek and drag-to-scrub interactions

--- a/music-commons-api/src/main/kotlin/net/transgressoft/commons/music/player/AudioItemPlayer.kt
+++ b/music-commons-api/src/main/kotlin/net/transgressoft/commons/music/player/AudioItemPlayer.kt
@@ -52,8 +52,7 @@ interface AudioItemPlayer : Flow.Publisher<AudioItemPlayerEvent> {
      * - [STOPPED]: playback halted by an explicit [stop] call; position is reset to 0 and the
      *   next [play] begins from the start of the audio item.
      * - [STALLED]: playback is starved of decoded data (e.g. buffer underrun in a streaming
-     *   pipeline). Not used by the current in-memory implementation; reserved for streaming
-     *   decoders.
+     *   pipeline).
      * - [HALTED]: playback ended because of an unrecoverable decode or I/O error. The
      *   player must be re-initialized with a new [play] call to recover.
      * - [DISPOSED]: terminal state after [dispose]; all further transport calls are

--- a/music-commons-media/src/main/kotlin/net/transgressoft/commons/media/player/CoreAudioItemPlayer.kt
+++ b/music-commons-media/src/main/kotlin/net/transgressoft/commons/media/player/CoreAudioItemPlayer.kt
@@ -119,8 +119,7 @@ open class CoreAudioItemPlayer private constructor(
     @Volatile
     private var framePosition: Long = 0L
 
-    @Volatile
-    private var seekTargetMillis: Long = -1L
+    private val seekTargetMillis = AtomicLong(-1L)
 
     // Byte offset in the decoded stream at which the currently-open SourceDataLine began playing.
     // line.microsecondPosition resets to 0 each time a new line is opened (e.g. after pause→resume),
@@ -169,7 +168,7 @@ open class CoreAudioItemPlayer private constructor(
                 throw UnsupportedAudioPlaybackException("Cannot play audio item '${audioItem.path.fileName}': unsupported format", e)
             }
         stopCurrentPlayback()
-        seekTargetMillis = -1L
+        seekTargetMillis.set(-1L)
         framePosition = 0L
         sourceDurationMillis = durationMillis(audioFileFormat)
         currentAudioItem.set(audioItem)
@@ -203,7 +202,7 @@ open class CoreAudioItemPlayer private constructor(
         stopCurrentPlayback()
         framePosition = 0L
         lineStartFrameOffset = 0L
-        seekTargetMillis = -1L
+        seekTargetMillis.set(-1L)
         internalStatus.set(Status.STOPPED)
     }
 
@@ -224,7 +223,7 @@ open class CoreAudioItemPlayer private constructor(
 
     override fun seek(position: Duration) {
         if (state.get() == InternalState.DISPOSED) return
-        seekTargetMillis = position.toMillis()
+        seekTargetMillis.set(position.toMillis())
     }
 
     override fun onFinish(value: Runnable) {
@@ -348,13 +347,7 @@ open class CoreAudioItemPlayer private constructor(
         return StreamSession(stream, format)
     }
 
-    private fun consumeSeekTarget(): Long {
-        val target = seekTargetMillis
-        if (target >= 0L) {
-            seekTargetMillis = -1L
-        }
-        return target
-    }
+    private fun consumeSeekTarget(): Long = seekTargetMillis.getAndSet(-1L)
 
     private fun skipFully(stream: AudioInputStream, requestedBytes: Long): Long {
         var remaining = requestedBytes

--- a/music-commons-media/src/main/kotlin/net/transgressoft/commons/media/player/CoreAudioItemPlayer.kt
+++ b/music-commons-media/src/main/kotlin/net/transgressoft/commons/media/player/CoreAudioItemPlayer.kt
@@ -27,14 +27,16 @@ import net.transgressoft.commons.music.player.event.AudioItemPlayerEvent.Played
 import net.transgressoft.lirp.event.FlowEventPublisher
 import net.transgressoft.lirp.event.LirpEventPublisher
 import mu.KotlinLogging
-import java.io.ByteArrayOutputStream
 import java.io.File
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
+import java.nio.file.Path
 import java.time.Duration
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
+import javax.sound.sampled.AudioFileFormat
 import javax.sound.sampled.AudioFormat
+import javax.sound.sampled.AudioInputStream
 import javax.sound.sampled.AudioSystem
 import javax.sound.sampled.DataLine
 import javax.sound.sampled.SourceDataLine
@@ -44,8 +46,8 @@ import javax.sound.sampled.UnsupportedAudioFileException
  * JavaFX-free audio player that decodes and plays audio via `javax.sound.sampled` SPI pipeline.
  *
  * Supports all 5 audio formats (MP3, FLAC, OGG, AAC/M4A, WAV) via JavaSound SPI decoders.
- * Uses [SourceDataLine] for PCM output. The pump thread is a daemon with explicit drain-and-close
- * in [dispose] to prevent JVM hang.
+ * Uses a bounded streaming decoder pipeline with [SourceDataLine] for PCM output. The pump
+ * thread is a daemon with explicit drain-and-close in [dispose] to prevent JVM hang.
  *
  * [stop] resets the playback position to the start; a subsequent [play] begins from the
  * beginning. Use [pause]/[resume] to preserve position across playback control changes.
@@ -54,9 +56,37 @@ import javax.sound.sampled.UnsupportedAudioFileException
  * @see AudioItemPlayer
  * @see SourceDataLine
  */
-open class CoreAudioItemPlayer(
-    private val publisher: LirpEventPublisher<AudioItemPlayerEvent.Type, AudioItemPlayerEvent> = FlowEventPublisher("CoreAudioItemPlayer")
+open class CoreAudioItemPlayer private constructor(
+    private val publisher: LirpEventPublisher<AudioItemPlayerEvent.Type, AudioItemPlayerEvent>,
+    private val pcmStreamFactory: (Path) -> AudioInputStream,
+    private val lineFactory: (AudioFormat) -> SourceDataLine,
+    private val nanoTime: () -> Long,
+    private val stallThresholdNanos: Long
 ) : LirpEventPublisher<AudioItemPlayerEvent.Type, AudioItemPlayerEvent> by publisher, AudioItemPlayer {
+
+    @JvmOverloads
+    constructor(
+        publisher: LirpEventPublisher<AudioItemPlayerEvent.Type, AudioItemPlayerEvent> = FlowEventPublisher("CoreAudioItemPlayer")
+    ) : this(
+        publisher = publisher,
+        pcmStreamFactory = ::decodeToPcmStream,
+        lineFactory = ::createSourceDataLine,
+        nanoTime = System::nanoTime,
+        stallThresholdNanos = DEFAULT_STALL_THRESHOLD_NANOS
+    )
+
+    internal constructor(
+        pcmStreamFactory: (Path) -> AudioInputStream,
+        lineFactory: (AudioFormat) -> SourceDataLine,
+        nanoTime: () -> Long,
+        stallThresholdNanos: Long
+    ) : this(
+        publisher = FlowEventPublisher("CoreAudioItemPlayer"),
+        pcmStreamFactory = pcmStreamFactory,
+        lineFactory = lineFactory,
+        nanoTime = nanoTime,
+        stallThresholdNanos = stallThresholdNanos
+    )
 
     private val logger = KotlinLogging.logger {}
 
@@ -74,7 +104,6 @@ open class CoreAudioItemPlayer(
     private val pumpThread = AtomicReference<Thread?>(null)
     private val onFinishCallback = AtomicReference<Runnable?>(null)
     private val internalStatus = AtomicReference(Status.UNKNOWN)
-    private val pcmData = AtomicReference<ByteArray?>(null)
     private val pcmFormat = AtomicReference<AudioFormat?>(null)
 
     // Monotonically incremented for each new play() invocation. The pump thread
@@ -93,7 +122,7 @@ open class CoreAudioItemPlayer(
     @Volatile
     private var seekTargetMillis: Long = -1L
 
-    // Byte offset in pcmData at which the currently-open SourceDataLine began playing.
+    // Byte offset in the decoded stream at which the currently-open SourceDataLine began playing.
     // line.microsecondPosition resets to 0 each time a new line is opened (e.g. after pause→resume),
     // so absolute playback time = lineStartFrameOffset + line.microsecondPosition.
     @Volatile
@@ -133,14 +162,16 @@ open class CoreAudioItemPlayer(
         if (!file.exists() || file.isDirectory) {
             throw UnsupportedAudioPlaybackException("Cannot play audio item '${audioItem.path.fileName}': file not found")
         }
-        try {
-            AudioSystem.getAudioFileFormat(file)
-        } catch (e: Exception) {
-            throw UnsupportedAudioPlaybackException("Cannot play audio item '${audioItem.path.fileName}': unsupported format", e)
-        }
+        val audioFileFormat =
+            try {
+                AudioSystem.getAudioFileFormat(file)
+            } catch (e: Exception) {
+                throw UnsupportedAudioPlaybackException("Cannot play audio item '${audioItem.path.fileName}': unsupported format", e)
+            }
         stopCurrentPlayback()
         seekTargetMillis = -1L
         framePosition = 0L
+        sourceDurationMillis = durationMillis(audioFileFormat)
         currentAudioItem.set(audioItem)
         val mySession = sessionId.incrementAndGet()
         activeSessionId.set(mySession)
@@ -179,7 +210,6 @@ open class CoreAudioItemPlayer(
     override fun dispose() {
         if (state.get() == InternalState.DISPOSED) return
         stopCurrentPlayback()
-        pcmData.set(null)
         pcmFormat.set(null)
         sourceDurationMillis = 0L
         state.set(InternalState.DISPOSED)
@@ -238,9 +268,8 @@ open class CoreAudioItemPlayer(
             var hadError = false
             var halted = false
             try {
-                decodeAndCachePcm(file)
                 state.set(InternalState.PLAYING)
-                playPcmFromCache()
+                streamPcm(file)
             } catch (_: InterruptedException) {
                 logger.debug { "Playback interrupted for '${audioItem.path.fileName}'" }
                 hadError = true
@@ -270,73 +299,94 @@ open class CoreAudioItemPlayer(
         }
     }
 
-    private fun decodeAndCachePcm(file: File) {
-        val pcmStream = decodeToPcmStream(file.toPath())
-        pcmStream.use { stream ->
-            val buf = ByteArrayOutputStream()
-            val buffer = ByteArray(16384)
-            var bytesRead: Int
-            while (stream.read(buffer).also { bytesRead = it } > 0) {
-                buf.write(buffer, 0, bytesRead)
-            }
-            val data = buf.toByteArray()
-            val format = stream.format
-            pcmData.set(data)
-            pcmFormat.set(format)
-            sourceDurationMillis =
-                (data.size.toDouble() / format.frameSize / format.frameRate * 1000.0).toLong()
-        }
-    }
-
-    private fun playPcmFromCache() {
-        val data = pcmData.get() ?: return
-        val format = pcmFormat.get() ?: return
-
-        if (seekTargetMillis >= 0L) {
-            val bytesPerMillis = (format.frameRate * format.frameSize / 1000.0).toLong()
-            framePosition = seekTargetMillis * bytesPerMillis
-            framePosition -= framePosition % format.frameSize.toLong()
-            seekTargetMillis = -1L
-        }
-
-        var line = openLine(format)
+    private fun streamPcm(file: File) {
+        var session = openStreamSession(file, framePosition)
+        var line = openLine(session.format)
+        val buffer = ByteArray(TRANSFER_BUFFER_SIZE)
 
         try {
-            var offset = framePosition.toInt()
-            val buffer = ByteArray(4096)
-            while (offset < data.size) {
+            while (true) {
                 val currentState = state.get()
                 if (currentState == InternalState.STOPPED || currentState == InternalState.DISPOSED) break
                 if (currentState == InternalState.PAUSED) {
-                    Thread.sleep(20)
+                    Thread.sleep(PAUSE_POLL_MILLIS)
                     continue
                 }
-                if (seekTargetMillis >= 0L) {
+
+                val seekTarget = consumeSeekTarget()
+                if (seekTarget >= 0L) {
+                    session.stream.close()
                     flushAndClose()
-                    val frameSz = (pcmFormat.get()?.frameSize ?: format.frameSize).toLong()
-                    val bytesPerMillis = (pcmFormat.get()?.frameRate ?: format.frameRate) * frameSz / 1000.0
-                    framePosition = (seekTargetMillis * bytesPerMillis).toLong().coerceIn(0, data.size.toLong())
-                    framePosition -= framePosition % frameSz
-                    seekTargetMillis = -1L
-                    line = openLine(format)
-                    offset = framePosition.toInt()
+                    val targetOffset = millisToByteOffset(seekTarget, session.format)
+                    session = openStreamSession(file, targetOffset)
+                    line = openLine(session.format)
                 }
-                if (offset >= data.size) break
-                val remaining = data.size - offset
-                val chunk = minOf(buffer.size, remaining)
-                System.arraycopy(data, offset, buffer, 0, chunk)
-                applyVolume(buffer, chunk, format)
-                framePosition += line.write(buffer, 0, chunk)
-                offset = framePosition.toInt()
+
+                val readStartedAt = nanoTime()
+                val bytesRead = session.stream.read(buffer)
+                val readDuration = nanoTime() - readStartedAt
+                if (bytesRead < 0) break
+                if (bytesRead == 0) continue
+
+                updateStallStatus(readDuration)
+                applyVolume(buffer, bytesRead, session.format)
+                framePosition += line.write(buffer, 0, bytesRead)
             }
         } finally {
+            session.stream.close()
             drainAndClose()
         }
     }
 
+    private fun openStreamSession(file: File, requestedOffset: Long): StreamSession {
+        val stream = pcmStreamFactory(file.toPath())
+        val format = stream.format
+        pcmFormat.set(format)
+        val alignedOffset = requestedOffset.coerceAtLeast(0L).alignDown(format.frameSize.toLong())
+        val skipped = skipFully(stream, alignedOffset)
+        framePosition = skipped.alignDown(format.frameSize.toLong())
+        return StreamSession(stream, format)
+    }
+
+    private fun consumeSeekTarget(): Long {
+        val target = seekTargetMillis
+        if (target >= 0L) {
+            seekTargetMillis = -1L
+        }
+        return target
+    }
+
+    private fun skipFully(stream: AudioInputStream, requestedBytes: Long): Long {
+        var remaining = requestedBytes
+        var skipped = 0L
+        val discard = ByteArray(TRANSFER_BUFFER_SIZE)
+        while (remaining > 0L) {
+            val currentState = state.get()
+            if (currentState == InternalState.STOPPED || currentState == InternalState.DISPOSED) break
+            val step = minOf(remaining, discard.size.toLong()).toInt()
+            val bytesRead = stream.read(discard, 0, step)
+            if (bytesRead < 0) break
+            skipped += bytesRead
+            remaining -= bytesRead
+        }
+        return skipped
+    }
+
+    private fun updateStallStatus(readDurationNanos: Long) {
+        if (readDurationNanos >= stallThresholdNanos && state.get() == InternalState.PLAYING) {
+            internalStatus.set(Status.STALLED)
+        } else {
+            recoverFromStallIfNeeded()
+        }
+    }
+
+    private fun recoverFromStallIfNeeded() {
+        if (internalStatus.get() != Status.STALLED) return
+        internalStatus.set(if (state.get() == InternalState.PAUSED) Status.PAUSED else Status.PLAYING)
+    }
+
     private fun openLine(format: AudioFormat): SourceDataLine {
-        val info = DataLine.Info(SourceDataLine::class.java, format)
-        val line = AudioSystem.getLine(info) as SourceDataLine
+        val line = lineFactory(format)
         lineRef.set(line)
         line.open(format, 4096)
         line.start()
@@ -392,6 +442,42 @@ open class CoreAudioItemPlayer(
         if (state.get() != InternalState.DISPOSED) {
             state.set(InternalState.IDLE)
             internalStatus.set(if (halted) Status.HALTED else Status.READY)
+        }
+    }
+
+    private fun durationMillis(audioFileFormat: AudioFileFormat): Long {
+        val durationMicros = audioFileFormat.properties()["duration"] as? Long
+        if (durationMicros != null && durationMicros > 0L) {
+            return durationMicros / 1000L
+        }
+        val format = audioFileFormat.format
+        return if (audioFileFormat.frameLength > 0 && format.frameRate > 0f) {
+            (audioFileFormat.frameLength * 1000.0 / format.frameRate).toLong()
+        } else {
+            0L
+        }
+    }
+
+    private fun millisToByteOffset(positionMillis: Long, format: AudioFormat): Long {
+        val bytesPerMillis = format.frameRate * format.frameSize / 1000.0
+        return (positionMillis * bytesPerMillis).toLong().alignDown(format.frameSize.toLong())
+    }
+
+    private fun Long.alignDown(step: Long): Long = if (step > 0L) this - this % step else this
+
+    private data class StreamSession(
+        val stream: AudioInputStream,
+        val format: AudioFormat
+    )
+
+    private companion object {
+        const val TRANSFER_BUFFER_SIZE = 4096
+        const val PAUSE_POLL_MILLIS = 20L
+        const val DEFAULT_STALL_THRESHOLD_NANOS = 100_000_000L
+
+        fun createSourceDataLine(format: AudioFormat): SourceDataLine {
+            val info = DataLine.Info(SourceDataLine::class.java, format)
+            return AudioSystem.getLine(info) as SourceDataLine
         }
     }
 }

--- a/music-commons-media/src/test/kotlin/net/transgressoft/commons/media/player/CoreAudioItemPlayerPlaybackTest.kt
+++ b/music-commons-media/src/test/kotlin/net/transgressoft/commons/media/player/CoreAudioItemPlayerPlaybackTest.kt
@@ -29,7 +29,6 @@ import io.kotest.assertions.nondeterministic.eventually
 import io.kotest.core.annotation.Tags
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.datatest.withData
-import io.kotest.matchers.ints.shouldBeGreaterThan
 import io.kotest.matchers.longs.shouldBeGreaterThan as shouldBeGreaterThanLong
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
@@ -69,22 +68,15 @@ internal class CoreAudioItemPlayerPlaybackTest : FunSpec({
             try {
                 player.play(audioItem)
 
-                // Wait for decoding to complete and verify PCM was decoded
+                // Wait for streaming setup and verify format state is available.
                 eventually(5.seconds) {
-                    val pcmDataField = CoreAudioItemPlayer::class.java.getDeclaredField("pcmData")
-                    pcmDataField.isAccessible = true
-                    val pcmData = pcmDataField.get(player) as AtomicReference<ByteArray>
-                    val data = pcmData.get()
-
-                    data shouldNotBe null
-                    data!!.size shouldBeGreaterThan 0
-
-                    // Verify format was set
                     val pcmFormatField = CoreAudioItemPlayer::class.java.getDeclaredField("pcmFormat")
                     pcmFormatField.isAccessible = true
                     val pcmFormat = pcmFormatField.get(player) as AtomicReference<*>
                     pcmFormat.get() shouldNotBe null
                 }
+
+                runCatching { CoreAudioItemPlayer::class.java.getDeclaredField("pcmData") }.exceptionOrNull() shouldNotBe null
             } finally {
                 player.dispose()
             }
@@ -143,7 +135,7 @@ internal class CoreAudioItemPlayerPlaybackTest : FunSpec({
         }
     }
 
-    test("seek changes current time for WAV") {
+    test("forward and backward seek change current time for WAV") {
         val player = CoreAudioItemPlayer()
         val realAudioPath = Arb.realAudioFile(WAV).next()
         val audioItem = Arb.audioItem { path = realAudioPath }.next()
@@ -155,11 +147,14 @@ internal class CoreAudioItemPlayerPlaybackTest : FunSpec({
                 player.status() shouldBe Status.PLAYING
             }
 
-            // Seek to 500ms
-            player.seek(Duration.ofMillis(500))
+            player.seek(Duration.ofMillis(700))
             eventually(1.seconds) {
-                // Current time should be around 500ms
-                player.getCurrentTime().toMillis() shouldBeGreaterThanLong 400L
+                player.getCurrentTime().toMillis() shouldBeGreaterThanLong 600L
+            }
+
+            player.seek(Duration.ofMillis(200))
+            eventually(1.seconds) {
+                player.getCurrentTime().toMillis() shouldBeGreaterThanLong 150L
             }
         } finally {
             player.dispose()

--- a/music-commons-media/src/test/kotlin/net/transgressoft/commons/media/player/CoreAudioItemPlayerPlaybackTest.kt
+++ b/music-commons-media/src/test/kotlin/net/transgressoft/commons/media/player/CoreAudioItemPlayerPlaybackTest.kt
@@ -30,8 +30,10 @@ import io.kotest.core.annotation.Tags
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.datatest.withData
 import io.kotest.matchers.longs.shouldBeGreaterThan as shouldBeGreaterThanLong
+import io.kotest.matchers.longs.shouldBeLessThanOrEqual
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.next
 import java.nio.file.Files.createTempFile
@@ -76,7 +78,7 @@ internal class CoreAudioItemPlayerPlaybackTest : FunSpec({
                     pcmFormat.get() shouldNotBe null
                 }
 
-                runCatching { CoreAudioItemPlayer::class.java.getDeclaredField("pcmData") }.exceptionOrNull() shouldNotBe null
+                runCatching { CoreAudioItemPlayer::class.java.getDeclaredField("pcmData") }.exceptionOrNull().shouldBeInstanceOf<NoSuchFieldException>()
             } finally {
                 player.dispose()
             }
@@ -154,7 +156,9 @@ internal class CoreAudioItemPlayerPlaybackTest : FunSpec({
 
             player.seek(Duration.ofMillis(200))
             eventually(1.seconds) {
-                player.getCurrentTime().toMillis() shouldBeGreaterThanLong 150L
+                val currentMillis = player.getCurrentTime().toMillis()
+                currentMillis shouldBeGreaterThanLong 150L
+                currentMillis shouldBeLessThanOrEqual 450L
             }
         } finally {
             player.dispose()

--- a/music-commons-media/src/test/kotlin/net/transgressoft/commons/media/player/CoreAudioItemPlayerUnitTest.kt
+++ b/music-commons-media/src/test/kotlin/net/transgressoft/commons/media/player/CoreAudioItemPlayerUnitTest.kt
@@ -32,7 +32,9 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.time.Duration
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
+import javax.sound.sampled.AudioFileFormat
 import javax.sound.sampled.AudioFormat
 import javax.sound.sampled.AudioInputStream
 import javax.sound.sampled.SourceDataLine
@@ -180,7 +182,25 @@ internal class CoreAudioItemPlayerUnitTest : StringSpec({
             player.seek(Duration.ofMillis(250))
 
             decodeCount.get() shouldBe 0
-            field("seekTargetMillis").getLong(player) shouldBe 250L
+            (field("seekTargetMillis").get(player) as AtomicLong).get() shouldBe 250L
+        } finally {
+            player.dispose()
+        }
+    }
+
+    "seek target consumption returns the latest target once" {
+        val player = CoreAudioItemPlayer()
+        val consumeSeekTarget =
+            CoreAudioItemPlayer::class.java.getDeclaredMethod("consumeSeekTarget").apply {
+                isAccessible = true
+            }
+
+        try {
+            player.seek(Duration.ofMillis(100))
+            player.seek(Duration.ofMillis(250))
+
+            consumeSeekTarget.invoke(player) shouldBe 250L
+            consumeSeekTarget.invoke(player) shouldBe -1L
         } finally {
             player.dispose()
         }
@@ -217,6 +237,135 @@ internal class CoreAudioItemPlayerUnitTest : StringSpec({
 
             updateStallStatus.invoke(player, 1L)
             player.status() shouldBe Status.PLAYING
+        } finally {
+            player.dispose()
+        }
+    }
+
+    "stalled playback recovers to PAUSED while transport is paused" {
+        val player = CoreAudioItemPlayer()
+        val state = field("state").get(player) as AtomicReference<*>
+        val internalStatus = field("internalStatus").get(player) as AtomicReference<*>
+        @Suppress("UNCHECKED_CAST")
+        (state as AtomicReference<Any>).set(enumValue("PAUSED"))
+        @Suppress("UNCHECKED_CAST")
+        (internalStatus as AtomicReference<Status>).set(Status.STALLED)
+        val recoverFromStallIfNeeded =
+            CoreAudioItemPlayer::class.java.getDeclaredMethod("recoverFromStallIfNeeded").apply {
+                isAccessible = true
+            }
+
+        try {
+            recoverFromStallIfNeeded.invoke(player)
+
+            player.status() shouldBe Status.PAUSED
+        } finally {
+            player.dispose()
+        }
+    }
+
+    "duration prefers metadata and falls back to frame length" {
+        val player = CoreAudioItemPlayer()
+        val durationMillis =
+            CoreAudioItemPlayer::class.java.getDeclaredMethod("durationMillis", AudioFileFormat::class.java).apply {
+                isAccessible = true
+            }
+        val metadataDuration =
+            AudioFileFormat(
+                AudioFileFormat.Type.WAVE,
+                PCM_FORMAT,
+                44_100,
+                mapOf("duration" to 1_234_000L)
+            )
+        val frameDuration = AudioFileFormat(AudioFileFormat.Type.WAVE, PCM_FORMAT, 88_200)
+        val unknownDuration = AudioFileFormat(AudioFileFormat.Type.WAVE, AudioFormat(44_100f, 16, 1, true, false), -1)
+
+        try {
+            durationMillis.invoke(player, metadataDuration) shouldBe 1_234L
+            durationMillis.invoke(player, frameDuration) shouldBe 2_000L
+            durationMillis.invoke(player, unknownDuration) shouldBe 0L
+        } finally {
+            player.dispose()
+        }
+    }
+
+    "streaming reopens the decoder when a pending seek is consumed" {
+        val decodeCount = AtomicInteger()
+        val lineCount = AtomicInteger()
+        val player =
+            CoreAudioItemPlayer(
+                pcmStreamFactory = {
+                    decodeCount.incrementAndGet()
+                    streamOf(ByteArray(16))
+                },
+                lineFactory = {
+                    lineCount.incrementAndGet()
+                    fakeLine()
+                },
+                nanoTime = { 0L },
+                stallThresholdNanos = Long.MAX_VALUE
+            )
+        val state = field("state").get(player) as AtomicReference<*>
+        @Suppress("UNCHECKED_CAST")
+        (state as AtomicReference<Any>).set(enumValue("PLAYING"))
+        val streamPcm =
+            CoreAudioItemPlayer::class.java.getDeclaredMethod("streamPcm", File::class.java).apply {
+                isAccessible = true
+            }
+
+        try {
+            player.seek(Duration.ZERO)
+            streamPcm.invoke(player, File("unused.wav"))
+
+            decodeCount.get() shouldBe 2
+            lineCount.get() shouldBe 2
+        } finally {
+            player.dispose()
+        }
+    }
+
+    "skipFully aborts when playback is already stopped" {
+        val player = CoreAudioItemPlayer()
+        val state = field("state").get(player) as AtomicReference<*>
+        @Suppress("UNCHECKED_CAST")
+        (state as AtomicReference<Any>).set(enumValue("STOPPED"))
+        val skipFully =
+            CoreAudioItemPlayer::class.java.getDeclaredMethod("skipFully", AudioInputStream::class.java, Long::class.javaPrimitiveType).apply {
+                isAccessible = true
+            }
+
+        try {
+            skipFully.invoke(player, streamOf(ByteArray(16)), 8L) shouldBe 0L
+        } finally {
+            player.dispose()
+        }
+    }
+
+    "volume scaling handles muted, 16-bit, and 8-bit buffers" {
+        val player = CoreAudioItemPlayer()
+        val applyVolume =
+            CoreAudioItemPlayer::class.java
+                .getDeclaredMethod("applyVolume", ByteArray::class.java, Int::class.javaPrimitiveType, AudioFormat::class.java)
+                .apply {
+                    isAccessible = true
+                }
+        val volume = field("volume")
+        val muted = byteArrayOf(1, 2, 3, 4)
+        val sixteenBit = byteArrayOf(0x00, 0x40, 0x00, 0xC0.toByte())
+        val eightBit = byteArrayOf(0x00, 0xFF.toByte())
+        val eightBitFormat = AudioFormat(44_100f, 8, 1, false, false)
+
+        try {
+            volume.setDouble(player, 0.0)
+            applyVolume.invoke(player, muted, muted.size, PCM_FORMAT)
+            muted.toList() shouldBe listOf<Byte>(0, 0, 0, 0)
+
+            volume.setDouble(player, 0.5)
+            applyVolume.invoke(player, sixteenBit, sixteenBit.size, PCM_FORMAT)
+            sixteenBit.toList() shouldBe listOf<Byte>(0x00, 0x20, 0x00, 0xE0.toByte())
+
+            applyVolume.invoke(player, eightBit, eightBit.size, eightBitFormat)
+            eightBit.toList() shouldBe listOf<Byte>(0x40, 0xBF.toByte())
         } finally {
             player.dispose()
         }

--- a/music-commons-media/src/test/kotlin/net/transgressoft/commons/media/player/CoreAudioItemPlayerUnitTest.kt
+++ b/music-commons-media/src/test/kotlin/net/transgressoft/commons/media/player/CoreAudioItemPlayerUnitTest.kt
@@ -27,9 +27,23 @@ import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import java.io.File
+import java.lang.reflect.Field
 import java.nio.file.Files
 import java.nio.file.Path
 import java.time.Duration
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
+import javax.sound.sampled.AudioFormat
+import javax.sound.sampled.AudioInputStream
+import javax.sound.sampled.SourceDataLine
+
+private val PCM_FORMAT = AudioFormat(44_100f, 16, 1, true, false)
+
+@Suppress("UNCHECKED_CAST")
+private fun enumValue(name: String): Any {
+    val enumClass = CoreAudioItemPlayer::class.java.declaredClasses.single { it.simpleName == "InternalState" }
+    return java.lang.Enum.valueOf(enumClass as Class<out Enum<*>>, name)
+}
 
 /**
  * Unit tests for [CoreAudioItemPlayer] that exercise the public API without triggering
@@ -46,6 +60,22 @@ internal class CoreAudioItemPlayerUnitTest : StringSpec({
             every { encoding } returns null
             every { encoder } returns null
         }
+
+    fun field(name: String): Field =
+        CoreAudioItemPlayer::class.java.getDeclaredField(name).apply {
+            isAccessible = true
+        }
+
+    fun fakeLine(): SourceDataLine =
+        mockk(relaxed = true) {
+            every { isOpen } returns true
+            every { write(any(), any(), any()) } answers { thirdArg() }
+        }
+
+    fun streamOf(vararg chunks: ByteArray): AudioInputStream {
+        val bytes = chunks.flatMap { it.toList() }.toByteArray()
+        return AudioInputStream(bytes.inputStream(), PCM_FORMAT, bytes.size.toLong() / PCM_FORMAT.frameSize)
+    }
 
     "initial status is UNKNOWN" {
         val player = CoreAudioItemPlayer()
@@ -124,6 +154,69 @@ internal class CoreAudioItemPlayerUnitTest : StringSpec({
         try {
             shouldNotThrowAny { player.seek(Duration.ofMillis(500)) }
             player.status() shouldBe Status.UNKNOWN
+        } finally {
+            player.dispose()
+        }
+    }
+
+    "paused seek stores the latest target without opening a decoder" {
+        val decodeCount = AtomicInteger()
+        val player =
+            CoreAudioItemPlayer(
+                pcmStreamFactory = {
+                    decodeCount.incrementAndGet()
+                    streamOf(ByteArray(8))
+                },
+                lineFactory = { fakeLine() },
+                nanoTime = { 0L },
+                stallThresholdNanos = Long.MAX_VALUE
+            )
+        val state = field("state").get(player) as AtomicReference<*>
+        @Suppress("UNCHECKED_CAST")
+        (state as AtomicReference<Any>).set(enumValue("PAUSED"))
+
+        try {
+            player.seek(Duration.ofMillis(100))
+            player.seek(Duration.ofMillis(250))
+
+            decodeCount.get() shouldBe 0
+            field("seekTargetMillis").getLong(player) shouldBe 250L
+        } finally {
+            player.dispose()
+        }
+    }
+
+    "unknown duration may remain ZERO before playback" {
+        val player = CoreAudioItemPlayer()
+        try {
+            player.totalDuration shouldBe Duration.ZERO
+        } finally {
+            player.dispose()
+        }
+    }
+
+    "sustained decoder starvation transitions from STALLED back to PLAYING" {
+        val player =
+            CoreAudioItemPlayer(
+                pcmStreamFactory = { streamOf(ByteArray(8)) },
+                lineFactory = { fakeLine() },
+                nanoTime = { 0L },
+                stallThresholdNanos = 100_000_000L
+            )
+        val state = field("state").get(player) as AtomicReference<*>
+        @Suppress("UNCHECKED_CAST")
+        (state as AtomicReference<Any>).set(enumValue("PLAYING"))
+        val updateStallStatus =
+            CoreAudioItemPlayer::class.java.getDeclaredMethod("updateStallStatus", Long::class.javaPrimitiveType).apply {
+                isAccessible = true
+            }
+
+        try {
+            updateStallStatus.invoke(player, 200_000_000L)
+            player.status() shouldBe Status.STALLED
+
+            updateStallStatus.invoke(player, 1L)
+            player.status() shouldBe Status.PLAYING
         } finally {
             player.dispose()
         }


### PR DESCRIPTION
## Summary

Closes #98.

`CoreAudioItemPlayer` no longer decodes an entire track into one retained PCM `ByteArray` before playback. The player now streams decoded PCM in fixed-size chunks, so long tracks do not require heap growth proportional to their full decoded size before audio can start.

## What changed

- Replaced the whole-track PCM cache with a bounded streaming loop that reads from `AudioInputStream` and writes directly to `SourceDataLine`.
- Switched seek handling from random access into a retained PCM array to decoder restart plus frame-aligned skipping from the requested position.
- Made pending seek consumption atomic with latest-target-wins behavior, so a concurrent seek cannot be overwritten while the pump consumes a prior target.
- Kept the public `AudioItemPlayer` API unchanged while preserving play, pause, resume, stop, and completion behavior.
- Populate duration from available `AudioFileFormat` metadata when possible, without draining the decoded stream first.
- Made `AudioItemPlayer.Status.STALLED` a live state for sustained decoder starvation, with recovery back to the active transport state.
- Updated public docs so `STALLED` is no longer described as only reserved for a future streaming implementation.

## Tests

- Replaced the old cache-introspection assertion with streaming setup coverage across MP3, M4A, WAV, FLAC, and OGG.
- Extended real playback coverage with forward and backward WAV seek checks after the refactor, including an upper bound that proves the backward seek moved the transport backward.
- Added deterministic unit coverage for:
  - paused seek coalescing,
  - atomic seek-target consumption,
  - duration metadata and frame-length fallback,
  - `STALLED -> PLAYING` and `STALLED -> PAUSED` recovery behavior,
  - decoder reopen on consumed seek,
  - stopped skip handling,
  - muted, 16-bit, and 8-bit volume scaling.

## Verification

- [x] `gradle compileKotlin compileTestKotlin :music-commons-media:test ktlintCheck testCodeCoverageReport --console=plain`
- [x] Aggregate JaCoCo line coverage: `87.24% (4765/5462)`
- [x] Manual long-file validation through `PlayableWaveformPaneDemo` on `2026-05-17`; behavior verified as correct.