### PR TITLE
Inject AudioMetadataIO and PathResolver

### DIFF
--- a/music-commons-api/build.gradle
+++ b/music-commons-api/build.gradle
@@ -2,4 +2,5 @@ description = 'Transgressoft Music Commons - API'
 
 dependencies {
     api 'org.jetbrains.kotlinx:kotlinx-coroutines-core'
+    api libs.jaudiotagger.get()
 }

--- a/music-commons-api/src/main/kotlin/net/transgressoft/commons/music/audio/AudioMetadataIO.kt
+++ b/music-commons-api/src/main/kotlin/net/transgressoft/commons/music/audio/AudioMetadataIO.kt
@@ -1,0 +1,70 @@
+/******************************************************************************
+ * Copyright (C) 2025  Octavio Calleya Garcia                                 *
+ *                                                                            *
+ * This program is free software: you can redistribute it and/or modify       *
+ * it under the terms of the GNU General Public License as published by       *
+ * the Free Software Foundation, either version 3 of the License, or          *
+ * (at your option) any later version.                                        *
+ *                                                                            *
+ * This program is distributed in the hope that it will be useful,            *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
+ * GNU General Public License for more details.                               *
+ *                                                                            *
+ * You should have received a copy of the GNU General Public License          *
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.     *
+ ******************************************************************************/
+
+package net.transgressoft.commons.music.audio
+
+import org.jaudiotagger.tag.Tag
+import java.nio.file.Path
+
+/**
+ * Port for reading and writing audio metadata against a file at a given [Path].
+ *
+ * Production callers wire in the default JAudioTagger-backed implementation; tests inject
+ * lightweight fakes so they neither touch the JAudioTagger static `AudioFileIO` nor require real
+ * audio bytes on disk. Centralizing the four operations behind this interface eliminates direct
+ * JAudioTagger access from audio item implementations.
+ */
+interface AudioMetadataIO {
+
+    /**
+     * Reads the tag block from the audio file at [path].
+     *
+     * @param path location of the audio file to read
+     * @return the populated [Tag] describing the file's metadata fields
+     */
+    fun readTag(path: Path): Tag
+
+    /**
+     * Reads the audio header (codec, bitrate, duration, container format) from [path].
+     *
+     * Header values are independent of tag content and survive empty or unreadable tag blocks,
+     * so this can be called even when [readTag] fails.
+     *
+     * @param path location of the audio file to inspect
+     * @return a [HeaderInfo] snapshot of the file's header fields
+     */
+    fun readHeaderInfo(path: Path): HeaderInfo
+
+    /**
+     * Returns the raw bytes of the first embedded cover artwork, or `null` when the file has no
+     * artwork or cannot be read.
+     *
+     * @param path location of the audio file to inspect
+     */
+    fun readCoverBytes(path: Path): ByteArray?
+
+    /**
+     * Writes [tag] back to the audio file at [path], replacing any existing tag block.
+     *
+     * Implementations must be idempotent: calling twice with the same tag must yield the same
+     * on-disk bytes.
+     *
+     * @param path location of the audio file to update
+     * @param tag the populated tag block to persist
+     */
+    fun writeTag(path: Path, tag: Tag)
+}

--- a/music-commons-api/src/main/kotlin/net/transgressoft/commons/music/audio/HeaderInfo.kt
+++ b/music-commons-api/src/main/kotlin/net/transgressoft/commons/music/audio/HeaderInfo.kt
@@ -1,0 +1,36 @@
+/******************************************************************************
+ * Copyright (C) 2025  Octavio Calleya Garcia                                 *
+ *                                                                            *
+ * This program is free software: you can redistribute it and/or modify       *
+ * it under the terms of the GNU General Public License as published by       *
+ * the Free Software Foundation, either version 3 of the License, or          *
+ * (at your option) any later version.                                        *
+ *                                                                            *
+ * This program is distributed in the hope that it will be useful,            *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
+ * GNU General Public License for more details.                               *
+ *                                                                            *
+ * You should have received a copy of the GNU General Public License          *
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.     *
+ ******************************************************************************/
+
+package net.transgressoft.commons.music.audio
+
+/**
+ * Plain-Kotlin view of the audio header fields consumed by metadata utilities.
+ *
+ * Mirrors the subset of JAudioTagger's `AudioHeader` actually read by `AudioItemMetadataUtils`:
+ * codec/encoding, parsed bitrate (the leading `~` marker for variable bitrate is already stripped),
+ * total track length in seconds, and the container format string used to choose the tag type when
+ * writing metadata back to disk.
+ *
+ * Decoupling this from JAudioTagger keeps `music-commons-api` free of library-specific types and
+ * lets test fakes synthesize header values without instantiating JAudioTagger objects.
+ */
+data class HeaderInfo(
+    val encodingType: String?,
+    val bitRate: Int,
+    val trackLengthSeconds: Long,
+    val format: String
+)

--- a/music-commons-api/src/main/kotlin/net/transgressoft/commons/music/common/PathJsonExtensions.kt
+++ b/music-commons-api/src/main/kotlin/net/transgressoft/commons/music/common/PathJsonExtensions.kt
@@ -21,6 +21,7 @@ import java.net.URI
 import java.nio.file.FileSystem
 import java.nio.file.FileSystems
 import java.nio.file.Path
+import java.nio.file.Paths
 import kotlinx.serialization.SerializationException
 
 /**
@@ -81,16 +82,26 @@ fun String.toPathFromJsonUri(fileSystem: FileSystem): Path {
         )
     }
     return try {
-        val rawPath = URI(this).path
-        // Strip the leading slash for Windows-style absolute paths like `/C:\foo\bar` so that
-        // Jimfs windows-config (and the real Windows JDK provider) parse the drive-rooted form.
-        val normalized =
-            if (rawPath.length > 3 && rawPath[0] == '/' && rawPath[2] == ':') {
-                rawPath.substring(1)
-            } else {
-                rawPath
-            }
-        fileSystem.getPath(normalized)
+        val uri = URI(this)
+        if (fileSystem == FileSystems.getDefault()) {
+            // Paths.get(URI) is the URI-aware path on the default provider: it handles
+            // Windows drive letters (file:///C:/... -> C:\...), UNC authority preservation
+            // (file:////server/share/... -> \\server\share\...), and POSIX paths
+            // (file:///home/... -> /home/...) without manual string surgery.
+            Paths.get(uri)
+        } else {
+            // Non-default filesystems (e.g. Jimfs) need explicit FileSystem.getPath. Strip the
+            // leading slash for Windows-style absolute paths like `/C:\foo\bar` so the
+            // Jimfs windows-config parses the drive-rooted form.
+            val rawPath = uri.path
+            val normalized =
+                if (rawPath.length > 3 && rawPath[0] == '/' && rawPath[2] == ':') {
+                    rawPath.substring(1)
+                } else {
+                    rawPath
+                }
+            fileSystem.getPath(normalized)
+        }
     } catch (e: Exception) {
         throw SerializationException("Invalid file:// URI: '$this'", e)
     }

--- a/music-commons-api/src/main/kotlin/net/transgressoft/commons/music/common/PathJsonExtensions.kt
+++ b/music-commons-api/src/main/kotlin/net/transgressoft/commons/music/common/PathJsonExtensions.kt
@@ -18,34 +18,62 @@
 package net.transgressoft.commons.music.common
 
 import java.net.URI
+import java.nio.file.FileSystem
+import java.nio.file.FileSystems
 import java.nio.file.Path
-import java.nio.file.Paths
 import kotlinx.serialization.SerializationException
 
 /**
  * Converts this path to a platform-neutral `file://` URI string for JSON persistence.
  *
- * Delegates to [Path.toAbsolutePath] before calling [Path.toUri] to satisfy the
- * JDK contract that requires an absolute path; [Path.toUri] handles OS-specific
- * encoding including drive letters, separator normalization, and percent-encoding
- * of spaces and special characters.
- *
- * Note: paths from non-default filesystem providers (e.g. Jimfs) serialize with
- * their provider's URI scheme (`jimfs://...`) and will not round-trip through
- * [toPathFromJsonUri], which only accepts the `file://` scheme. This is
- * intentional: production code should serialize real filesystem paths only.
+ * Default-filesystem paths use [Path.toUri] which handles OS-specific encoding (drive letters,
+ * separator normalization, percent-encoding). Paths from non-default filesystem providers
+ * (e.g. Jimfs) would otherwise serialize with their provider's URI scheme (`jimfs://...`),
+ * which would fail the `file://` guard in [toPathFromJsonUri] on round-trip. To keep the
+ * serialized form stable across filesystems, non-default-FS paths emit a synthetic `file://`
+ * URI built from the absolute path string.
  */
-fun Path.toJsonUri(): String = toAbsolutePath().toUri().toString()
+fun Path.toJsonUri(): String =
+    if (fileSystem == FileSystems.getDefault()) {
+        toAbsolutePath().toUri().toString()
+    } else {
+        // Synthesize a file:// URI from the path string so toPathFromJsonUri's `file://` guard
+        // passes. Use URI's 4-arg constructor to percent-encode spaces, backslashes, drive
+        // letters, and other reserved characters that would otherwise break URI(this) round-trip
+        // in toPathFromJsonUri. Ensure the path starts with '/' so the resulting URI has the
+        // canonical file:///... shape (Jimfs windows paths like `C:\a\b` would otherwise produce
+        // a relative-form URI).
+        val absolute = toAbsolutePath().toString()
+        val pathForUri = if (absolute.startsWith("/")) absolute else "/$absolute"
+        // 5-arg URI(scheme, authority, path, query, fragment) with empty-string authority emits
+        // the canonical file:///... triple-slash form (file://<authority>/<path>).
+        URI("file", "", pathForUri, null, null).toString()
+    }
 
 /**
- * Reconstructs a [Path] from a `file://` URI string produced by [toJsonUri].
+ * Reconstructs a [Path] from a `file://` URI string produced by [toJsonUri], using the
+ * default filesystem.
  *
  * @throws SerializationException if the string does not start with `file://`
  *         (indicating pre-25.1 JSON using raw OS path strings — no migration
  *         fallback is provided), or if the URI is structurally invalid or
  *         points at a filesystem provider that is not registered in this JVM.
  */
-fun String.toPathFromJsonUri(): Path {
+fun String.toPathFromJsonUri(): Path = toPathFromJsonUri(FileSystems.getDefault())
+
+/**
+ * Reconstructs a [Path] from a `file://` URI string against an explicit [FileSystem].
+ *
+ * Strips the URI scheme/authority and resolves the path component against
+ * [fileSystem]. This allows JSON persisted from one filesystem (e.g. real disk)
+ * to be deserialized against another (e.g. Jimfs) by passing the target filesystem
+ * explicitly.
+ *
+ * @param fileSystem the [FileSystem] used to materialize the resulting [Path].
+ * @throws SerializationException if the string does not start with `file://`,
+ *         or if the URI is structurally invalid.
+ */
+fun String.toPathFromJsonUri(fileSystem: FileSystem): Path {
     if (!startsWith("file://")) {
         throw SerializationException(
             "Invalid path format: expected a file:// URI but found '$this'. " +
@@ -53,7 +81,16 @@ fun String.toPathFromJsonUri(): Path {
         )
     }
     return try {
-        Paths.get(URI(this))
+        val rawPath = URI(this).path
+        // Strip the leading slash for Windows-style absolute paths like `/C:\foo\bar` so that
+        // Jimfs windows-config (and the real Windows JDK provider) parse the drive-rooted form.
+        val normalized =
+            if (rawPath.length > 3 && rawPath[0] == '/' && rawPath[2] == ':') {
+                rawPath.substring(1)
+            } else {
+                rawPath
+            }
+        fileSystem.getPath(normalized)
     } catch (e: Exception) {
         throw SerializationException("Invalid file:// URI: '$this'", e)
     }

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/MusicLibrary.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/MusicLibrary.kt
@@ -23,6 +23,7 @@ import net.transgressoft.commons.music.audio.Artist
 import net.transgressoft.commons.music.audio.ArtistCatalog
 import net.transgressoft.commons.music.audio.AudioItem
 import net.transgressoft.commons.music.audio.AudioItemMapSerializer
+import net.transgressoft.commons.music.audio.AudioItemMetadataUtils
 import net.transgressoft.commons.music.audio.AudioLibrary
 import net.transgressoft.commons.music.audio.DefaultAudioLibrary
 import net.transgressoft.commons.music.audio.event.AudioItemEventSubscriber
@@ -42,6 +43,7 @@ import net.transgressoft.lirp.persistence.VolatileRepository
 import net.transgressoft.lirp.persistence.json.JsonFileRepository
 import net.transgressoft.lirp.persistence.sql.SqlRepository
 import net.transgressoft.lirp.persistence.sql.SqlTableDef
+import java.io.File
 import java.nio.file.Path
 import java.util.Optional
 import java.util.concurrent.CompletableFuture
@@ -52,7 +54,7 @@ internal sealed interface StorageConfig
 
 internal data object VolatileStorage : StorageConfig
 
-internal data class JsonFileStorage(val file: java.io.File) : StorageConfig
+internal data class JsonFileStorage(val file: File) : StorageConfig
 
 internal data class SqlStorage<E : IdentifiableEntity<*>>(
     val dataSource: DataSource,
@@ -183,21 +185,30 @@ class CoreMusicLibrary private constructor(
      *     .build()
      * ```
      */
-    class Builder {
+    class Builder() {
 
         private var audioLibraryStorage: StorageConfig = VolatileStorage
         private var playlistHierarchyStorage: StorageConfig = VolatileStorage
         private var waveformRepositoryStorage: StorageConfig = VolatileStorage
+        private var metadataUtils: AudioItemMetadataUtils = AudioItemMetadataUtils()
+
+        // Internal seam for in-module tests: lets a spec construct a Builder whose audio library
+        // routes metadata reads/writes through a FakeAudioMetadataIO-backed AudioItemMetadataUtils.
+        // Not exposed on the public Builder API because end-users don't configure metadata I/O —
+        // they just persist via *JsonFile / *Sql storage and accept the default JAudioTagger seam.
+        internal constructor(metadataUtils: AudioItemMetadataUtils) : this() {
+            this.metadataUtils = metadataUtils
+        }
 
         /** Configures the audio library to persist to [file] using JSON. */
-        fun audioLibraryJsonFile(file: java.io.File): Builder = apply { audioLibraryStorage = JsonFileStorage(file) }
+        fun audioLibraryJsonFile(file: File): Builder = apply { audioLibraryStorage = JsonFileStorage(file) }
 
         /** Configures the playlist hierarchy to persist to [file] using JSON. */
-        fun playlistHierarchyJsonFile(file: java.io.File): Builder =
+        fun playlistHierarchyJsonFile(file: File): Builder =
             apply { playlistHierarchyStorage = JsonFileStorage(file) }
 
         /** Configures the waveform repository to persist to [file] using JSON. */
-        fun waveformRepositoryJsonFile(file: java.io.File): Builder =
+        fun waveformRepositoryJsonFile(file: File): Builder =
             apply { waveformRepositoryStorage = JsonFileStorage(file) }
 
         /**
@@ -236,7 +247,7 @@ class CoreMusicLibrary private constructor(
         fun build(): CoreMusicLibrary {
             // 1. Audio library first — registers AudioItem in LirpContext
             val audioRepo = createAudioRepository()
-            val audioLibrary = DefaultAudioLibrary(audioRepo)
+            val audioLibrary = DefaultAudioLibrary(audioRepo, metadataUtils)
 
             var waveformRepository: AudioWaveformRepository<AudioWaveform, AudioItem>? = null
             try {

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/AudioItemMetadataUtils.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/AudioItemMetadataUtils.kt
@@ -23,8 +23,6 @@ import net.transgressoft.commons.music.audio.AudioFileType.MP3
 import net.transgressoft.commons.music.audio.AudioFileType.WAV
 import com.neovisionaries.i18n.CountryCode
 import mu.KLogger
-import org.jaudiotagger.audio.AudioFileIO
-import org.jaudiotagger.audio.AudioHeader
 import org.jaudiotagger.audio.exceptions.CannotReadException
 import org.jaudiotagger.audio.wav.WavOptions
 import org.jaudiotagger.tag.FieldKey
@@ -66,281 +64,268 @@ data class AudioFileMetadata(
 )
 
 /**
- * Shared utility object centralizing all JAudioTagger metadata read and write operations.
+ * Centralizes all metadata read and write operations against an [AudioMetadataIO] seam.
  *
  * Isolates JAudioTagger-dependent code from [net.transgressoft.commons.music.audio.MutableAudioItem]
- * and [net.transgressoft.commons.fx.music.audio.FXAudioItem], creating a clean seam for future
- * library replacement. Both audio item implementations delegate metadata operations to this object
- * rather than depending on JAudioTagger types.
+ * and [net.transgressoft.commons.fx.music.audio.FXAudioItem] by delegating I/O through an injected
+ * [AudioMetadataIO]. The default constructor wires in the JAudioTagger-backed [DefaultAudioMetadataIO];
+ * tests can supply a fake instead.
  *
  * The public API consists of [readMetadata], [readCoverBytes], and [writeMetadataToFile].
- * All JAudioTagger type references are confined to this object.
+ * JAudioTagger types are still referenced internally for building tag instances on the write path.
  */
-object AudioItemMetadataUtils {
+class AudioItemMetadataUtils
+    @JvmOverloads
+    constructor(
+        private val audioMetadataIO: AudioMetadataIO = DefaultAudioMetadataIO()
+    ) {
 
-    /**
-     * Reads all metadata from the audio file at [path] and returns it as an [AudioFileMetadata]
-     * value object containing only plain Kotlin/Java types.
-     *
-     * @param path path to the audio file
-     */
-    fun readMetadata(path: Path): AudioFileMetadata {
-        val audioFile =
+        /**
+         * Reads all metadata from the audio file at [path] and returns it as an [AudioFileMetadata]
+         * value object containing only plain Kotlin/Java types.
+         *
+         * @param path path to the audio file
+         */
+        fun readMetadata(path: Path): AudioFileMetadata {
+            val tag =
+                try {
+                    audioMetadataIO.readTag(path)
+                } catch (_: CannotReadException) {
+                    // File is a valid audio stream but has no readable tag block (e.g. OGG without vorbiscomment).
+                    // Fall back to header-only metadata so the file can still be played.
+                    return emptyMetadata(runCatching { audioMetadataIO.readHeaderInfo(path) }.getOrNull())
+                } catch (_: NullPointerException) {
+                    // JAudioTagger's Mp4InfoReader throws NPE for unsupported M4A codecs
+                    // (Opus, FLAC-in-M4A) because fields like noOfChannels are null.
+                    // Fall back to empty metadata so the file can still be played.
+                    return emptyMetadata(runCatching { audioMetadataIO.readHeaderInfo(path) }.getOrNull())
+                }
+            val header = audioMetadataIO.readHeaderInfo(path)
+            return AudioFileMetadata(
+                bitRate = header.bitRate,
+                duration = Duration.ofSeconds(header.trackLengthSeconds),
+                encoder = getFieldIfExisting(tag, FieldKey.ENCODER),
+                encoding = header.encodingType,
+                title = getFieldIfExisting(tag, FieldKey.TITLE) ?: "",
+                artist = parseArtist(tag),
+                album = parseAlbum(tag),
+                genres = getFieldIfExisting(tag, FieldKey.GENRE)?.let { Genre.parseGenre(it) } ?: emptySet(),
+                comments = getFieldIfExisting(tag, FieldKey.COMMENT)?.takeIf { it.isNotEmpty() },
+                trackNumber = parseOptionalShort(getFieldIfExisting(tag, FieldKey.TRACK)),
+                discNumber = parseOptionalShort(getFieldIfExisting(tag, FieldKey.DISC_NO)),
+                bpm = parseOptionalBpm(getFieldIfExisting(tag, FieldKey.BPM)),
+                coverBytes = parseCoverBytes(tag)
+            )
+        }
+
+        private fun emptyMetadata(header: HeaderInfo? = null): AudioFileMetadata =
+            AudioFileMetadata(
+                bitRate = header?.bitRate ?: 0,
+                duration = header?.let { Duration.ofSeconds(it.trackLengthSeconds) } ?: Duration.ZERO,
+                encoder = null,
+                encoding = header?.encodingType,
+                title = "",
+                artist = ImmutableArtist.UNKNOWN,
+                album = ImmutableAlbum.UNKNOWN,
+                genres = emptySet(),
+                comments = null,
+                trackNumber = null,
+                discNumber = null,
+                bpm = null,
+                coverBytes = null
+            )
+
+        /**
+         * Reads the cover image bytes from the audio file at [path], or returns `null` if the file
+         * has no artwork or cannot be read.
+         */
+        fun readCoverBytes(path: Path): ByteArray? = audioMetadataIO.readCoverBytes(path)
+
+        /**
+         * Writes metadata to the audio file at [path], creating the appropriate tag format and
+         * committing changes to disk.
+         *
+         * @param logger caller's logger for artwork error reporting
+         * @param fileName caller's file name for temp file naming during artwork creation
+         */
+        @SuppressWarnings("kotlin:S107") // Audio metadata requires all tag fields as parameters; splitting would obscure the mapping
+        fun writeMetadataToFile(
+            path: Path,
+            title: String,
+            album: Album,
+            artist: Artist,
+            genres: Set<Genre>,
+            comments: String?,
+            trackNumber: Short?,
+            discNumber: Short?,
+            bpm: Float?,
+            encoder: String?,
+            coverImageBytes: ByteArray?,
+            fileName: String,
+            logger: KLogger
+        ) {
+            val format = audioMetadataIO.readHeaderInfo(path).format
+            val tag =
+                createTag(
+                    format, title, album, artist, genres,
+                    comments, trackNumber, discNumber, bpm, encoder,
+                    coverImageBytes, fileName, logger
+                )
+            audioMetadataIO.writeTag(path, tag)
+        }
+
+        // getFirst returns "" for missing fields, but throws UnsupportedOperationException for some tag/field
+        // combinations (e.g. WavTag + COUNTRY). Treat both as "field not present".
+        private fun getFieldIfExisting(tag: Tag, fieldKey: FieldKey): String? =
+            runCatching { tag.getFirst(fieldKey) }.getOrNull()
+
+        private fun parseArtist(tag: Tag): Artist =
+            getFieldIfExisting(tag, FieldKey.ARTIST)?.let { artistName ->
+                val country =
+                    getFieldIfExisting(tag, FieldKey.COUNTRY)
+                        ?.let { CountryCode.getByCode(it) ?: CountryCode.UNDEFINED }
+                        ?: CountryCode.UNDEFINED
+                ImmutableArtist.of(AudioUtils.beautifyArtistName(artistName), country)
+            } ?: ImmutableArtist.UNKNOWN
+
+        private fun parseAlbum(tag: Tag): ImmutableAlbum =
+            getFieldIfExisting(tag, FieldKey.ALBUM).let { albumName ->
+                return if (albumName == null) {
+                    ImmutableAlbum.UNKNOWN
+                } else {
+                    val albumArtistName = getFieldIfExisting(tag, FieldKey.ALBUM_ARTIST) ?: ""
+                    val isCompilation =
+                        getFieldIfExisting(tag, FieldKey.IS_COMPILATION)?.let {
+                            if (tag is Mp4Tag)
+                                it == "1"
+                            else
+                                it == "true"
+                        } ?: false
+                    val year = getFieldIfExisting(tag, FieldKey.YEAR)?.toShortOrNull()?.takeIf { it > 0 }
+                    val label = getFieldIfExisting(tag, FieldKey.GROUPING)?.let { ImmutableLabel.of(it) } ?: ImmutableLabel.UNKNOWN
+                    ImmutableAlbum(albumName, ImmutableArtist.of(AudioUtils.beautifyArtistName(albumArtistName)), isCompilation, year, label)
+                }
+            }
+
+        private fun parseCoverBytes(tag: Tag): ByteArray? = tag.artworkList.isNotEmpty().takeIf { it }?.let { tag.firstArtwork.binaryData }
+
+        private fun parseOptionalShort(value: String?): Short? =
+            value?.takeUnless { it.isEmpty() || it == "0" }?.toShortOrNull()?.takeIf { it > 0 }
+
+        private fun parseOptionalBpm(value: String?): Float? =
+            value?.takeUnless { it.isEmpty() || it == "0" }?.toFloatOrNull()?.takeIf { it > 0 }
+
+        @SuppressWarnings("kotlin:S107")
+        private fun createTag(
+            format: String,
+            title: String,
+            album: Album,
+            artist: Artist,
+            genres: Set<Genre>,
+            comments: String?,
+            trackNumber: Short?,
+            discNumber: Short?,
+            bpm: Float?,
+            encoder: String?,
+            coverImageBytes: ByteArray?,
+            fileName: String,
+            logger: KLogger
+        ): Tag =
+            when {
+                format.startsWith(WAV.extension, ignoreCase = true) -> {
+                    val wavTag = WavTag(WavOptions.READ_ID3_ONLY)
+                    wavTag.iD3Tag = ID3v24Tag()
+                    wavTag.infoTag = WavInfoTag()
+                    wavTag
+                }
+
+                format.startsWith(MP3.extension, ignoreCase = true) -> {
+                    TagOptionSingleton.getInstance().isWriteMp3GenresAsText = true
+                    val tag: Tag = ID3v24Tag()
+                    tag.artworkList.clear()
+                    tag
+                }
+
+                format.startsWith(FLAC.extension, ignoreCase = true) -> {
+                    val tag: Tag = FlacTag()
+                    tag.artworkList.clear()
+                    tag
+                }
+
+                format.startsWith("Aac", ignoreCase = true) -> {
+                    TagOptionSingleton.getInstance().isWriteMp4GenresAsText = true
+                    val tag: Tag = Mp4Tag()
+                    tag.artworkList.clear()
+                    tag
+                }
+
+                else -> {
+                    WavInfoTag()
+                }
+            }.also {
+                setTrackFieldsToTag(it, title, album, artist, genres, comments, trackNumber, discNumber, bpm, encoder, coverImageBytes, fileName, logger)
+            }
+
+        @SuppressWarnings("kotlin:S107")
+        private fun setTrackFieldsToTag(
+            tag: Tag,
+            title: String,
+            album: Album,
+            artist: Artist,
+            genres: Set<Genre>,
+            comments: String?,
+            trackNumber: Short?,
+            discNumber: Short?,
+            bpm: Float?,
+            encoder: String?,
+            coverImageBytes: ByteArray?,
+            fileName: String,
+            logger: KLogger
+        ) {
+            tag.setField(FieldKey.TITLE, title)
+            tag.setField(FieldKey.ALBUM, album.name)
+            tag.setField(FieldKey.ALBUM_ARTIST, album.albumArtist.name)
+            tag.setField(FieldKey.ARTIST, artist.name)
+            tag.setField(FieldKey.GENRE, Genre.joinGenres(genres))
+            tag.setField(FieldKey.COUNTRY, artist.countryCode.name)
+            comments?.let { tag.setField(FieldKey.COMMENT, it) }
+            trackNumber?.let { tag.setField(FieldKey.TRACK, it.toString()) }
+            album.year?.let { tag.setField(FieldKey.YEAR, it.toString()) }
+            encoder?.let { tag.setField(FieldKey.ENCODER, it) }
+            tag.setField(FieldKey.GROUPING, album.label.name)
+            discNumber?.let { tag.setField(FieldKey.DISC_NO, it.toString()) }
+            val compilationValue =
+                if (tag is Mp4Tag) {
+                    if (album.isCompilation) "1" else "0"
+                } else {
+                    album.isCompilation.toString()
+                }
+            tag.setField(FieldKey.IS_COMPILATION, compilationValue)
+            bpm?.let {
+                if (tag is Mp4Tag) {
+                    tag.setField(FieldKey.BPM, it.toInt().toString())
+                } else {
+                    tag.setField(FieldKey.BPM, it.toString())
+                }
+            }
+            coverImageBytes?.let {
+                tag.deleteArtworkField()
+                tag.addField(createArtwork(it, fileName, logger))
+            }
+        }
+
+        private fun createArtwork(coverBytes: ByteArray, fileName: String, logger: KLogger): Artwork {
+            var tempCover: Path? = null
             try {
-                AudioFileIO.read(path.toFile())
-            } catch (_: CannotReadException) {
-                // File is a valid audio stream but has no readable tag block (e.g. OGG without vorbiscomment).
-                // Fall back to header-only metadata so the file can still be played.
-                return emptyMetadata()
-            } catch (_: NullPointerException) {
-                // JAudioTagger's Mp4InfoReader throws NPE for unsupported M4A codecs
-                // (Opus, FLAC-in-M4A) because fields like noOfChannels are null.
-                // Fall back to empty metadata so the file can still be played.
-                return emptyMetadata()
+                tempCover = Files.createTempFile("tempCover_$fileName", ".tmp")
+                Files.write(tempCover, coverBytes, StandardOpenOption.CREATE)
+                return ArtworkFactory.createArtworkFromFile(tempCover.toFile())
+            } catch (exception: IOException) {
+                val errorText = "Error creating artwork of $fileName"
+                logger.error(errorText, exception)
+                throw AudioItemManipulationException(errorText, exception)
+            } finally {
+                tempCover?.let { runCatching { Files.deleteIfExists(it) } }
             }
-        val header = audioFile.audioHeader
-        val tag = audioFile.tag ?: return emptyMetadata(header)
-        return AudioFileMetadata(
-            bitRate = parseBitRate(header),
-            duration = Duration.ofSeconds(header.trackLength.toLong()),
-            encoder = getFieldIfExisting(tag, FieldKey.ENCODER),
-            encoding = header.encodingType,
-            title = getFieldIfExisting(tag, FieldKey.TITLE) ?: "",
-            artist = parseArtist(tag),
-            album = parseAlbum(tag),
-            genres = getFieldIfExisting(tag, FieldKey.GENRE)?.let { Genre.parseGenre(it) } ?: emptySet(),
-            comments = getFieldIfExisting(tag, FieldKey.COMMENT)?.takeIf { it.isNotEmpty() },
-            trackNumber = parseOptionalShort(getFieldIfExisting(tag, FieldKey.TRACK)),
-            discNumber = parseOptionalShort(getFieldIfExisting(tag, FieldKey.DISC_NO)),
-            bpm = parseOptionalBpm(getFieldIfExisting(tag, FieldKey.BPM)),
-            coverBytes = parseCoverBytes(tag)
-        )
-    }
-
-    private fun emptyMetadata(header: AudioHeader? = null): AudioFileMetadata =
-        AudioFileMetadata(
-            bitRate = header?.let(::parseBitRate) ?: 0,
-            duration = header?.let { Duration.ofSeconds(it.trackLength.toLong()) } ?: Duration.ZERO,
-            encoder = null,
-            encoding = header?.encodingType,
-            title = "",
-            artist = ImmutableArtist.UNKNOWN,
-            album = ImmutableAlbum.UNKNOWN,
-            genres = emptySet(),
-            comments = null,
-            trackNumber = null,
-            discNumber = null,
-            bpm = null,
-            coverBytes = null
-        )
-
-    /**
-     * Reads the cover image bytes from the audio file at [path], or returns `null` if the file
-     * has no artwork or cannot be read.
-     */
-    fun readCoverBytes(path: Path): ByteArray? {
-        val file = path.toFile()
-        if (!file.exists() || !file.canRead()) return null
-        return runCatching { AudioFileIO.read(file).tag }
-            .getOrNull()
-            ?.let(::parseCoverBytes)
-    }
-
-    /**
-     * Writes metadata to the audio file at [path], creating the appropriate tag format and
-     * committing changes to disk.
-     *
-     * @param logger caller's logger for artwork error reporting
-     * @param fileName caller's file name for temp file naming during artwork creation
-     */
-    @SuppressWarnings("kotlin:S107") // Audio metadata requires all tag fields as parameters; splitting would obscure the mapping
-    fun writeMetadataToFile(
-        path: Path,
-        title: String,
-        album: Album,
-        artist: Artist,
-        genres: Set<Genre>,
-        comments: String?,
-        trackNumber: Short?,
-        discNumber: Short?,
-        bpm: Float?,
-        encoder: String?,
-        coverImageBytes: ByteArray?,
-        fileName: String,
-        logger: KLogger
-    ) {
-        val audio = AudioFileIO.read(path.toFile())
-        createTag(
-            audio.audioHeader.format, title, album, artist, genres,
-            comments, trackNumber, discNumber, bpm, encoder,
-            coverImageBytes, fileName, logger
-        ).let {
-            audio.tag = it
-        }
-        audio.commit()
-    }
-
-    // getFirst returns "" for missing fields, but throws UnsupportedOperationException for some tag/field
-    // combinations (e.g. WavTag + COUNTRY). Treat both as "field not present".
-    private fun getFieldIfExisting(tag: Tag, fieldKey: FieldKey): String? =
-        runCatching { tag.getFirst(fieldKey) }.getOrNull()
-
-    private fun parseArtist(tag: Tag): Artist =
-        getFieldIfExisting(tag, FieldKey.ARTIST)?.let { artistName ->
-            val country =
-                getFieldIfExisting(tag, FieldKey.COUNTRY)
-                    ?.let { CountryCode.getByCode(it) ?: CountryCode.UNDEFINED }
-                    ?: CountryCode.UNDEFINED
-            ImmutableArtist.of(AudioUtils.beautifyArtistName(artistName), country)
-        } ?: ImmutableArtist.UNKNOWN
-
-    private fun parseAlbum(tag: Tag): ImmutableAlbum =
-        getFieldIfExisting(tag, FieldKey.ALBUM).let { albumName ->
-            return if (albumName == null) {
-                ImmutableAlbum.UNKNOWN
-            } else {
-                val albumArtistName = getFieldIfExisting(tag, FieldKey.ALBUM_ARTIST) ?: ""
-                val isCompilation =
-                    getFieldIfExisting(tag, FieldKey.IS_COMPILATION)?.let {
-                        if (tag is Mp4Tag)
-                            it == "1"
-                        else
-                            it == "true"
-                    } ?: false
-                val year = getFieldIfExisting(tag, FieldKey.YEAR)?.toShortOrNull()?.takeIf { it > 0 }
-                val label = getFieldIfExisting(tag, FieldKey.GROUPING)?.let { ImmutableLabel.of(it) } ?: ImmutableLabel.UNKNOWN
-                ImmutableAlbum(albumName, ImmutableArtist.of(AudioUtils.beautifyArtistName(albumArtistName)), isCompilation, year, label)
-            }
-        }
-
-    private fun parseBitRate(audioHeader: AudioHeader): Int {
-        val bitRate = audioHeader.bitRate
-        return if ("~" == bitRate.substring(0, 1)) {
-            bitRate.substring(1).toInt()
-        } else {
-            bitRate.toInt()
         }
     }
-
-    private fun parseCoverBytes(tag: Tag): ByteArray? = tag.artworkList.isNotEmpty().takeIf { it }?.let { tag.firstArtwork.binaryData }
-
-    private fun parseOptionalShort(value: String?): Short? =
-        value?.takeUnless { it.isEmpty() || it == "0" }?.toShortOrNull()?.takeIf { it > 0 }
-
-    private fun parseOptionalBpm(value: String?): Float? =
-        value?.takeUnless { it.isEmpty() || it == "0" }?.toFloatOrNull()?.takeIf { it > 0 }
-
-    @SuppressWarnings("kotlin:S107")
-    private fun createTag(
-        format: String,
-        title: String,
-        album: Album,
-        artist: Artist,
-        genres: Set<Genre>,
-        comments: String?,
-        trackNumber: Short?,
-        discNumber: Short?,
-        bpm: Float?,
-        encoder: String?,
-        coverImageBytes: ByteArray?,
-        fileName: String,
-        logger: KLogger
-    ): Tag =
-        when {
-            format.startsWith(WAV.extension, ignoreCase = true) -> {
-                val wavTag = WavTag(WavOptions.READ_ID3_ONLY)
-                wavTag.iD3Tag = ID3v24Tag()
-                wavTag.infoTag = WavInfoTag()
-                wavTag
-            }
-
-            format.startsWith(MP3.extension, ignoreCase = true) -> {
-                TagOptionSingleton.getInstance().isWriteMp3GenresAsText = true
-                val tag: Tag = ID3v24Tag()
-                tag.artworkList.clear()
-                tag
-            }
-
-            format.startsWith(FLAC.extension, ignoreCase = true) -> {
-                val tag: Tag = FlacTag()
-                tag.artworkList.clear()
-                tag
-            }
-
-            format.startsWith("Aac", ignoreCase = true) -> {
-                TagOptionSingleton.getInstance().isWriteMp4GenresAsText = true
-                val tag: Tag = Mp4Tag()
-                tag.artworkList.clear()
-                tag
-            }
-
-            else -> {
-                WavInfoTag()
-            }
-        }.also {
-            setTrackFieldsToTag(it, title, album, artist, genres, comments, trackNumber, discNumber, bpm, encoder, coverImageBytes, fileName, logger)
-        }
-
-    @SuppressWarnings("kotlin:S107")
-    private fun setTrackFieldsToTag(
-        tag: Tag,
-        title: String,
-        album: Album,
-        artist: Artist,
-        genres: Set<Genre>,
-        comments: String?,
-        trackNumber: Short?,
-        discNumber: Short?,
-        bpm: Float?,
-        encoder: String?,
-        coverImageBytes: ByteArray?,
-        fileName: String,
-        logger: KLogger
-    ) {
-        tag.setField(FieldKey.TITLE, title)
-        tag.setField(FieldKey.ALBUM, album.name)
-        tag.setField(FieldKey.ALBUM_ARTIST, album.albumArtist.name)
-        tag.setField(FieldKey.ARTIST, artist.name)
-        tag.setField(FieldKey.GENRE, Genre.joinGenres(genres))
-        tag.setField(FieldKey.COUNTRY, artist.countryCode.name)
-        comments?.let { tag.setField(FieldKey.COMMENT, it) }
-        trackNumber?.let { tag.setField(FieldKey.TRACK, it.toString()) }
-        album.year?.let { tag.setField(FieldKey.YEAR, it.toString()) }
-        encoder?.let { tag.setField(FieldKey.ENCODER, it) }
-        tag.setField(FieldKey.GROUPING, album.label.name)
-        discNumber?.let { tag.setField(FieldKey.DISC_NO, it.toString()) }
-        val compilationValue =
-            if (tag is Mp4Tag) {
-                if (album.isCompilation) "1" else "0"
-            } else {
-                album.isCompilation.toString()
-            }
-        tag.setField(FieldKey.IS_COMPILATION, compilationValue)
-        bpm?.let {
-            if (tag is Mp4Tag) {
-                tag.setField(FieldKey.BPM, it.toInt().toString())
-            } else {
-                tag.setField(FieldKey.BPM, it.toString())
-            }
-        }
-        coverImageBytes?.let {
-            tag.deleteArtworkField()
-            tag.addField(createArtwork(it, fileName, logger))
-        }
-    }
-
-    private fun createArtwork(coverBytes: ByteArray, fileName: String, logger: KLogger): Artwork {
-        var tempCover: Path? = null
-        try {
-            tempCover = Files.createTempFile("tempCover_$fileName", ".tmp")
-            Files.write(tempCover, coverBytes, StandardOpenOption.CREATE)
-            return ArtworkFactory.createArtworkFromFile(tempCover.toFile())
-        } catch (exception: IOException) {
-            val errorText = "Error creating artwork of $fileName"
-            logger.error(errorText, exception)
-            throw AudioItemManipulationException(errorText, exception)
-        } finally {
-            tempCover?.let { runCatching { Files.deleteIfExists(it) } }
-        }
-    }
-}

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/AudioItemSerializer.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/AudioItemSerializer.kt
@@ -20,6 +20,8 @@ package net.transgressoft.commons.music.audio
 import net.transgressoft.commons.music.common.toPathFromJsonUri
 import net.transgressoft.lirp.persistence.json.LirpEntityPolymorphicSerializer
 import com.neovisionaries.i18n.CountryCode
+import java.nio.file.FileSystem
+import java.nio.file.FileSystems
 import java.nio.file.Path
 import java.time.Duration
 import java.time.LocalDateTime
@@ -48,7 +50,7 @@ import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.long
 
 @get:JvmName("AudioItemMapSerializer")
-internal val AudioItemMapSerializer: KSerializer<Map<Int, AudioItem>> = MapSerializer(Int.serializer(), AudioItemSerializer)
+internal val AudioItemMapSerializer: KSerializer<Map<Int, AudioItem>> = MapSerializer(Int.serializer(), AudioItemSerializer())
 
 /**
  * Kotlinx serialization serializer for [AudioItem] instances.
@@ -56,36 +58,46 @@ internal val AudioItemMapSerializer: KSerializer<Map<Int, AudioItem>> = MapSeria
  * Handles JSON serialization and deserialization of audio items, preserving all metadata
  * fields including artist, album, and label information. Creates [MutableAudioItem]
  * instances during deserialization to enable metadata modification.
+ *
+ * @param fileSystem the [FileSystem] used to materialize [Path] instances during
+ *  deserialization. Defaults to [FileSystems.getDefault]; tests may pass a Jimfs
+ *  filesystem to deserialize against an in-memory tree.
  */
-internal object AudioItemSerializer : AudioItemSerializerBase<AudioItem>() {
+internal class AudioItemSerializer
+    @JvmOverloads
+    constructor(
+        fileSystem: FileSystem = FileSystems.getDefault()
+    ) : AudioItemSerializerBase<AudioItem>(fileSystem) {
 
-    override fun constructEntity(
-        path: Path,
-        id: Int,
-        title: String,
-        duration: Duration,
-        bitRate: Int,
-        artist: Artist,
-        album: Album,
-        genres: Set<Genre>,
-        comments: String?,
-        trackNumber: Short?,
-        discNumber: Short?,
-        bpm: Float?,
-        encoder: String?,
-        encoding: String?,
-        dateOfCreation: LocalDateTime,
-        lastDateModified: LocalDateTime,
-        playCount: Short
-    ): AudioItem =
-        MutableAudioItem(
-            path, id, title, duration, bitRate, artist, album, genres,
-            comments, trackNumber, discNumber, bpm, encoder, encoding,
-            dateOfCreation, lastDateModified, playCount
-        )
-}
+        override fun constructEntity(
+            path: Path,
+            id: Int,
+            title: String,
+            duration: Duration,
+            bitRate: Int,
+            artist: Artist,
+            album: Album,
+            genres: Set<Genre>,
+            comments: String?,
+            trackNumber: Short?,
+            discNumber: Short?,
+            bpm: Float?,
+            encoder: String?,
+            encoding: String?,
+            dateOfCreation: LocalDateTime,
+            lastDateModified: LocalDateTime,
+            playCount: Short
+        ): AudioItem =
+            MutableAudioItem(
+                path, id, title, duration, bitRate, artist, album, genres,
+                comments, trackNumber, discNumber, bpm, encoder, encoding,
+                dateOfCreation, lastDateModified, playCount
+            )
+    }
 
-abstract class AudioItemSerializerBase<I : ReactiveAudioItem<I>> : LirpEntityPolymorphicSerializer<I> {
+abstract class AudioItemSerializerBase<I : ReactiveAudioItem<I>>(
+    private val fileSystem: FileSystem = FileSystems.getDefault()
+) : LirpEntityPolymorphicSerializer<I> {
 
     // This serializer is JSON-only: deserialize() reads fields by name via JsonDecoder,
     // so the descriptor serves as a schema identity marker, not for positional decoding.
@@ -149,7 +161,13 @@ abstract class AudioItemSerializerBase<I : ReactiveAudioItem<I>> : LirpEntityPol
             obj[key]?.jsonPrimitive?.contentOrNull
                 ?: throw SerializationException("Missing required field '$fullKey' in AudioItem JSON")
 
-        val path = requireString(json, "path").toPathFromJsonUri()
+        val pathString = requireString(json, "path")
+        val path =
+            if (fileSystem == FileSystems.getDefault()) {
+                pathString.toPathFromJsonUri()
+            } else {
+                pathString.toPathFromJsonUri(fileSystem)
+            }
         val id = require("id").jsonPrimitive.int
         val title = requireString(json, "title")
         val duration = Duration.ofSeconds(require("duration").jsonPrimitive.long)

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/DefaultAudioLibrary.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/DefaultAudioLibrary.kt
@@ -40,44 +40,49 @@ import kotlinx.serialization.modules.subclass
  * lazily through the context. Deregisters on [close] to support repeated construction within the same JVM.
  */
 @LirpRepository
-internal class DefaultAudioLibrary(repository: Repository<Int, AudioItem>) :
-    AudioLibraryBase<AudioItem, ArtistCatalog<AudioItem>>(repository, DefaultArtistCatalogRegistry()),
-    AudioLibrary {
-    private val logger = KotlinLogging.logger {}
+internal class DefaultAudioLibrary
+    @JvmOverloads
+    constructor(
+        repository: Repository<Int, AudioItem>,
+        private val metadataUtils: AudioItemMetadataUtils = AudioItemMetadataUtils()
+    ) : AudioLibraryBase<AudioItem, ArtistCatalog<AudioItem>>(repository, DefaultArtistCatalogRegistry()),
+        AudioLibrary {
+        private val logger = KotlinLogging.logger {}
 
-    init {
-        RegistryBase.deregisterRepository(AudioItem::class.java)
-        RegistryBase.registerRepository(AudioItem::class.java, repository)
-        playerSubscriber.addOnNextEventAction(PLAYED) { event ->
-            val audioItem = event.audioItem
-            logger.info { "Audio item with id ${audioItem.id} was played" }
-            if (audioItem is MutableAudioItem) {
-                val audioItemClone = audioItem.clone()
-                audioItem.incrementPlayCount()
-                repository.emitAsync(Update(audioItem, audioItemClone))
-                logger.debug { "Play count for audio item ${audioItem.id} increased to ${audioItem.playCount}" }
+        init {
+            RegistryBase.deregisterRepository(AudioItem::class.java)
+            RegistryBase.registerRepository(AudioItem::class.java, repository)
+            playerSubscriber.addOnNextEventAction(PLAYED) { event ->
+                val audioItem = event.audioItem
+                logger.info { "Audio item with id ${audioItem.id} was played" }
+                if (audioItem is MutableAudioItem) {
+                    val audioItemClone = audioItem.clone()
+                    audioItem.incrementPlayCount()
+                    repository.emitAsync(Update(audioItem, audioItemClone))
+                    logger.debug { "Play count for audio item ${audioItem.id} increased to ${audioItem.playCount}" }
+                }
             }
         }
+
+        override fun createFromFile(audioItemPath: Path): AudioItem =
+            MutableAudioItem(audioItemPath, newId(), metadataUtils)
+                .also { audioItem ->
+                    add(audioItem)
+                    logger.debug { "New AudioItem was created from file $audioItemPath with id ${audioItem.id}" }
+                }
+
+        override fun close() {
+            super.close()
+            RegistryBase.deregisterRepository(AudioItem::class.java)
+        }
+
+        override fun toString() = "AudioItemJsonRepository(audioItemsCount=${size()})"
     }
-
-    override fun createFromFile(audioItemPath: Path): AudioItem =
-        MutableAudioItem(audioItemPath, newId())
-            .also { audioItem ->
-                add(audioItem)
-                logger.debug { "New AudioItem was created from file $audioItemPath with id ${audioItem.id}" }
-            }
-
-    override fun close() {
-        super.close()
-        RegistryBase.deregisterRepository(AudioItem::class.java)
-    }
-
-    override fun toString() = "AudioItemJsonRepository(audioItemsCount=${size()})"
-}
 
 @get:JvmName("audioItemSerializerModule")
 internal val audioItemSerializerModule =
     SerializersModule {
+        polymorphic(AudioItem::class, AudioItemSerializer())
         polymorphic(Artist::class) {
             subclass(ImmutableArtist.serializer())
         }

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/DefaultAudioMetadataIO.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/DefaultAudioMetadataIO.kt
@@ -1,0 +1,80 @@
+/******************************************************************************
+ * Copyright (C) 2025  Octavio Calleya Garcia                                 *
+ *                                                                            *
+ * This program is free software: you can redistribute it and/or modify       *
+ * it under the terms of the GNU General Public License as published by       *
+ * the Free Software Foundation, either version 3 of the License, or          *
+ * (at your option) any later version.                                        *
+ *                                                                            *
+ * This program is distributed in the hope that it will be useful,            *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
+ * GNU General Public License for more details.                               *
+ *                                                                            *
+ * You should have received a copy of the GNU General Public License          *
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.     *
+ ******************************************************************************/
+
+package net.transgressoft.commons.music.audio
+
+import org.jaudiotagger.audio.AudioFileIO
+import org.jaudiotagger.tag.Tag
+import java.nio.file.FileSystems
+import java.nio.file.Path
+
+/**
+ * Production [AudioMetadataIO] backed by JAudioTagger's [AudioFileIO].
+ *
+ * Fails fast when handed a [Path] from a non-default filesystem provider (e.g. Jimfs):
+ * JAudioTagger reads through `java.io.File`, and non-default-FS paths throw
+ * `UnsupportedOperationException` from `path.toFile()`. Tests that need to operate
+ * against an in-memory filesystem must inject [FakeAudioMetadataIO] instead — the
+ * guard makes the mismatch surface with a helpful message rather than the cryptic
+ * upstream exception.
+ */
+internal class DefaultAudioMetadataIO : AudioMetadataIO {
+
+    override fun readTag(path: Path): Tag {
+        requireDefaultFileSystem(path)
+        return AudioFileIO.read(path.toFile()).tag
+    }
+
+    override fun readHeaderInfo(path: Path): HeaderInfo {
+        requireDefaultFileSystem(path)
+        val header = AudioFileIO.read(path.toFile()).audioHeader
+        return HeaderInfo(
+            encodingType = header.encodingType,
+            bitRate = parseBitRate(header.bitRate),
+            trackLengthSeconds = header.trackLength.toLong(),
+            format = header.format
+        )
+    }
+
+    override fun readCoverBytes(path: Path): ByteArray? {
+        requireDefaultFileSystem(path)
+        val file = path.toFile()
+        if (!file.exists() || !file.canRead()) return null
+        return runCatching { AudioFileIO.read(file).tag }
+            .getOrNull()
+            ?.let { tag ->
+                if (tag.artworkList.isNotEmpty()) tag.firstArtwork.binaryData else null
+            }
+    }
+
+    override fun writeTag(path: Path, tag: Tag) {
+        requireDefaultFileSystem(path)
+        val audioFile = AudioFileIO.read(path.toFile())
+        audioFile.tag = tag
+        audioFile.commit()
+    }
+
+    private fun requireDefaultFileSystem(path: Path) {
+        require(path.fileSystem == FileSystems.getDefault()) {
+            "DefaultAudioMetadataIO does not support non-default filesystems (got ${path.fileSystem}). " +
+                "Use FakeAudioMetadataIO for Jimfs paths."
+        }
+    }
+
+    private fun parseBitRate(bitRate: String): Int =
+        if (bitRate.startsWith("~")) bitRate.substring(1).toInt() else bitRate.toInt()
+}

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/MutableAudioItem.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/MutableAudioItem.kt
@@ -19,8 +19,6 @@ package net.transgressoft.commons.music.audio
 
 import net.transgressoft.commons.music.AudioUtils.audioItemTrackDiscNumberComparator
 import net.transgressoft.commons.music.AudioUtils.getArtistsNamesInvolved
-import net.transgressoft.commons.music.audio.AudioItemMetadataUtils.readMetadata
-import net.transgressoft.commons.music.audio.AudioItemMetadataUtils.writeMetadataToFile
 import net.transgressoft.commons.music.common.WindowsPathValidator
 import net.transgressoft.lirp.entity.ReactiveEntityBase
 import mu.KotlinLogging
@@ -41,6 +39,36 @@ import kotlinx.serialization.Transient
 
 const val UNASSIGNED_ID = 0
 
+// MutableAudioItem's primary constructor reads file metadata up-front to populate `metadata` and
+// derived properties. The secondary deserialization constructor overwrites those fields immediately
+// after, making the up-front read redundant on the deserialization path. However the primary still
+// has to produce *some* metadata object, and when called via the secondary path with a non-default
+// filesystem (e.g. Jimfs deserialization through AudioItemSerializer(fileSystem)) the default
+// AudioMetadataIO impl rejects the path with IllegalArgumentException. Swallow that one specific
+// failure so deserialization succeeds; the secondary constructor will overwrite the fields with
+// the values from JSON. Other failures (CannotReadException, NPE) are already handled inside
+// AudioItemMetadataUtils.readMetadata.
+private fun readMetadataSafely(metadataUtils: AudioItemMetadataUtils, path: Path) =
+    try {
+        metadataUtils.readMetadata(path)
+    } catch (_: IllegalArgumentException) {
+        AudioFileMetadata(
+            bitRate = 0,
+            duration = java.time.Duration.ZERO,
+            encoder = null,
+            encoding = null,
+            title = "",
+            artist = ImmutableArtist.UNKNOWN,
+            album = ImmutableAlbum.UNKNOWN,
+            genres = emptySet(),
+            comments = null,
+            trackNumber = null,
+            discNumber = null,
+            bpm = null,
+            coverBytes = null
+        )
+    }
+
 /**
  * Marker interface representing a concrete audio item implementation.
  *
@@ -51,6 +79,10 @@ interface AudioItem : ReactiveAudioItem<AudioItem> {
 
     override fun clone(): AudioItem
 }
+
+// Serializer is wired via `audioItemSerializerModule` polymorphic registration (see DefaultAudioLibrary).
+// The serializer is a stateful class (AudioItemSerializer(FileSystem)) so it cannot be referenced as a
+// bare `@Serializable(with = ...)` target — kotlinx-serialization requires KSerializer-typed ctor params.
 
 /**
  * Mutable implementation of [AudioItem] that reads and writes audio file metadata.
@@ -65,237 +97,239 @@ interface AudioItem : ReactiveAudioItem<AudioItem> {
  *
  * @see <a href=https://www.jthink.net/jaudiotagger/>JAudioTagger website</a>
  */
-@Suppress("SERIALIZER_TYPE_INCOMPATIBLE") // Serializer handles polymorphic AudioItem hierarchy; declared type intentionally broader than serializer target
-@Serializable(with = AudioItemSerializer::class)
-internal class MutableAudioItem(
-    override val path: Path,
-    override val id: Int = UNASSIGNED_ID
-) : AudioItem, ReactiveEntityBase<Int, AudioItem>() {
+internal class MutableAudioItem
+    @JvmOverloads
+    constructor(
+        override val path: Path,
+        override val id: Int = UNASSIGNED_ID,
+        private val metadataUtils: AudioItemMetadataUtils = AudioItemMetadataUtils()
+    ) : AudioItem, ReactiveEntityBase<Int, AudioItem>() {
 
-    @Transient
-    private val logger = KotlinLogging.logger {}
+        @Transient
+        private val logger = KotlinLogging.logger {}
 
-    private val ioScope =
-        CoroutineScope(
-            Dispatchers.IO + SupervisorJob() +
-                CoroutineExceptionHandler { _, exception ->
-                    val errorText = "Error writing metadata of $this"
-                    logger.error(errorText, exception)
+        private val ioScope =
+            CoroutineScope(
+                Dispatchers.IO + SupervisorJob() +
+                    CoroutineExceptionHandler { _, exception ->
+                        val errorText = "Error writing metadata of $this"
+                        logger.error(errorText, exception)
+                    }
+            )
+
+        // Constructor for deserialization & iTunes import
+        internal constructor(
+            path: Path,
+            id: Int,
+            title: String,
+            duration: Duration,
+            bitRate: Int,
+            artist: Artist,
+            album: Album,
+            genres: Set<Genre>,
+            comments: String?,
+            trackNumber: Short?,
+            discNumber: Short?,
+            bpm: Float?,
+            encoder: String?,
+            encoding: String?,
+            dateOfCreation: LocalDateTime,
+            lastDateModified: LocalDateTime,
+            playCount: Short,
+            metadataUtils: AudioItemMetadataUtils = AudioItemMetadataUtils()
+        ) : this(path, id, metadataUtils) {
+            disableEvents()
+            this.title = title
+            this._duration = duration
+            this.artist = artist
+            this.genres = genres
+            this.comments = comments
+            this.trackNumber = trackNumber
+            this.discNumber = discNumber
+            this.bpm = bpm
+            this.album = album
+            this._bitRate = bitRate
+            this._encoder = encoder
+            this._encoding = encoding
+            this._dateOfCreation = dateOfCreation
+            this.lastDateModified = lastDateModified
+            this._playCount = playCount
+            enableEvents()
+        }
+
+        init {
+            WindowsPathValidator.validatePath(path)
+            if (!Files.exists(path)) {
+                throw InvalidAudioFilePathException("File '${path.toAbsolutePath()}' does not exist")
+            }
+            if (!Files.isRegularFile(path)) {
+                throw InvalidAudioFilePathException("Path '${path.toAbsolutePath()}' is not a regular file")
+            }
+            if (!Files.isReadable(path)) {
+                throw InvalidAudioFilePathException("File '${path.toAbsolutePath()}' is not readable")
+            }
+        }
+
+        @Transient
+        private val metadata = readMetadataSafely(metadataUtils, path)
+
+        private var _bitRate: Int = metadata.bitRate
+
+        @Serializable
+        override val bitRate: Int
+            get() = _bitRate
+
+        private var _duration: Duration = metadata.duration
+
+        @Serializable
+        override val duration: Duration
+            get() = _duration
+
+        private var _encoder: String? = metadata.encoder?.takeIf { it.isNotEmpty() }
+
+        @Serializable
+        override val encoder: String?
+            get() = _encoder
+
+        private var _encoding: String? = metadata.encoding?.takeIf { it.isNotEmpty() }
+
+        @Serializable
+        override val encoding: String?
+            get() = _encoding
+
+        private var _dateOfCreation: LocalDateTime = LocalDateTime.now()
+
+        @Serializable
+        override val dateOfCreation: LocalDateTime
+            get() = _dateOfCreation
+
+        @Serializable
+        override var lastDateModified: LocalDateTime = _dateOfCreation
+
+        private var _playCount: Short by reactiveProperty(0.toShort())
+
+        @Serializable
+        override val playCount: Short
+            get() = _playCount
+
+        override val fileName by lazy {
+            path.fileName.toString()
+        }
+
+        override val extension by lazy {
+            path.extension
+        }
+
+        override val artistsInvolved
+            get() = getArtistsNamesInvolved(title, artist.name, album.albumArtist.name).map { ImmutableArtist.of(it) }.toSet()
+
+        override val length by lazy {
+            Files.size(path)
+        }
+
+        override val uniqueId
+            get() =
+                buildString {
+                    append(path.fileName.toString().replace(' ', '_'))
+                    append("-$title")
+                    append("-${duration.toSeconds()}")
+                    append("-$bitRate")
                 }
-        )
 
-    // Constructor for deserialization & iTunes import
-    internal constructor(
-        path: Path,
-        id: Int,
-        title: String,
-        duration: Duration,
-        bitRate: Int,
-        artist: Artist,
-        album: Album,
-        genres: Set<Genre>,
-        comments: String?,
-        trackNumber: Short?,
-        discNumber: Short?,
-        bpm: Float?,
-        encoder: String?,
-        encoding: String?,
-        dateOfCreation: LocalDateTime,
-        lastDateModified: LocalDateTime,
-        playCount: Short
-    ) : this(path, id) {
-        disableEvents()
-        this.title = title
-        this._duration = duration
-        this.artist = artist
-        this.genres = genres
-        this.comments = comments
-        this.trackNumber = trackNumber
-        this.discNumber = discNumber
-        this.bpm = bpm
-        this.album = album
-        this._bitRate = bitRate
-        this._encoder = encoder
-        this._encoding = encoding
-        this._dateOfCreation = dateOfCreation
-        this.lastDateModified = lastDateModified
-        this._playCount = playCount
-        enableEvents()
-    }
+        /** Mutable properties */
 
-    init {
-        WindowsPathValidator.validatePath(path)
-        if (!Files.exists(path)) {
-            throw InvalidAudioFilePathException("File '${path.toAbsolutePath()}' does not exist")
-        }
-        if (!Files.isRegularFile(path)) {
-            throw InvalidAudioFilePathException("Path '${path.toAbsolutePath()}' is not a regular file")
-        }
-        if (!Files.isReadable(path)) {
-            throw InvalidAudioFilePathException("File '${path.toAbsolutePath()}' is not readable")
-        }
-    }
+        @Serializable
+        override var title: String by reactiveProperty(metadata.title)
 
-    @Transient
-    private val metadata = readMetadata(path)
+        @Serializable
+        override var artist: Artist by reactiveProperty(metadata.artist)
 
-    private var _bitRate: Int = metadata.bitRate
+        @Serializable
+        override var genres: Set<Genre> by reactiveProperty(metadata.genres)
 
-    @Serializable
-    override val bitRate: Int
-        get() = _bitRate
+        @Transient
+        private var _comments: String? = metadata.comments
 
-    private var _duration: Duration = metadata.duration
+        @Serializable
+        override var comments: String?
+            by reactiveProperty(
+                getter = { _comments },
+                setter = { _comments = it?.takeIf { s -> s.isNotEmpty() } }
+            )
 
-    @Serializable
-    override val duration: Duration
-        get() = _duration
+        @Serializable
+        override var trackNumber: Short? by reactiveProperty(metadata.trackNumber)
 
-    private var _encoder: String? = metadata.encoder?.takeIf { it.isNotEmpty() }
+        @Serializable
+        override var discNumber: Short? by reactiveProperty(metadata.discNumber)
 
-    @Serializable
-    override val encoder: String?
-        get() = _encoder
+        @Serializable
+        override var bpm: Float? by reactiveProperty(metadata.bpm)
 
-    private var _encoding: String? = metadata.encoding?.takeIf { it.isNotEmpty() }
+        @Serializable
+        override var album: Album by reactiveProperty(metadata.album)
 
-    @Serializable
-    override val encoding: String?
-        get() = _encoding
+        @Transient
+        private var _coverImageBytes: ByteArray? = metadata.coverBytes?.copyOf()
 
-    private var _dateOfCreation: LocalDateTime = LocalDateTime.now()
+        @Transient
+        override var coverImageBytes: ByteArray?
+            by reactiveProperty(
+                getter = { _coverImageBytes?.copyOf() },
+                setter = { _coverImageBytes = it?.copyOf() }
+            )
 
-    @Serializable
-    override val dateOfCreation: LocalDateTime
-        get() = _dateOfCreation
-
-    @Serializable
-    override var lastDateModified: LocalDateTime = _dateOfCreation
-
-    private var _playCount: Short by reactiveProperty(0.toShort())
-
-    @Serializable
-    override val playCount: Short
-        get() = _playCount
-
-    override val fileName by lazy {
-        path.fileName.toString()
-    }
-
-    override val extension by lazy {
-        path.extension
-    }
-
-    override val artistsInvolved
-        get() = getArtistsNamesInvolved(title, artist.name, album.albumArtist.name).map { ImmutableArtist.of(it) }.toSet()
-
-    override val length by lazy {
-        path.toFile().length()
-    }
-
-    override val uniqueId
-        get() =
-            buildString {
-                append(path.fileName.toString().replace(' ', '_'))
-                append("-$title")
-                append("-${duration.toSeconds()}")
-                append("-$bitRate")
+        /**
+         * Asynchronously writes the current metadata back to the audio file.
+         *
+         * Creates the appropriate tag format based on the file type and commits changes to disk.
+         * Errors during writing are logged but do not throw exceptions to prevent
+         * disrupting the application flow, especially during batch, background operations.
+         */
+        override fun writeMetadata(): Job =
+            ioScope.launch {
+                logger.debug { "Writing metadata of $this to file '${path.toAbsolutePath()}'" }
+                metadataUtils.writeMetadataToFile(
+                    path, title, album, artist, genres,
+                    comments, trackNumber, discNumber, bpm, encoder,
+                    coverImageBytes, fileName, logger
+                )
+                logger.debug { "Metadata of $this successfully written to file" }
             }
 
-    /** Mutable properties */
+        internal fun incrementPlayCount() = _playCount++
 
-    @Serializable
-    override var title: String by reactiveProperty(metadata.title)
-
-    @Serializable
-    override var artist: Artist by reactiveProperty(metadata.artist)
-
-    @Serializable
-    override var genres: Set<Genre> by reactiveProperty(metadata.genres)
-
-    @Transient
-    private var _comments: String? = metadata.comments
-
-    @Serializable
-    override var comments: String?
-        by reactiveProperty(
-            getter = { _comments },
-            setter = { _comments = it?.takeIf { s -> s.isNotEmpty() } }
-        )
-
-    @Serializable
-    override var trackNumber: Short? by reactiveProperty(metadata.trackNumber)
-
-    @Serializable
-    override var discNumber: Short? by reactiveProperty(metadata.discNumber)
-
-    @Serializable
-    override var bpm: Float? by reactiveProperty(metadata.bpm)
-
-    @Serializable
-    override var album: Album by reactiveProperty(metadata.album)
-
-    @Transient
-    private var _coverImageBytes: ByteArray? = metadata.coverBytes?.copyOf()
-
-    @Transient
-    override var coverImageBytes: ByteArray?
-        by reactiveProperty(
-            getter = { _coverImageBytes?.copyOf() },
-            setter = { _coverImageBytes = it?.copyOf() }
-        )
-
-    /**
-     * Asynchronously writes the current metadata back to the audio file.
-     *
-     * Creates the appropriate tag format based on the file type and commits changes to disk.
-     * Errors during writing are logged but do not throw exceptions to prevent
-     * disrupting the application flow, especially during batch, background operations.
-     */
-    override fun writeMetadata(): Job =
-        ioScope.launch {
-            logger.debug { "Writing metadata of $this to file '${path.toAbsolutePath()}'" }
-            writeMetadataToFile(
-                path, title, album, artist, genres,
-                comments, trackNumber, discNumber, bpm, encoder,
-                coverImageBytes, fileName, logger
-            )
-            logger.debug { "Metadata of $this successfully written to file" }
+        override fun setPlayCount(count: Short) {
+            require(count >= 0) { "Play count cannot be negative" }
+            withEventsDisabled { _playCount = count }
         }
 
-    internal fun incrementPlayCount() = _playCount++
+        override operator fun compareTo(other: AudioItem) = audioItemTrackDiscNumberComparator<AudioItem>().compare(this, other)
 
-    override fun setPlayCount(count: Short) {
-        require(count >= 0) { "Play count cannot be negative" }
-        withEventsDisabled { _playCount = count }
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other == null || javaClass != other.javaClass) return false
+            val that = other as MutableAudioItem
+            return trackNumber == that.trackNumber &&
+                discNumber == that.discNumber &&
+                bpm == that.bpm &&
+                path == that.path &&
+                title == that.title &&
+                artist == that.artist &&
+                album == that.album &&
+                genres == that.genres &&
+                comments == that.comments &&
+                duration == that.duration
+        }
+
+        override fun hashCode() = Objects.hash(path, title, artist, album, genres, comments, trackNumber, discNumber, bpm, duration)
+
+        override fun clone(): MutableAudioItem =
+            MutableAudioItem(
+                path, id, title, duration, bitRate, artist, album, genres,
+                comments, trackNumber, discNumber, bpm, encoder, encoding,
+                dateOfCreation, lastDateModified, _playCount, metadataUtils
+            )
+
+        override fun toString() = "AudioItem(id=$id, path=$path, title=$title, artist=${artist.name})"
     }
-
-    override operator fun compareTo(other: AudioItem) = audioItemTrackDiscNumberComparator<AudioItem>().compare(this, other)
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other == null || javaClass != other.javaClass) return false
-        val that = other as MutableAudioItem
-        return trackNumber == that.trackNumber &&
-            discNumber == that.discNumber &&
-            bpm == that.bpm &&
-            path == that.path &&
-            title == that.title &&
-            artist == that.artist &&
-            album == that.album &&
-            genres == that.genres &&
-            comments == that.comments &&
-            duration == that.duration
-    }
-
-    override fun hashCode() = Objects.hash(path, title, artist, album, genres, comments, trackNumber, discNumber, bpm, duration)
-
-    override fun clone(): MutableAudioItem =
-        MutableAudioItem(
-            path, id, title, duration, bitRate, artist, album, genres,
-            comments, trackNumber, discNumber, bpm, encoder, encoding,
-            dateOfCreation, lastDateModified, _playCount
-        )
-
-    override fun toString() = "AudioItem(id=$id, path=$path, title=$title, artist=${artist.name})"
-}

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/itunes/ItunesImportService.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/itunes/ItunesImportService.kt
@@ -20,6 +20,7 @@ import java.nio.file.FileSystem
 import java.nio.file.FileSystems
 import java.nio.file.Files
 import java.nio.file.Path
+import java.nio.file.Paths
 import java.text.Normalizer
 import java.util.concurrent.CompletableFuture
 import kotlin.io.path.extension
@@ -223,7 +224,17 @@ class ItunesImportService<I, P>
 
     private fun resolveTrackPath(track: ItunesTrack): Path {
         val uri = URI(track.location)
-        val rawPath = fileSystem.getPath(uri.path)
+        val rawPath =
+            if (fileSystem == FileSystems.getDefault()) {
+                // Paths.get(URI) handles Windows drive letters (file:///C:/... -> C:\...) and
+                // UNC authority preservation (file:////server/share/... -> \\server\share\...)
+                // correctly on the default filesystem. The earlier fileSystem.getPath(uri.path)
+                // form mangled both because URI.path returns `/C:/...` which Windows' NIO
+                // provider parses ambiguously, and the UNC authority is silently dropped.
+                Paths.get(uri)
+            } else {
+                fileSystem.getPath(uri.path)
+            }
         // Normalize filename to NFC: macOS iTunes writes NFD-decomposed Unicode;
         // Linux/Windows expect NFC. Idempotent and no-op for ASCII.
         val normalizedName = Normalizer.normalize(rawPath.fileName.toString(), Normalizer.Form.NFC)

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/itunes/ItunesImportService.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/itunes/ItunesImportService.kt
@@ -16,9 +16,10 @@ import net.transgressoft.commons.music.playlist.ReactiveAudioPlaylist
 import net.transgressoft.lirp.event.ReactiveMutationEvent
 import mu.KotlinLogging
 import java.net.URI
+import java.nio.file.FileSystem
+import java.nio.file.FileSystems
 import java.nio.file.Files
 import java.nio.file.Path
-import java.nio.file.Paths
 import java.text.Normalizer
 import java.util.concurrent.CompletableFuture
 import kotlin.io.path.extension
@@ -51,8 +52,12 @@ import kotlinx.coroutines.future.future
  *
  * @param musicLibrary The target library to import into.
  */
-class ItunesImportService<I, P>(private val musicLibrary: MusicLibrary<I, P>)
-    where I : ReactiveAudioItem<I>,
+class ItunesImportService<I, P>
+    @JvmOverloads
+    constructor(
+        private val musicLibrary: MusicLibrary<I, P>,
+        private val fileSystem: FileSystem = FileSystems.getDefault()
+    ) where I : ReactiveAudioItem<I>,
           P : ReactiveAudioPlaylist<I, P> {
 
     private val logger = KotlinLogging.logger {}
@@ -218,7 +223,7 @@ class ItunesImportService<I, P>(private val musicLibrary: MusicLibrary<I, P>)
 
     private fun resolveTrackPath(track: ItunesTrack): Path {
         val uri = URI(track.location)
-        val rawPath = Paths.get(uri)
+        val rawPath = fileSystem.getPath(uri.path)
         // Normalize filename to NFC: macOS iTunes writes NFD-decomposed Unicode;
         // Linux/Windows expect NFC. Idempotent and no-op for ASCII.
         val normalizedName = Normalizer.normalize(rawPath.fileName.toString(), Normalizer.Form.NFC)

--- a/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/CrossPlatformFilesystemTest.kt
+++ b/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/CrossPlatformFilesystemTest.kt
@@ -18,7 +18,7 @@
 package net.transgressoft.commons.music
 
 import net.transgressoft.commons.music.audio.AudioItem
-import net.transgressoft.commons.music.audio.AudioItemMapSerializer
+import net.transgressoft.commons.music.audio.AudioItemSerializer
 import net.transgressoft.commons.music.audio.ImmutableAlbum
 import net.transgressoft.commons.music.audio.ImmutableArtist
 import net.transgressoft.commons.music.audio.ImmutableLabel
@@ -33,6 +33,8 @@ import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.property.arbitrary.next
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.int
 import kotlinx.serialization.json.jsonArray
@@ -93,10 +95,11 @@ internal class CrossPlatformFilesystemTest : StringSpec({
                         this.discNumber = 1
                     }.next()
                 val originalId = 1000 + offset
-                val original: AudioItem = MutableAudioItemTestBridge.createAudioItem(path, originalId)
+                val original: AudioItem = MutableAudioItemTestBridge.createAudioItem(path, originalId, files.metadataUtils)
 
-                val encoded = json.encodeToString(AudioItemMapSerializer, mapOf(original.id to original))
-                val decoded = json.decodeFromString(AudioItemMapSerializer, encoded).getValue(original.id)
+                val mapSerializer = MapSerializer(Int.serializer(), AudioItemSerializer(fs))
+                val encoded = json.encodeToString(mapSerializer, mapOf(original.id to original))
+                val decoded = json.decodeFromString(mapSerializer, encoded).getValue(original.id)
 
                 decoded.path.toString() shouldBe original.path.toString()
                 decoded.id shouldBe original.id
@@ -115,7 +118,7 @@ internal class CrossPlatformFilesystemTest : StringSpec({
                         this.album = asciiAlbum
                     }.next()
                 val audioItemId = 3000 + offset
-                MutableAudioItemTestBridge.createAudioItem(path, audioItemId)
+                MutableAudioItemTestBridge.createAudioItem(path, audioItemId, files.metadataUtils)
 
                 val playlistId = 4000 + offset
                 val playlist =

--- a/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/MusicLibraryIntegrationTest.kt
+++ b/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/MusicLibraryIntegrationTest.kt
@@ -49,7 +49,7 @@ internal class MusicLibraryIntegrationTest : StringSpec({
         waveformsFile = tempfile("waveformRepository-test", ".json").apply { deleteOnExit() }
 
         musicLibrary =
-            CoreMusicLibrary.builder()
+            CoreMusicLibrary.Builder(files.metadataUtils)
                 .audioLibraryJsonFile(audioFile)
                 .playlistHierarchyJsonFile(playlistsFile)
                 .waveformRepositoryJsonFile(waveformsFile)

--- a/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/MusicLibraryTest.kt
+++ b/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/MusicLibraryTest.kt
@@ -57,7 +57,7 @@ internal class MusicLibraryTest : StringSpec({
     }
 
     "MusicLibrary curated methods delegate to components" {
-        val library = CoreMusicLibrary.builder().build()
+        val library = CoreMusicLibrary.Builder(files.metadataUtils).build()
 
         val audioItem = library.audioItemFromFile(files.virtualAudioFile().next())
         reactive.advance()
@@ -72,7 +72,7 @@ internal class MusicLibraryTest : StringSpec({
     }
 
     "MusicLibrary close disposes all components" {
-        val library = CoreMusicLibrary.builder().build()
+        val library = CoreMusicLibrary.Builder(files.metadataUtils).build()
 
         val audioItem = library.audioItemFromFile(files.virtualAudioFile().next())
         reactive.advance()

--- a/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/audio/AudioItemSerializerTest.kt
+++ b/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/audio/AudioItemSerializerTest.kt
@@ -7,7 +7,10 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.property.arbitrary.next
+import java.nio.file.Path
 import kotlinx.serialization.SerializationException
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
@@ -29,6 +32,13 @@ internal class AudioItemSerializerTest : StringSpec({
             explicitNulls = true
         }
 
+    // Bind the serializer to the Jimfs filesystem so encoded `file://` URIs deserialize back to
+    // the same Jimfs path tree, and JsonFileRepository-style round-trip exercises real fields.
+    val mapSerializer = MapSerializer(Int.serializer(), AudioItemSerializer(files.fileSystem))
+
+    fun createItem(path: Path, id: Int): AudioItem =
+        MutableAudioItemTestBridge.createAudioItem(path, id, files.metadataUtils)
+
     "AudioItemSerializer encodes golden JSON fixture with required fields for path, id, title, duration, artist and album" {
         val artist = ImmutableArtist.of("The Beatles", CountryCode.GB)
         val label = ImmutableLabel.of("EMI")
@@ -45,9 +55,9 @@ internal class AudioItemSerializerTest : StringSpec({
                 this.discNumber = 1
             }.next()
 
-        val audioItem: AudioItem = MutableAudioItemTestBridge.createAudioItem(path, 42)
+        val audioItem: AudioItem = createItem(path, 42)
 
-        val encoded = json.encodeToString(AudioItemMapSerializer, mapOf(42 to audioItem))
+        val encoded = json.encodeToString(mapSerializer, mapOf(42 to audioItem))
 
         encoded shouldContain "\"path\""
         encoded shouldContain "\"id\""
@@ -79,10 +89,10 @@ internal class AudioItemSerializerTest : StringSpec({
                 this.bpm = 120.0f
             }.next()
 
-        val originalItem: AudioItem = MutableAudioItemTestBridge.createAudioItem(path, 99)
+        val originalItem: AudioItem = createItem(path, 99)
 
-        val encoded = json.encodeToString(AudioItemMapSerializer, mapOf(originalItem.id to originalItem))
-        val decoded = json.decodeFromString(AudioItemMapSerializer, encoded)
+        val encoded = json.encodeToString(mapSerializer, mapOf(originalItem.id to originalItem))
+        val decoded = json.decodeFromString(mapSerializer, encoded)
 
         val decodedItem = decoded.getValue(99)
 
@@ -116,9 +126,9 @@ internal class AudioItemSerializerTest : StringSpec({
                 this.artist = artist
             }.next()
 
-        val audioItem: AudioItem = MutableAudioItemTestBridge.createAudioItem(path, 10)
+        val audioItem: AudioItem = createItem(path, 10)
 
-        val encoded = json.encodeToString(AudioItemMapSerializer, mapOf(10 to audioItem))
+        val encoded = json.encodeToString(mapSerializer, mapOf(10 to audioItem))
         val jsonElement = Json.parseToJsonElement(encoded).jsonObject["10"]!!.jsonObject
 
         jsonElement["artist"]!!.jsonObject["name"]!!.jsonPrimitive.content shouldBe "Solo Artist"
@@ -131,8 +141,8 @@ internal class AudioItemSerializerTest : StringSpec({
                 this.title = "Test Song"
             }.next()
 
-        val originalItem: AudioItem = MutableAudioItemTestBridge.createAudioItem(path, 77)
-        val encoded = json.encodeToString(AudioItemMapSerializer, mapOf(77 to originalItem))
+        val originalItem: AudioItem = createItem(path, 77)
+        val encoded = json.encodeToString(mapSerializer, mapOf(77 to originalItem))
 
         // Remove the "title" field from the JSON object to simulate a missing required field
         val jsonTree = Json.parseToJsonElement(encoded).jsonObject
@@ -150,7 +160,7 @@ internal class AudioItemSerializerTest : StringSpec({
 
         val exception =
             shouldThrow<SerializationException> {
-                json.decodeFromString(AudioItemMapSerializer, modifiedJson)
+                json.decodeFromString(mapSerializer, modifiedJson)
             }
         exception.message shouldContain "Missing required field 'title'"
     }
@@ -168,8 +178,8 @@ internal class AudioItemSerializerTest : StringSpec({
                 this.bpm = 130.0f
             }.next()
 
-        val originalItem: AudioItem = MutableAudioItemTestBridge.createAudioItem(path, 55)
-        val encoded = json.encodeToString(AudioItemMapSerializer, mapOf(55 to originalItem))
+        val originalItem: AudioItem = createItem(path, 55)
+        val encoded = json.encodeToString(mapSerializer, mapOf(55 to originalItem))
 
         // Strip only the mutable nullable fields from the JSON; keep encoder/encoding since
         // MutableAudioItem always re-reads those from the audio file during construction.
@@ -185,7 +195,7 @@ internal class AudioItemSerializerTest : StringSpec({
                 mapOf("55" to JsonObject(filteredEntries))
             ).toString()
 
-        val decoded = json.decodeFromString(AudioItemMapSerializer, modifiedJson)
+        val decoded = json.decodeFromString(mapSerializer, modifiedJson)
         val decodedItem = decoded.getValue(55)
 
         decodedItem.comments shouldBe null
@@ -197,9 +207,9 @@ internal class AudioItemSerializerTest : StringSpec({
 
     "AudioItemSerializer writes path as file:// URI in JSON" {
         val path = files.virtualAudioFile().next()
-        val audioItem: AudioItem = MutableAudioItemTestBridge.createAudioItem(path, 200)
+        val audioItem: AudioItem = createItem(path, 200)
 
-        val encoded = json.encodeToString(AudioItemMapSerializer, mapOf(200 to audioItem))
+        val encoded = json.encodeToString(mapSerializer, mapOf(200 to audioItem))
 
         // file:// URIs always have three slashes (file://<authority>/<path> with empty authority);
         // assert on that to catch regressions to malformed forms like "file://relative".
@@ -239,7 +249,7 @@ internal class AudioItemSerializerTest : StringSpec({
             """.trimIndent()
 
         shouldThrow<InvalidAudioFilePathException> {
-            json.decodeFromString(AudioItemMapSerializer, offlineDriveJson)
+            json.decodeFromString(mapSerializer, offlineDriveJson)
         }
     }
 
@@ -276,7 +286,7 @@ internal class AudioItemSerializerTest : StringSpec({
             """.trimIndent()
 
         shouldThrow<SerializationException> {
-            json.decodeFromString(AudioItemMapSerializer, legacyJson)
+            json.decodeFromString(mapSerializer, legacyJson)
         }
     }
 })

--- a/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/audio/AudioLibraryBaseTest.kt
+++ b/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/audio/AudioLibraryBaseTest.kt
@@ -21,7 +21,7 @@ internal class AudioLibraryBaseTest : StringSpec({
 
     beforeEach {
         repository = VolatileRepository("AudioLibraryBaseTest")
-        audioLibrary = TestAudioLibrary(repository)
+        audioLibrary = TestAudioLibrary(repository, files.metadataUtils)
     }
 
     "AudioLibraryBase adds audio item and syncs artist catalog" {
@@ -66,7 +66,7 @@ internal class AudioLibraryBaseTest : StringSpec({
 
         // Add another item directly to repository after close — catalog should not pick it up
         val virtualPath = files.virtualAudioFile().next()
-        val newItem = MutableAudioItem(virtualPath, Int.MAX_VALUE - 1)
+        val newItem = MutableAudioItem(virtualPath, Int.MAX_VALUE - 1, files.metadataUtils)
         repository.add(newItem)
         reactive.advance()
 

--- a/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/audio/DefaultAudioLibraryTest.kt
+++ b/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/audio/DefaultAudioLibraryTest.kt
@@ -28,6 +28,8 @@ import java.io.File
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.asExecutor
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
 
@@ -43,8 +45,8 @@ internal class DefaultAudioLibraryTest: StringSpec({
 
     beforeEach {
         jsonFile = tempfile("audioLibrary-test", ".json").also { it.deleteOnExit() }
-        jsonFileRepository = JsonFileRepository(jsonFile, AudioItemMapSerializer)
-        audioRepository = DefaultAudioLibrary(jsonFileRepository)
+        jsonFileRepository = JsonFileRepository(jsonFile, MapSerializer(Int.serializer(), AudioItemSerializer(files.fileSystem)))
+        audioRepository = DefaultAudioLibrary(jsonFileRepository, files.metadataUtils)
     }
 
     afterEach {
@@ -198,8 +200,8 @@ internal class DefaultAudioLibraryTest: StringSpec({
         // This simulates loading from a persisted file
         jsonFileRepository.close()
 
-        val loadedJsonFileRepository = JsonFileRepository(jsonFile, AudioItemMapSerializer)
-        val loadedAudioRepository = DefaultAudioLibrary(loadedJsonFileRepository)
+        val loadedJsonFileRepository = JsonFileRepository(jsonFile, MapSerializer(Int.serializer(), AudioItemSerializer(files.fileSystem)))
+        val loadedAudioRepository = DefaultAudioLibrary(loadedJsonFileRepository, files.metadataUtils)
 
         reactive.advance()
 

--- a/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/audio/MutableArtistCatalogTest.kt
+++ b/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/audio/MutableArtistCatalogTest.kt
@@ -17,7 +17,6 @@
 
 package net.transgressoft.commons.music.audio
 
-import net.transgressoft.commons.music.audio.MutableAudioItemTestBridge.createAudioItem
 import net.transgressoft.commons.music.audio.virtualFiles
 import net.transgressoft.commons.music.testing.reactiveScope
 import net.transgressoft.lirp.event.MutationEvent
@@ -30,6 +29,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.next
+import java.nio.file.Path
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 
 typealias ArtistCatalogMutation = MutationEvent<Artist, ArtistCatalog<AudioItem>>
@@ -39,6 +39,9 @@ class MutableArtistCatalogTest : StringSpec({
 
     val reactive = reactiveScope()
     val files = virtualFiles()
+
+    fun createAudioItem(path: Path): AudioItem =
+        MutableAudioItemTestBridge.createAudioItem(path, files.metadataUtils)
 
     "MUTATE event is published when audio item is added to empty catalog" {
         val expectedArtist = Arb.artist().next()

--- a/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/audio/MutableAudioItemTest.kt
+++ b/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/audio/MutableAudioItemTest.kt
@@ -110,9 +110,9 @@ internal class MutableAudioItemTest : FunSpec({
             audioItem.path.extension.toAudioFileType().toString() shouldBe fileExtension
             audioItem.path.extension.toAudioFileType().extension shouldBe fileExtension
 
-            json.encodeToString(AudioItemSerializer, audioItem).let {
+            json.encodeToString(AudioItemSerializer(), audioItem).let {
                 it shouldEqualJson audioItem.asJsonValue()
-                json.decodeFromString<MutableAudioItem>(it) shouldBe audioItem
+                (json.decodeFromString(AudioItemSerializer(), it) as MutableAudioItem) shouldBe audioItem
             }
 
             val audioItemChanges = Arb.audioItemChange().next()
@@ -177,8 +177,8 @@ internal class MutableAudioItemTest : FunSpec({
         audioItem.writeMetadata()
 
         eventually(200.milliseconds) {
-            val encodedAudioItem = json.encodeToString(AudioItemSerializer, audioItem)
-            val decodedAudioItem = json.decodeFromString<MutableAudioItem>(encodedAudioItem)
+            val encodedAudioItem = json.encodeToString(AudioItemSerializer(), audioItem)
+            val decodedAudioItem = json.decodeFromString(AudioItemSerializer(), encodedAudioItem) as MutableAudioItem
 
             decodedAudioItem.coverImageBytes shouldBe testCoverBytes
         }

--- a/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/audio/MutableAudioItemTestBridge.kt
+++ b/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/audio/MutableAudioItemTestBridge.kt
@@ -11,4 +11,10 @@ object MutableAudioItemTestBridge {
     fun createAudioItem(path: Path, id: Int): AudioItem = MutableAudioItem(path, id)
 
     fun createAudioItem(path: Path): AudioItem = MutableAudioItem(path, AudioItemTestFactory.nextTestId())
+
+    fun createAudioItem(path: Path, id: Int, metadataUtils: AudioItemMetadataUtils): AudioItem =
+        MutableAudioItem(path, id, metadataUtils)
+
+    fun createAudioItem(path: Path, metadataUtils: AudioItemMetadataUtils): AudioItem =
+        MutableAudioItem(path, AudioItemTestFactory.nextTestId(), metadataUtils)
 }

--- a/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/audio/TestAudioLibrary.kt
+++ b/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/audio/TestAudioLibrary.kt
@@ -10,9 +10,10 @@ import java.nio.file.Path
  * enabling isolated unit testing of the base class reactive catalog management.
  */
 internal class TestAudioLibrary(
-    repository: Repository<Int, AudioItem>
+    repository: Repository<Int, AudioItem>,
+    private val metadataUtils: AudioItemMetadataUtils = AudioItemMetadataUtils()
 ) : AudioLibraryBase<AudioItem, ArtistCatalog<AudioItem>>(repository, DefaultArtistCatalogRegistry()) {
 
     override fun createFromFile(audioItemPath: Path): AudioItem =
-        MutableAudioItem(audioItemPath, newId()).also { add(it) }
+        MutableAudioItem(audioItemPath, newId(), metadataUtils).also { add(it) }
 }

--- a/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/audio/event/AudioItemEventSubscriberTest.kt
+++ b/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/audio/event/AudioItemEventSubscriberTest.kt
@@ -25,7 +25,7 @@ internal class AudioItemEventSubscriberTest : StringSpec({
 
     beforeEach {
         repository = VolatileRepository("TestRepo")
-        library = DefaultAudioLibrary(repository)
+        library = DefaultAudioLibrary(repository, files.metadataUtils)
     }
 
     afterEach {

--- a/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/m3u/M3uImportServiceTest.kt
+++ b/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/m3u/M3uImportServiceTest.kt
@@ -34,7 +34,7 @@ internal class M3uImportServiceTest : StringSpec({
     lateinit var service: M3uImportService
 
     beforeEach {
-        library = CoreMusicLibrary.builder().build()
+        library = CoreMusicLibrary.Builder(files.metadataUtils).build()
         service = M3uImportService(library)
     }
 

--- a/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/playlist/PlaylistHierarchyBaseTest.kt
+++ b/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/playlist/PlaylistHierarchyBaseTest.kt
@@ -53,7 +53,7 @@ internal class PlaylistHierarchyBaseTest : StringSpec({
         val audioLibraryRepository = VolatileRepository<Int, AudioItem>("SyncTest")
         deregisterRepository(AudioItem::class.java)
         registerRepository(AudioItem::class.java, audioLibraryRepository)
-        val audioLibrary = TestAudioLibrary(audioLibraryRepository)
+        val audioLibrary = TestAudioLibrary(audioLibraryRepository, files.metadataUtils)
         audioLibrary.subscribe(playlistHierarchy)
 
         val audioItem = audioLibrary.createFromFile(files.virtualAudioFile().next())
@@ -102,7 +102,7 @@ internal class PlaylistHierarchyBaseTest : StringSpec({
         val audioLibraryRepository = VolatileRepository<Int, AudioItem>("CloseTest")
         deregisterRepository(AudioItem::class.java)
         registerRepository(AudioItem::class.java, audioLibraryRepository)
-        val audioLibrary = TestAudioLibrary(audioLibraryRepository)
+        val audioLibrary = TestAudioLibrary(audioLibraryRepository, files.metadataUtils)
         audioLibrary.subscribe(playlistHierarchy)
 
         val audioItem = audioLibrary.createFromFile(files.virtualAudioFile().next())

--- a/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/FXMusicLibrary.kt
+++ b/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/FXMusicLibrary.kt
@@ -31,6 +31,7 @@ import net.transgressoft.commons.media.waveform.audioWaveformRepository
 import net.transgressoft.commons.music.MusicLibrary
 import net.transgressoft.commons.music.audio.Album
 import net.transgressoft.commons.music.audio.Artist
+import net.transgressoft.commons.music.audio.AudioItemMetadataUtils
 import net.transgressoft.commons.music.audio.event.AudioItemEventSubscriber
 import net.transgressoft.commons.music.common.WindowsPathValidator
 import net.transgressoft.commons.music.waveform.AudioWaveform
@@ -178,11 +179,18 @@ class FXMusicLibrary private constructor(
      *     .build()
      * ```
      */
-    class Builder {
+    class Builder() {
 
         private var audioLibraryStorage: StorageConfig = VolatileStorage
         private var playlistHierarchyStorage: StorageConfig = VolatileStorage
         private var waveformRepositoryStorage: StorageConfig = VolatileStorage
+        private var metadataUtils: AudioItemMetadataUtils = AudioItemMetadataUtils()
+
+        // Internal seam for in-module tests: see CoreMusicLibrary.Builder's internal constructor
+        // for rationale. Not exposed on the public Builder API.
+        internal constructor(metadataUtils: AudioItemMetadataUtils) : this() {
+            this.metadataUtils = metadataUtils
+        }
 
         /** Configures the audio library to use JSON file persistence at [file]. */
         fun audioLibraryJsonFile(file: File): Builder = apply { audioLibraryStorage = JsonFileStorage(file) }
@@ -223,7 +231,7 @@ class FXMusicLibrary private constructor(
         /** Builds the [FXMusicLibrary], wiring all event subscriptions between components. */
         fun build(): FXMusicLibrary {
             val audioRepo = createAudioRepository()
-            val audioLibrary = FXAudioLibrary(audioRepo)
+            val audioLibrary = FXAudioLibrary(audioRepo, metadataUtils)
             var playlistRepoRegistered = false
 
             var waveformRepository: AudioWaveformRepository<AudioWaveform, ObservableAudioItem>? = null

--- a/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/audio/FXAudioItem.kt
+++ b/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/audio/FXAudioItem.kt
@@ -21,9 +21,10 @@ import net.transgressoft.commons.music.AudioUtils.audioItemTrackDiscNumberCompar
 import net.transgressoft.commons.music.AudioUtils.getArtistsNamesInvolved
 import net.transgressoft.commons.music.audio.Album
 import net.transgressoft.commons.music.audio.Artist
-import net.transgressoft.commons.music.audio.AudioItemMetadataUtils.readMetadata
-import net.transgressoft.commons.music.audio.AudioItemMetadataUtils.writeMetadataToFile
+import net.transgressoft.commons.music.audio.AudioFileMetadata
+import net.transgressoft.commons.music.audio.AudioItemMetadataUtils
 import net.transgressoft.commons.music.audio.Genre
+import net.transgressoft.commons.music.audio.ImmutableAlbum
 import net.transgressoft.commons.music.audio.ImmutableArtist
 import net.transgressoft.commons.music.audio.InvalidAudioFilePathException
 import net.transgressoft.commons.music.audio.UNASSIGNED_ID
@@ -65,6 +66,32 @@ import kotlinx.serialization.Transient
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.polymorphic
 
+// Serializer is wired via `observableAudioItemSerializerModule` polymorphic registration (see bottom of this file).
+// The serializer is a stateful class (ObservableAudioItemSerializer(FileSystem)) so it cannot be referenced as a
+// bare `@Serializable(with = ...)` target — kotlinx-serialization requires KSerializer-typed ctor params.
+
+// See MutableAudioItem.readMetadataSafely for rationale. Mirrored here because module visibility blocks reuse.
+private fun readMetadataSafely(metadataUtils: AudioItemMetadataUtils, path: java.nio.file.Path): AudioFileMetadata =
+    try {
+        metadataUtils.readMetadata(path)
+    } catch (_: IllegalArgumentException) {
+        AudioFileMetadata(
+            bitRate = 0,
+            duration = java.time.Duration.ZERO,
+            encoder = null,
+            encoding = null,
+            title = "",
+            artist = ImmutableArtist.UNKNOWN,
+            album = ImmutableAlbum.UNKNOWN,
+            genres = emptySet(),
+            comments = null,
+            trackNumber = null,
+            discNumber = null,
+            bpm = null,
+            coverBytes = null
+        )
+    }
+
 /**
  * JavaFX implementation of [ObservableAudioItem] with lirp-fx scalar properties.
  *
@@ -80,408 +107,410 @@ import kotlinx.serialization.modules.polymorphic
  * [lastDateModifiedProperty] is updated automatically by [ReactiveEntityBase] after each
  * successful mutation.
  */
-@Suppress("SERIALIZER_TYPE_INCOMPATIBLE") // Serializer handles polymorphic AudioItem hierarchy; declared type intentionally broader than serializer target
-@Serializable(with = ObservableAudioItemSerializer::class)
-class FXAudioItem internal constructor(
-    override val path: Path,
-    override val id: Int = UNASSIGNED_ID
-): ObservableAudioItem, Comparable<ObservableAudioItem>,
-    ReactiveEntityBase<Int, ObservableAudioItem>() {
-
-    @Transient
-    private val logger = KotlinLogging.logger {}
-
-    private val ioScope =
-        CoroutineScope(
-            Dispatchers.IO + SupervisorJob() +
-                CoroutineExceptionHandler { _, exception ->
-                    val errorText = "Error writing metadata of $this"
-                    logger.error(errorText, exception)
-                }
-        )
-
+class FXAudioItem
+    @JvmOverloads
     internal constructor(
-        path: Path,
-        id: Int,
-        title: String,
-        duration: Duration,
-        bitRate: Int,
-        artist: Artist,
-        album: Album,
-        genres: Set<Genre>,
-        comments: String?,
-        trackNumber: Short?,
-        discNumber: Short?,
-        bpm: Float?,
-        encoder: String?,
-        encoding: String?,
-        dateOfCreation: LocalDateTime,
-        lastDateModified: LocalDateTime,
-        playCount: Short
-    ): this(path, id) {
-        disableEvents()
-        this.title = title
-        this._duration = duration
-        this.artist = artist
-        this.genres = genres
-        this.comments = comments
-        this.trackNumber = trackNumber
-        this.discNumber = discNumber
-        this.bpm = bpm
-        this.album = album
-        this._bitRate = bitRate
-        this._encoder = encoder
-        this._encoding = encoding
-        this._dateOfCreation = dateOfCreation
-        this.lastDateModified = lastDateModified
-        this.coverImageBytes = metadata.coverBytes
-        _playCountProperty.set(playCount.toInt())
-        enableEvents()
-    }
+        override val path: Path,
+        override val id: Int = UNASSIGNED_ID,
+        private val metadataUtils: AudioItemMetadataUtils = AudioItemMetadataUtils()
+    ): ObservableAudioItem, Comparable<ObservableAudioItem>,
+        ReactiveEntityBase<Int, ObservableAudioItem>() {
 
-    init {
-        WindowsPathValidator.validatePath(path)
-        if (!Files.exists(path)) {
-            throw InvalidAudioFilePathException("File '${path.toAbsolutePath()}' does not exist")
+        @Transient
+        private val logger = KotlinLogging.logger {}
+
+        private val ioScope =
+            CoroutineScope(
+                Dispatchers.IO + SupervisorJob() +
+                    CoroutineExceptionHandler { _, exception ->
+                        val errorText = "Error writing metadata of $this"
+                        logger.error(errorText, exception)
+                    }
+            )
+
+        internal constructor(
+            path: Path,
+            id: Int,
+            title: String,
+            duration: Duration,
+            bitRate: Int,
+            artist: Artist,
+            album: Album,
+            genres: Set<Genre>,
+            comments: String?,
+            trackNumber: Short?,
+            discNumber: Short?,
+            bpm: Float?,
+            encoder: String?,
+            encoding: String?,
+            dateOfCreation: LocalDateTime,
+            lastDateModified: LocalDateTime,
+            playCount: Short,
+            metadataUtils: AudioItemMetadataUtils = AudioItemMetadataUtils()
+        ): this(path, id, metadataUtils) {
+            disableEvents()
+            this.title = title
+            this._duration = duration
+            this.artist = artist
+            this.genres = genres
+            this.comments = comments
+            this.trackNumber = trackNumber
+            this.discNumber = discNumber
+            this.bpm = bpm
+            this.album = album
+            this._bitRate = bitRate
+            this._encoder = encoder
+            this._encoding = encoding
+            this._dateOfCreation = dateOfCreation
+            this.lastDateModified = lastDateModified
+            this.coverImageBytes = metadata.coverBytes
+            _playCountProperty.set(playCount.toInt())
+            enableEvents()
         }
-        if (!Files.isRegularFile(path)) {
-            throw InvalidAudioFilePathException("Path '${path.toAbsolutePath()}' is not a regular file")
+
+        init {
+            WindowsPathValidator.validatePath(path)
+            if (!Files.exists(path)) {
+                throw InvalidAudioFilePathException("File '${path.toAbsolutePath()}' does not exist")
+            }
+            if (!Files.isRegularFile(path)) {
+                throw InvalidAudioFilePathException("Path '${path.toAbsolutePath()}' is not a regular file")
+            }
+            if (!Files.isReadable(path)) {
+                throw InvalidAudioFilePathException("File '${path.toAbsolutePath()}' is not readable")
+            }
         }
-        if (!Files.isReadable(path)) {
-            throw InvalidAudioFilePathException("File '${path.toAbsolutePath()}' is not readable")
+
+        @Transient
+        private val metadata = readMetadataSafely(metadataUtils, path)
+
+        /** Immutable properties */
+
+        private var _bitRate: Int = metadata.bitRate
+
+        @Serializable
+        override val bitRate: Int
+            get() = _bitRate
+
+        private var _duration: Duration = metadata.duration
+
+        override val duration: Duration
+            get() = _duration
+
+        private var _encoder: String? = metadata.encoder?.takeIf { it.isNotEmpty() }
+
+        @Serializable
+        override val encoder: String?
+            get() = _encoder
+
+        private var _encoding: String? = metadata.encoding?.takeIf { it.isNotEmpty() }
+
+        @Serializable
+        override val encoding: String?
+            get() = _encoding
+
+        private var _dateOfCreation: LocalDateTime = LocalDateTime.now()
+
+        @Serializable
+        override val dateOfCreation: LocalDateTime
+            get() = _dateOfCreation
+
+        @Transient
+        override val dateOfCreationProperty: ReadOnlyObjectProperty<LocalDateTime> = SimpleObjectProperty(this, "date of creation", _dateOfCreation)
+
+        override val fileName by lazy {
+            path.fileName.toString()
         }
-    }
 
-    @Transient
-    private val metadata = readMetadata(path)
+        override val extension by lazy {
+            path.extension
+        }
 
-    /** Immutable properties */
+        override val length by lazy {
+            Files.size(path)
+        }
 
-    private var _bitRate: Int = metadata.bitRate
+        override val uniqueId
+            get() =
+                buildString {
+                    append(path.fileName.toString().replace(' ', '_'))
+                    append("-$title")
+                    append("-${duration.toSeconds()}")
+                    append("-$bitRate")
+                }
 
-    @Serializable
-    override val bitRate: Int
-        get() = _bitRate
+        /** Mutable properties — lirp-fx properties are the JavaFX source of truth.
+         *  Change listeners on each lirp-fx property sync the domain setter, which publishes
+         *  mutation events and updates lastDateModified. This pattern works both with and without
+         *  a RegistryBase-managed repository. */
 
-    private var _duration: Duration = metadata.duration
+        @Transient
+        private val metadataTitle = metadata.title
 
-    override val duration: Duration
-        get() = _duration
+        @Transient
+        override val titleProperty: StringProperty = fxString(metadataTitle)
 
-    private var _encoder: String? = metadata.encoder?.takeIf { it.isNotEmpty() }
-
-    @Serializable
-    override val encoder: String?
-        get() = _encoder
-
-    private var _encoding: String? = metadata.encoding?.takeIf { it.isNotEmpty() }
-
-    @Serializable
-    override val encoding: String?
-        get() = _encoding
-
-    private var _dateOfCreation: LocalDateTime = LocalDateTime.now()
-
-    @Serializable
-    override val dateOfCreation: LocalDateTime
-        get() = _dateOfCreation
-
-    @Transient
-    override val dateOfCreationProperty: ReadOnlyObjectProperty<LocalDateTime> = SimpleObjectProperty(this, "date of creation", _dateOfCreation)
-
-    override val fileName by lazy {
-        path.fileName.toString()
-    }
-
-    override val extension by lazy {
-        path.extension
-    }
-
-    override val length by lazy {
-        path.toFile().length()
-    }
-
-    override val uniqueId
-        get() =
-            buildString {
-                append(path.fileName.toString().replace(' ', '_'))
-                append("-$title")
-                append("-${duration.toSeconds()}")
-                append("-$bitRate")
+        override var title: String = metadataTitle
+            set(value) {
+                mutateAndPublish {
+                    field = value
+                    syncArtistsInvolved()
+                }
+                titleProperty.set(value)
             }
 
-    /** Mutable properties — lirp-fx properties are the JavaFX source of truth.
-     *  Change listeners on each lirp-fx property sync the domain setter, which publishes
-     *  mutation events and updates lastDateModified. This pattern works both with and without
-     *  a RegistryBase-managed repository. */
+        // LirpObjectProperty<T> extends SimpleObjectProperty<T?>, so it is ObjectProperty<T?> in
+        // Kotlin's type system. The cast to ObjectProperty<T> (non-nullable) is safe at runtime
+        // because JavaFX generics erase to raw types on the JVM.
+        // Safe cast: generic type erased at runtime but guaranteed by the builder/serializer contract
+        @Transient
+        private val metadataArtist: Artist = metadata.artist
 
-    @Transient
-    private val metadataTitle = metadata.title
+        @Transient
+        @Suppress("UNCHECKED_CAST")
+        override val artistProperty: ObjectProperty<Artist> = fxObject(metadataArtist) as ObjectProperty<Artist>
 
-    @Transient
-    override val titleProperty: StringProperty = fxString(metadataTitle)
+        override var artist: Artist = metadataArtist
+            set(value) {
+                mutateAndPublish {
+                    field = value
+                    syncArtistsInvolved()
+                }
+                artistProperty.set(value)
+            }
 
-    override var title: String = metadataTitle
-        set(value) {
-            mutateAndPublish {
+        @Transient
+        private val metadataAlbum: Album = metadata.album
+
+        @Transient
+        @Suppress("UNCHECKED_CAST")
+        override val albumProperty: ObjectProperty<Album> = fxObject(metadataAlbum) as ObjectProperty<Album>
+
+        override var album: Album = metadataAlbum
+            set(value) {
+                mutateAndPublish {
+                    field = value
+                    syncArtistsInvolved()
+                }
+                albumProperty.set(value)
+            }
+
+        @Transient
+        private val metadataGenres: Set<Genre> = metadata.genres.toSet()
+
+        @Transient
+        @Suppress("UNCHECKED_CAST")
+        override val genresProperty: ObjectProperty<Set<Genre>> = fxObject(metadataGenres) as ObjectProperty<Set<Genre>>
+
+        override var genres: Set<Genre> = metadataGenres
+            set(value) {
+                val copy = value.toSet()
+                mutateAndPublish { field = copy }
+                genresProperty.set(copy)
+            }
+
+        @Transient
+        private val metadataComments: String? = metadata.comments
+
+        @Transient
+        override val commentsProperty: StringProperty by fxString(metadataComments ?: "")
+
+        override var comments: String? = metadataComments
+            set(value) {
+                mutateAndPublish { field = value }
+                commentsProperty.set(value ?: "")
+            }
+
+        @Transient
+        private val metadataTrackNumber: Short? = metadata.trackNumber
+
+        @Transient
+        override val trackNumberProperty: IntegerProperty by fxInteger(metadataTrackNumber?.toInt() ?: -1)
+
+        override var trackNumber: Short? = metadataTrackNumber
+            set(value) {
+                mutateAndPublish { field = value }
+                trackNumberProperty.set(value?.toInt() ?: -1)
+            }
+
+        @Transient
+        private val metadataDiscNumber: Short? = metadata.discNumber
+
+        @Transient
+        override val discNumberProperty: IntegerProperty by fxInteger(metadataDiscNumber?.toInt() ?: -1)
+
+        override var discNumber: Short? = metadataDiscNumber
+            set(value) {
+                mutateAndPublish { field = value }
+                discNumberProperty.set(value?.toInt() ?: -1)
+            }
+
+        @Transient
+        private val metadataBpm: Float? = metadata.bpm
+
+        @Transient
+        override val bpmProperty: FloatProperty by fxFloat(metadataBpm ?: -1f)
+
+        override var bpm: Float? = metadataBpm
+            set(value) {
+                mutateAndPublish { field = value }
+                bpmProperty.set(value ?: -1f)
+            }
+
+        @Serializable
+        override var lastDateModified: LocalDateTime = dateOfCreation
+            set(value) {
                 field = value
-                syncArtistsInvolved()
+                _lastDateModifiedProperty.set(value)
             }
-            titleProperty.set(value)
-        }
 
-    // LirpObjectProperty<T> extends SimpleObjectProperty<T?>, so it is ObjectProperty<T?> in
-    // Kotlin's type system. The cast to ObjectProperty<T> (non-nullable) is safe at runtime
-    // because JavaFX generics erase to raw types on the JVM.
-    // Safe cast: generic type erased at runtime but guaranteed by the builder/serializer contract
-    @Transient
-    private val metadataArtist: Artist = metadata.artist
+        private val _lastDateModifiedProperty = SimpleObjectProperty(this, "date of last modification", lastDateModified)
 
-    @Transient
-    @Suppress("UNCHECKED_CAST")
-    override val artistProperty: ObjectProperty<Artist> = fxObject(metadataArtist) as ObjectProperty<Artist>
+        @Transient
+        override val lastDateModifiedProperty: ReadOnlyObjectProperty<LocalDateTime> = _lastDateModifiedProperty
 
-    override var artist: Artist = metadataArtist
-        set(value) {
-            mutateAndPublish {
-                field = value
-                syncArtistsInvolved()
+        override var coverImageBytes: ByteArray? = metadata.coverBytes?.copyOf()
+            get() = field?.copyOf()
+            set(value) {
+                val copy = value?.copyOf()
+                mutateAndPublish {
+                    field = copy
+                    _coverImageProperty.set(Optional.ofNullable(copy).map { bytes: ByteArray -> Image(ByteArrayInputStream(bytes)) })
+                }
             }
-            artistProperty.set(value)
-        }
 
-    @Transient
-    private val metadataAlbum: Album = metadata.album
+        private val _coverImageProperty =
+            SimpleObjectProperty(
+                this,
+                "cover image",
+                Optional.ofNullable(coverImageBytes)
+                    .map { bytes: ByteArray -> Image(ByteArrayInputStream(bytes)) }
+            )
 
-    @Transient
-    @Suppress("UNCHECKED_CAST")
-    override val albumProperty: ObjectProperty<Album> = fxObject(metadataAlbum) as ObjectProperty<Album>
+        @Transient
+        override val coverImageProperty: ReadOnlyObjectProperty<Optional<Image>> = _coverImageProperty
 
-    override var album: Album = metadataAlbum
-        set(value) {
-            mutateAndPublish {
-                field = value
-                syncArtistsInvolved()
+        @Transient
+        override val artistsInvolvedProperty: ReadOnlySetProperty<Artist> =
+            SimpleSetProperty(
+                this, "artists involved",
+                FXCollections.observableSet(
+                    getArtistsNamesInvolved(
+                        titleProperty.value, artistProperty.value.name, albumProperty.value.albumArtist.name
+                    ).map { ImmutableArtist.of(it) }.toMutableSet()
+                )
+            )
+
+        override val artistsInvolved: Set<Artist>
+            get() = artistsInvolvedProperty.value
+
+        @Serializable
+        override val playCount: Short
+            get() = _playCountProperty.get().toShort()
+
+        private val _playCountProperty = SimpleIntegerProperty(this, "play count", 0)
+
+        @Transient
+        override val playCountProperty: ReadOnlyIntegerProperty = _playCountProperty
+
+        init {
+            titleProperty.addListener { _, _, newTitle ->
+                if (title != newTitle) title = newTitle
             }
-            albumProperty.set(value)
-        }
-
-    @Transient
-    private val metadataGenres: Set<Genre> = metadata.genres.toSet()
-
-    @Transient
-    @Suppress("UNCHECKED_CAST")
-    override val genresProperty: ObjectProperty<Set<Genre>> = fxObject(metadataGenres) as ObjectProperty<Set<Genre>>
-
-    override var genres: Set<Genre> = metadataGenres
-        set(value) {
-            val copy = value.toSet()
-            mutateAndPublish { field = copy }
-            genresProperty.set(copy)
-        }
-
-    @Transient
-    private val metadataComments: String? = metadata.comments
-
-    @Transient
-    override val commentsProperty: StringProperty by fxString(metadataComments ?: "")
-
-    override var comments: String? = metadataComments
-        set(value) {
-            mutateAndPublish { field = value }
-            commentsProperty.set(value ?: "")
-        }
-
-    @Transient
-    private val metadataTrackNumber: Short? = metadata.trackNumber
-
-    @Transient
-    override val trackNumberProperty: IntegerProperty by fxInteger(metadataTrackNumber?.toInt() ?: -1)
-
-    override var trackNumber: Short? = metadataTrackNumber
-        set(value) {
-            mutateAndPublish { field = value }
-            trackNumberProperty.set(value?.toInt() ?: -1)
-        }
-
-    @Transient
-    private val metadataDiscNumber: Short? = metadata.discNumber
-
-    @Transient
-    override val discNumberProperty: IntegerProperty by fxInteger(metadataDiscNumber?.toInt() ?: -1)
-
-    override var discNumber: Short? = metadataDiscNumber
-        set(value) {
-            mutateAndPublish { field = value }
-            discNumberProperty.set(value?.toInt() ?: -1)
-        }
-
-    @Transient
-    private val metadataBpm: Float? = metadata.bpm
-
-    @Transient
-    override val bpmProperty: FloatProperty by fxFloat(metadataBpm ?: -1f)
-
-    override var bpm: Float? = metadataBpm
-        set(value) {
-            mutateAndPublish { field = value }
-            bpmProperty.set(value ?: -1f)
-        }
-
-    @Serializable
-    override var lastDateModified: LocalDateTime = dateOfCreation
-        set(value) {
-            field = value
-            _lastDateModifiedProperty.set(value)
-        }
-
-    private val _lastDateModifiedProperty = SimpleObjectProperty(this, "date of last modification", lastDateModified)
-
-    @Transient
-    override val lastDateModifiedProperty: ReadOnlyObjectProperty<LocalDateTime> = _lastDateModifiedProperty
-
-    override var coverImageBytes: ByteArray? = metadata.coverBytes?.copyOf()
-        get() = field?.copyOf()
-        set(value) {
-            val copy = value?.copyOf()
-            mutateAndPublish {
-                field = copy
-                _coverImageProperty.set(Optional.ofNullable(copy).map { bytes: ByteArray -> Image(ByteArrayInputStream(bytes)) })
+            artistProperty.addListener { _, _, newArtist ->
+                if (newArtist != null && artist != newArtist) artist = newArtist
+            }
+            albumProperty.addListener { _, _, newAlbum ->
+                if (newAlbum != null && album != newAlbum) album = newAlbum
+            }
+            genresProperty.addListener { _, _, newGenres ->
+                if (newGenres != null && genres != newGenres) genres = newGenres
+            }
+            commentsProperty.addListener { _, _, newComments ->
+                val newValue = newComments.takeIf { it.isNotEmpty() }
+                if (comments != newValue) comments = newValue
+            }
+            trackNumberProperty.addListener { _, _, newTrack ->
+                val intVal = newTrack.toInt()
+                val newValue = if (intVal in 0..Short.MAX_VALUE.toInt()) intVal.toShort() else null
+                if (trackNumber != newValue) trackNumber = newValue
+            }
+            discNumberProperty.addListener { _, _, newDisc ->
+                val intVal = newDisc.toInt()
+                val newValue = if (intVal in 0..Short.MAX_VALUE.toInt()) intVal.toShort() else null
+                if (discNumber != newValue) discNumber = newValue
+            }
+            bpmProperty.addListener { _, _, newBpm ->
+                val newValue = newBpm.toFloat().takeUnless { it == -1f }
+                if (bpm != newValue) bpm = newValue
             }
         }
 
-    private val _coverImageProperty =
-        SimpleObjectProperty(
-            this,
-            "cover image",
-            Optional.ofNullable(coverImageBytes)
-                .map { bytes: ByteArray -> Image(ByteArrayInputStream(bytes)) }
-        )
-
-    @Transient
-    override val coverImageProperty: ReadOnlyObjectProperty<Optional<Image>> = _coverImageProperty
-
-    @Transient
-    override val artistsInvolvedProperty: ReadOnlySetProperty<Artist> =
-        SimpleSetProperty(
-            this, "artists involved",
-            FXCollections.observableSet(
+        private fun syncArtistsInvolved() {
+            val involved =
                 getArtistsNamesInvolved(
-                    titleProperty.value, artistProperty.value.name, albumProperty.value.albumArtist.name
-                ).map { ImmutableArtist.of(it) }.toMutableSet()
+                    title, artist.name, album.albumArtist.name
+                ).map { ImmutableArtist.of(it) }.toSet()
+            artistsInvolvedProperty.clear()
+            artistsInvolvedProperty.addAll(involved)
+        }
+
+        override fun writeMetadata(): Job =
+            ioScope.launch {
+                logger.debug { "Writing metadata of $this to file '${path.toAbsolutePath()}'" }
+                metadataUtils.writeMetadataToFile(
+                    path, title, album, artist, genres,
+                    comments, trackNumber, discNumber, bpm, encoder,
+                    coverImageBytes, fileName, logger
+                )
+                logger.debug { "Metadata of $this successfully written to file" }
+            }
+
+        override fun setPlayCount(count: Short) {
+            require(count >= 0) { "Play count cannot be negative" }
+            withEventsDisabled { _playCountProperty.set(count.toInt()) }
+        }
+
+        internal fun incrementPlayCount() {
+            mutateAndPublish {
+                _playCountProperty.set(_playCountProperty.get() + 1)
+            }
+        }
+
+        override operator fun compareTo(other: ObservableAudioItem) = audioItemTrackDiscNumberComparator<ObservableAudioItem>().compare(this, other)
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other == null || javaClass != other.javaClass) return false
+            val that = other as FXAudioItem
+            return trackNumber == that.trackNumber &&
+                discNumber == that.discNumber &&
+                bpm == that.bpm &&
+                path == that.path &&
+                title == that.title &&
+                artist == that.artist &&
+                album == that.album &&
+                genres == that.genres &&
+                comments == that.comments &&
+                duration == that.duration &&
+                playCount == that.playCount &&
+                coverImageBytes.contentEquals(that.coverImageBytes)
+        }
+
+        override fun hashCode() =
+            Objects.hash(path, title, artist, album, genres, comments, trackNumber, discNumber, bpm, duration, playCount, coverImageBytes.contentHashCode())
+
+        override fun clone(): FXAudioItem =
+            FXAudioItem(
+                path, id, title, duration, bitRate, artist, album, genres,
+                comments, trackNumber, discNumber, bpm, encoder, encoding,
+                dateOfCreation, lastDateModified, playCount, metadataUtils
             )
-        )
 
-    override val artistsInvolved: Set<Artist>
-        get() = artistsInvolvedProperty.value
-
-    @Serializable
-    override val playCount: Short
-        get() = _playCountProperty.get().toShort()
-
-    private val _playCountProperty = SimpleIntegerProperty(this, "play count", 0)
-
-    @Transient
-    override val playCountProperty: ReadOnlyIntegerProperty = _playCountProperty
-
-    init {
-        titleProperty.addListener { _, _, newTitle ->
-            if (title != newTitle) title = newTitle
-        }
-        artistProperty.addListener { _, _, newArtist ->
-            if (newArtist != null && artist != newArtist) artist = newArtist
-        }
-        albumProperty.addListener { _, _, newAlbum ->
-            if (newAlbum != null && album != newAlbum) album = newAlbum
-        }
-        genresProperty.addListener { _, _, newGenres ->
-            if (newGenres != null && genres != newGenres) genres = newGenres
-        }
-        commentsProperty.addListener { _, _, newComments ->
-            val newValue = newComments.takeIf { it.isNotEmpty() }
-            if (comments != newValue) comments = newValue
-        }
-        trackNumberProperty.addListener { _, _, newTrack ->
-            val intVal = newTrack.toInt()
-            val newValue = if (intVal in 0..Short.MAX_VALUE.toInt()) intVal.toShort() else null
-            if (trackNumber != newValue) trackNumber = newValue
-        }
-        discNumberProperty.addListener { _, _, newDisc ->
-            val intVal = newDisc.toInt()
-            val newValue = if (intVal in 0..Short.MAX_VALUE.toInt()) intVal.toShort() else null
-            if (discNumber != newValue) discNumber = newValue
-        }
-        bpmProperty.addListener { _, _, newBpm ->
-            val newValue = newBpm.toFloat().takeUnless { it == -1f }
-            if (bpm != newValue) bpm = newValue
-        }
+        override fun toString() = "ObservableAudioItem(id=$id, path=$path, title=$title, artist=${artist.name})"
     }
-
-    private fun syncArtistsInvolved() {
-        val involved =
-            getArtistsNamesInvolved(
-                title, artist.name, album.albumArtist.name
-            ).map { ImmutableArtist.of(it) }.toSet()
-        artistsInvolvedProperty.clear()
-        artistsInvolvedProperty.addAll(involved)
-    }
-
-    override fun writeMetadata(): Job =
-        ioScope.launch {
-            logger.debug { "Writing metadata of $this to file '${path.toAbsolutePath()}'" }
-            writeMetadataToFile(
-                path, title, album, artist, genres,
-                comments, trackNumber, discNumber, bpm, encoder,
-                coverImageBytes, fileName, logger
-            )
-            logger.debug { "Metadata of $this successfully written to file" }
-        }
-
-    override fun setPlayCount(count: Short) {
-        require(count >= 0) { "Play count cannot be negative" }
-        withEventsDisabled { _playCountProperty.set(count.toInt()) }
-    }
-
-    internal fun incrementPlayCount() {
-        mutateAndPublish {
-            _playCountProperty.set(_playCountProperty.get() + 1)
-        }
-    }
-
-    override operator fun compareTo(other: ObservableAudioItem) = audioItemTrackDiscNumberComparator<ObservableAudioItem>().compare(this, other)
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other == null || javaClass != other.javaClass) return false
-        val that = other as FXAudioItem
-        return trackNumber == that.trackNumber &&
-            discNumber == that.discNumber &&
-            bpm == that.bpm &&
-            path == that.path &&
-            title == that.title &&
-            artist == that.artist &&
-            album == that.album &&
-            genres == that.genres &&
-            comments == that.comments &&
-            duration == that.duration &&
-            playCount == that.playCount &&
-            coverImageBytes.contentEquals(that.coverImageBytes)
-    }
-
-    override fun hashCode() =
-        Objects.hash(path, title, artist, album, genres, comments, trackNumber, discNumber, bpm, duration, playCount, coverImageBytes.contentHashCode())
-
-    override fun clone(): FXAudioItem =
-        FXAudioItem(
-            path, id, title, duration, bitRate, artist, album, genres,
-            comments, trackNumber, discNumber, bpm, encoder, encoding,
-            dateOfCreation, lastDateModified, playCount
-        )
-
-    override fun toString() = "ObservableAudioItem(id=$id, path=$path, title=$title, artist=${artist.name})"
-}
 
 val observableAudioItemSerializerModule =
     SerializersModule {
-        polymorphic(ObservableAudioItem::class, ObservableAudioItemSerializer)
+        polymorphic(ObservableAudioItem::class, ObservableAudioItemSerializer())
     }

--- a/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/audio/FXAudioLibrary.kt
+++ b/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/audio/FXAudioLibrary.kt
@@ -19,6 +19,7 @@ package net.transgressoft.commons.fx.music.audio
 
 import net.transgressoft.commons.music.audio.Album
 import net.transgressoft.commons.music.audio.Artist
+import net.transgressoft.commons.music.audio.AudioItemMetadataUtils
 import net.transgressoft.commons.music.audio.AudioLibraryBase
 import net.transgressoft.commons.music.player.event.AudioItemPlayerEvent.Type.PLAYED
 import net.transgressoft.lirp.event.CrudEvent.Type.CREATE
@@ -65,232 +66,236 @@ import kotlinx.coroutines.launch
  * through the default uncaught exception handler.
  */
 @LirpRepository
-internal class FXAudioLibrary(repository: Repository<Int, ObservableAudioItem>)
-: AudioLibraryBase<ObservableAudioItem, ObservableArtistCatalog>(
-    repository,
-    FXArtistCatalogRegistry()
-),
-    ObservableAudioLibrary {
+internal class FXAudioLibrary
+    @JvmOverloads
+    constructor(
+        repository: Repository<Int, ObservableAudioItem>,
+        private val metadataUtils: AudioItemMetadataUtils = AudioItemMetadataUtils()
+    ) : AudioLibraryBase<ObservableAudioItem, ObservableArtistCatalog>(
+            repository,
+            FXArtistCatalogRegistry()
+        ),
+        ObservableAudioLibrary {
 
-    private val logger = KotlinLogging.logger {}
+        private val logger = KotlinLogging.logger {}
 
-    private companion object {
-        const val FX_REFRESH_DEBOUNCE_MILLIS = 16L
-    }
+        private companion object {
+            const val FX_REFRESH_DEBOUNCE_MILLIS = 16L
+        }
 
-    // Primary observable items collection -- populated from CRUD events, auto-dispatches to FX thread
-    private val audioItems: FxAggregateList<Int, ObservableAudioItem> by fxAggregateList()
-    private val audioItemIds = ConcurrentHashMap.newKeySet<Int>()
-    private val pendingCreatedAudioItems = ConcurrentLinkedQueue<ObservableAudioItem>()
-    private val pendingDeletedAudioItemIds = ConcurrentLinkedQueue<Int>()
-    private val audioItemsRefreshQueued = AtomicBoolean(false)
-    private val recomputeArtistsRequested = AtomicBoolean(false)
+        // Primary observable items collection -- populated from CRUD events, auto-dispatches to FX thread
+        private val audioItems: FxAggregateList<Int, ObservableAudioItem> by fxAggregateList()
+        private val audioItemIds = ConcurrentHashMap.newKeySet<Int>()
+        private val pendingCreatedAudioItems = ConcurrentLinkedQueue<ObservableAudioItem>()
+        private val pendingDeletedAudioItemIds = ConcurrentLinkedQueue<Int>()
+        private val audioItemsRefreshQueued = AtomicBoolean(false)
+        private val recomputeArtistsRequested = AtomicBoolean(false)
 
-    @get:JvmName("audioItemsProperty")
-    override val audioItemsProperty: ReadOnlyListProperty<ObservableAudioItem> =
-        SimpleListProperty(this, "observable audio items", audioItems)
+        @get:JvmName("audioItemsProperty")
+        override val audioItemsProperty: ReadOnlyListProperty<ObservableAudioItem> =
+            SimpleListProperty(this, "observable audio items", audioItems)
 
-    @get:JvmName("emptyLibraryProperty")
-    override val emptyLibraryProperty: ReadOnlyBooleanProperty = audioItemsProperty.emptyProperty()
+        @get:JvmName("emptyLibraryProperty")
+        override val emptyLibraryProperty: ReadOnlyBooleanProperty = audioItemsProperty.emptyProperty()
 
-    @get:JvmName("artistsProperty")
-    override val artistsProperty: ReadOnlySetProperty<Artist> = SimpleSetProperty(this, "artists", observableSet())
+        @get:JvmName("artistsProperty")
+        override val artistsProperty: ReadOnlySetProperty<Artist> = SimpleSetProperty(this, "artists", observableSet())
 
-    // Thread-safe backing for artist catalogs -- updated directly from catalog subscription
-    private val artistCatalogBacking: CopyOnWriteArraySet<ObservableArtistCatalog> = CopyOnWriteArraySet()
-    private val catalogRefreshQueued = AtomicBoolean(false)
-    private val catalogRefreshRequested = AtomicBoolean(false)
+        // Thread-safe backing for artist catalogs -- updated directly from catalog subscription
+        private val artistCatalogBacking: CopyOnWriteArraySet<ObservableArtistCatalog> = CopyOnWriteArraySet()
+        private val catalogRefreshQueued = AtomicBoolean(false)
+        private val catalogRefreshRequested = AtomicBoolean(false)
 
-    private val observableArtistCatalogSet: ObservableSet<ObservableArtistCatalog> = observableSet()
+        private val observableArtistCatalogSet: ObservableSet<ObservableArtistCatalog> = observableSet()
 
-    @get:JvmName("artistCatalogsProperty")
-    override val artistCatalogsProperty: ReadOnlySetProperty<ObservableArtistCatalog> =
-        SimpleSetProperty(this, "artist catalogs", observableArtistCatalogSet)
+        @get:JvmName("artistCatalogsProperty")
+        override val artistCatalogsProperty: ReadOnlySetProperty<ObservableArtistCatalog> =
+            SimpleSetProperty(this, "artist catalogs", observableArtistCatalogSet)
 
-    private val _albumsProperty = SimpleSetProperty<Album>(this, "albums", observableSet())
+        private val _albumsProperty = SimpleSetProperty<Album>(this, "albums", observableSet())
 
-    @get:JvmName("albumsProperty")
-    override val albumsProperty: ReadOnlySetProperty<Album> = _albumsProperty
+        @get:JvmName("albumsProperty")
+        override val albumsProperty: ReadOnlySetProperty<Album> = _albumsProperty
 
-    private val _albumCountProperty = SimpleIntegerProperty(this, "albumCount", 0)
+        private val _albumCountProperty = SimpleIntegerProperty(this, "albumCount", 0)
 
-    @get:JvmName("albumCountProperty")
-    override val albumCountProperty: ReadOnlyIntegerProperty = _albumCountProperty
+        @get:JvmName("albumCountProperty")
+        override val albumCountProperty: ReadOnlyIntegerProperty = _albumCountProperty
 
-    // Subscribe to repository events to populate audioItemsDelegate and artistsProperty.
-    // artistsProperty tracks all artists from artistsInvolved (primary + featured artists).
-    private val internalSubscription =
-        subscribe(CREATE, UPDATE, DELETE) { event ->
-            if (event.isDelete()) {
-                event.entities.keys.forEach { id ->
-                    audioItemIds.remove(id)
-                    pendingDeletedAudioItemIds.add(id)
-                }
-                recomputeArtistsRequested.set(true)
-                queueAudioItemsRefresh()
-            } else if (event.isCreate()) {
-                event.entities.values.forEach { item ->
-                    if (audioItemIds.add(item.id)) {
-                        pendingCreatedAudioItems.add(item)
+        // Subscribe to repository events to populate audioItemsDelegate and artistsProperty.
+        // artistsProperty tracks all artists from artistsInvolved (primary + featured artists).
+        private val internalSubscription =
+            subscribe(CREATE, UPDATE, DELETE) { event ->
+                if (event.isDelete()) {
+                    event.entities.keys.forEach { id ->
+                        audioItemIds.remove(id)
+                        pendingDeletedAudioItemIds.add(id)
                     }
+                    recomputeArtistsRequested.set(true)
+                    queueAudioItemsRefresh()
+                } else if (event.isCreate()) {
+                    event.entities.values.forEach { item ->
+                        if (audioItemIds.add(item.id)) {
+                            pendingCreatedAudioItems.add(item)
+                        }
+                    }
+                    queueAudioItemsRefresh()
+                } else {
+                    recomputeArtistsRequested.set(true)
+                    queueAudioItemsRefresh()
                 }
-                queueAudioItemsRefresh()
-            } else {
-                recomputeArtistsRequested.set(true)
-                queueAudioItemsRefresh()
+            }
+
+        private val catalogSubscription =
+            artistCatalogPublisher.subscribe(CREATE, UPDATE, DELETE) { event ->
+                if (event.isDelete()) {
+                    artistCatalogBacking.removeAll(event.entities.values.toSet())
+                } else {
+                    artistCatalogBacking.addAll(event.entities.values)
+                }
+                queueCatalogRefresh()
+            }
+
+        init {
+            RegistryBase.deregisterRepository(ObservableAudioItem::class.java)
+            RegistryBase.registerRepository(ObservableAudioItem::class.java, repository)
+
+            // Populate fxAggregateList and artistsProperty from existing items
+            val initialAudioItems = toList()
+            audioItemIds.addAll(initialAudioItems.map { it.id })
+            if (initialAudioItems.isNotEmpty()) {
+                Platform.runLater {
+                    audioItems.addAll(initialAudioItems)
+                    artistsProperty.addAll(initialAudioItems.flatMap { it.artistsInvolved })
+                }
+            }
+
+            // Populate catalog backing from registries created during AudioLibraryBase init
+            observableArtistCatalogRegistry.forEach { artistCatalogBacking.add(it) }
+            queueCatalogRefresh()
+
+            // Subscribe to the player events to update the play count
+            playerSubscriber.addOnNextEventAction(PLAYED) { event ->
+                val audioItem = event.audioItem
+                if (audioItem is FXAudioItem) {
+                    audioItem.incrementPlayCount()
+                    logger.debug { "Play count of audio item with id ${audioItem.id} increased to ${audioItem.playCount}" }
+                }
             }
         }
 
-    private val catalogSubscription =
-        artistCatalogPublisher.subscribe(CREATE, UPDATE, DELETE) { event ->
-            if (event.isDelete()) {
-                artistCatalogBacking.removeAll(event.entities.values.toSet())
-            } else {
-                artistCatalogBacking.addAll(event.entities.values)
+        private fun queueAudioItemsRefresh() {
+            if (!audioItemsRefreshQueued.compareAndSet(false, true)) {
+                return
             }
+            ReactiveScope.flowScope.launch {
+                delay(FX_REFRESH_DEBOUNCE_MILLIS)
+                Platform.runLater {
+                    try {
+                        drainAudioItemChanges()
+                    } finally {
+                        audioItemsRefreshQueued.set(false)
+                        if (hasPendingAudioItemRefresh()) {
+                            queueAudioItemsRefresh()
+                        }
+                    }
+                }
+            }
+        }
+
+        private fun drainAudioItemChanges() {
+            val deletedIds = generateSequence { pendingDeletedAudioItemIds.poll() }.toSet()
+            if (deletedIds.isNotEmpty()) {
+                audioItems.removeAll(audioItems.filter { it.id in deletedIds })
+            }
+
+            val createdAudioItems =
+                generateSequence { pendingCreatedAudioItems.poll() }
+                    .filter { it.id in audioItemIds }
+                    .toList()
+            if (createdAudioItems.isNotEmpty()) {
+                audioItems.addAll(createdAudioItems)
+            }
+
+            if (recomputeArtistsRequested.getAndSet(false)) {
+                val allArtists = audioItems.flatMap { it.artistsInvolved }.toSet()
+                artistsProperty.retainAll(allArtists)
+                artistsProperty.addAll(allArtists)
+            } else if (createdAudioItems.isNotEmpty()) {
+                artistsProperty.addAll(createdAudioItems.flatMap { it.artistsInvolved })
+            }
+        }
+
+        private fun hasPendingAudioItemRefresh(): Boolean =
+            pendingCreatedAudioItems.isNotEmpty() || pendingDeletedAudioItemIds.isNotEmpty() || recomputeArtistsRequested.get()
+
+        private fun queueCatalogRefresh() {
+            catalogRefreshRequested.set(true)
+            if (!catalogRefreshQueued.compareAndSet(false, true)) {
+                return
+            }
+            ReactiveScope.flowScope.launch {
+                delay(FX_REFRESH_DEBOUNCE_MILLIS)
+                Platform.runLater {
+                    try {
+                        catalogRefreshRequested.set(false)
+                        refreshCatalogProperties()
+                    } finally {
+                        catalogRefreshQueued.set(false)
+                        if (catalogRefreshRequested.get()) {
+                            queueCatalogRefresh()
+                        }
+                    }
+                }
+            }
+        }
+
+        private fun refreshCatalogProperties() {
+            observableArtistCatalogSet.apply {
+                clear()
+                addAll(artistCatalogBacking)
+            }
+            val allAlbums =
+                artistCatalogBacking.flatMap { catalog ->
+                    catalog.albums.map { it.first().album }
+                }.toSet()
+            _albumsProperty.apply {
+                clear()
+                addAll(allAlbums)
+            }
+            _albumCountProperty.set(allAlbums.size)
+        }
+
+        /**
+         * Cancels all event subscriptions managed by this library, including those from the base class
+         * and the FX-specific internal and catalog subscriptions, then deregisters the repository from LirpContext.
+         */
+        override fun close() {
+            super.close()
+            internalSubscription.cancel()
+            catalogSubscription.cancel()
+            RegistryBase.deregisterRepository(ObservableAudioItem::class.java)
+        }
+
+        override fun clear() {
+            super.clear()
+            audioItemIds.clear()
+            pendingCreatedAudioItems.clear()
+            pendingDeletedAudioItemIds.clear()
+            Platform.runLater {
+                audioItems.clear()
+                artistsProperty.clear()
+            }
+            artistCatalogBacking.clear()
             queueCatalogRefresh()
         }
 
-    init {
-        RegistryBase.deregisterRepository(ObservableAudioItem::class.java)
-        RegistryBase.registerRepository(ObservableAudioItem::class.java, repository)
-
-        // Populate fxAggregateList and artistsProperty from existing items
-        val initialAudioItems = toList()
-        audioItemIds.addAll(initialAudioItems.map { it.id })
-        if (initialAudioItems.isNotEmpty()) {
-            Platform.runLater {
-                audioItems.addAll(initialAudioItems)
-                artistsProperty.addAll(initialAudioItems.flatMap { it.artistsInvolved })
-            }
-        }
-
-        // Populate catalog backing from registries created during AudioLibraryBase init
-        observableArtistCatalogRegistry.forEach { artistCatalogBacking.add(it) }
-        queueCatalogRefresh()
-
-        // Subscribe to the player events to update the play count
-        playerSubscriber.addOnNextEventAction(PLAYED) { event ->
-            val audioItem = event.audioItem
-            if (audioItem is FXAudioItem) {
-                audioItem.incrementPlayCount()
-                logger.debug { "Play count of audio item with id ${audioItem.id} increased to ${audioItem.playCount}" }
-            }
-        }
-    }
-
-    private fun queueAudioItemsRefresh() {
-        if (!audioItemsRefreshQueued.compareAndSet(false, true)) {
-            return
-        }
-        ReactiveScope.flowScope.launch {
-            delay(FX_REFRESH_DEBOUNCE_MILLIS)
-            Platform.runLater {
-                try {
-                    drainAudioItemChanges()
-                } finally {
-                    audioItemsRefreshQueued.set(false)
-                    if (hasPendingAudioItemRefresh()) {
-                        queueAudioItemsRefresh()
-                    }
+        override fun createFromFile(audioItemPath: Path): FXAudioItem =
+            FXAudioItem(audioItemPath, newId(), metadataUtils)
+                .also { fxAudioItem ->
+                    add(fxAudioItem)
+                    logger.debug { "New ObservableAudioItem was created from file $audioItemPath with id ${fxAudioItem.id}" }
                 }
-            }
-        }
+
+        override fun toString() = "FXAudioLibrary(audioItemsCount=${size()})"
     }
-
-    private fun drainAudioItemChanges() {
-        val deletedIds = generateSequence { pendingDeletedAudioItemIds.poll() }.toSet()
-        if (deletedIds.isNotEmpty()) {
-            audioItems.removeAll(audioItems.filter { it.id in deletedIds })
-        }
-
-        val createdAudioItems =
-            generateSequence { pendingCreatedAudioItems.poll() }
-                .filter { it.id in audioItemIds }
-                .toList()
-        if (createdAudioItems.isNotEmpty()) {
-            audioItems.addAll(createdAudioItems)
-        }
-
-        if (recomputeArtistsRequested.getAndSet(false)) {
-            val allArtists = audioItems.flatMap { it.artistsInvolved }.toSet()
-            artistsProperty.retainAll(allArtists)
-            artistsProperty.addAll(allArtists)
-        } else if (createdAudioItems.isNotEmpty()) {
-            artistsProperty.addAll(createdAudioItems.flatMap { it.artistsInvolved })
-        }
-    }
-
-    private fun hasPendingAudioItemRefresh(): Boolean =
-        pendingCreatedAudioItems.isNotEmpty() || pendingDeletedAudioItemIds.isNotEmpty() || recomputeArtistsRequested.get()
-
-    private fun queueCatalogRefresh() {
-        catalogRefreshRequested.set(true)
-        if (!catalogRefreshQueued.compareAndSet(false, true)) {
-            return
-        }
-        ReactiveScope.flowScope.launch {
-            delay(FX_REFRESH_DEBOUNCE_MILLIS)
-            Platform.runLater {
-                try {
-                    catalogRefreshRequested.set(false)
-                    refreshCatalogProperties()
-                } finally {
-                    catalogRefreshQueued.set(false)
-                    if (catalogRefreshRequested.get()) {
-                        queueCatalogRefresh()
-                    }
-                }
-            }
-        }
-    }
-
-    private fun refreshCatalogProperties() {
-        observableArtistCatalogSet.apply {
-            clear()
-            addAll(artistCatalogBacking)
-        }
-        val allAlbums =
-            artistCatalogBacking.flatMap { catalog ->
-                catalog.albums.map { it.first().album }
-            }.toSet()
-        _albumsProperty.apply {
-            clear()
-            addAll(allAlbums)
-        }
-        _albumCountProperty.set(allAlbums.size)
-    }
-
-    /**
-     * Cancels all event subscriptions managed by this library, including those from the base class
-     * and the FX-specific internal and catalog subscriptions, then deregisters the repository from LirpContext.
-     */
-    override fun close() {
-        super.close()
-        internalSubscription.cancel()
-        catalogSubscription.cancel()
-        RegistryBase.deregisterRepository(ObservableAudioItem::class.java)
-    }
-
-    override fun clear() {
-        super.clear()
-        audioItemIds.clear()
-        pendingCreatedAudioItems.clear()
-        pendingDeletedAudioItemIds.clear()
-        Platform.runLater {
-            audioItems.clear()
-            artistsProperty.clear()
-        }
-        artistCatalogBacking.clear()
-        queueCatalogRefresh()
-    }
-
-    override fun createFromFile(audioItemPath: Path): FXAudioItem =
-        FXAudioItem(audioItemPath, newId())
-            .also { fxAudioItem ->
-                add(fxAudioItem)
-                logger.debug { "New ObservableAudioItem was created from file $audioItemPath with id ${fxAudioItem.id}" }
-            }
-
-    override fun toString() = "FXAudioLibrary(audioItemsCount=${size()})"
-}

--- a/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/audio/ObservableAudioItemSerializer.kt
+++ b/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/audio/ObservableAudioItemSerializer.kt
@@ -21,6 +21,8 @@ import net.transgressoft.commons.music.audio.Album
 import net.transgressoft.commons.music.audio.Artist
 import net.transgressoft.commons.music.audio.AudioItemSerializerBase
 import net.transgressoft.commons.music.audio.Genre
+import java.nio.file.FileSystem
+import java.nio.file.FileSystems
 import java.nio.file.Path
 import java.time.Duration
 import java.time.LocalDateTime
@@ -29,7 +31,7 @@ import kotlinx.serialization.builtins.MapSerializer
 import kotlinx.serialization.builtins.serializer
 
 @get:JvmName("ObservableAudioItemMapSerializer")
-internal val ObservableAudioItemMapSerializer: KSerializer<Map<Int, ObservableAudioItem>> = MapSerializer(Int.serializer(), ObservableAudioItemSerializer)
+internal val ObservableAudioItemMapSerializer: KSerializer<Map<Int, ObservableAudioItem>> = MapSerializer(Int.serializer(), ObservableAudioItemSerializer())
 
 /**
  * Kotlinx serialization serializer for [ObservableAudioItem] instances.
@@ -37,45 +39,53 @@ internal val ObservableAudioItemMapSerializer: KSerializer<Map<Int, ObservableAu
  * Serializes JavaFX audio items to JSON, preserving all metadata while excluding
  * transient JavaFX properties. Creates [FXAudioItem] instances during deserialization
  * that automatically reconstruct JavaFX property bindings.
+ *
+ * @param fileSystem the [FileSystem] used to materialize [Path] instances during
+ *  deserialization. Defaults to [FileSystems.getDefault]; tests may pass a Jimfs
+ *  filesystem to deserialize against an in-memory tree.
  */
-internal object ObservableAudioItemSerializer : AudioItemSerializerBase<ObservableAudioItem>() {
+internal class ObservableAudioItemSerializer
+    @JvmOverloads
+    constructor(
+        fileSystem: FileSystem = FileSystems.getDefault()
+    ) : AudioItemSerializerBase<ObservableAudioItem>(fileSystem) {
 
-    override fun constructEntity(
-        path: Path,
-        id: Int,
-        title: String,
-        duration: Duration,
-        bitRate: Int,
-        artist: Artist,
-        album: Album,
-        genres: Set<Genre>,
-        comments: String?,
-        trackNumber: Short?,
-        discNumber: Short?,
-        bpm: Float?,
-        encoder: String?,
-        encoding: String?,
-        dateOfCreation: LocalDateTime,
-        lastDateModified: LocalDateTime,
-        playCount: Short
-    ): ObservableAudioItem =
-        FXAudioItem(
-            path = path,
-            id = id,
-            title = title,
-            duration = duration,
-            bitRate = bitRate,
-            artist = artist,
-            album = album,
-            genres = genres,
-            comments = comments,
-            trackNumber = trackNumber,
-            discNumber = discNumber,
-            bpm = bpm,
-            encoder = encoder,
-            encoding = encoding,
-            dateOfCreation = dateOfCreation,
-            lastDateModified = lastDateModified,
-            playCount = playCount
-        )
-}
+        override fun constructEntity(
+            path: Path,
+            id: Int,
+            title: String,
+            duration: Duration,
+            bitRate: Int,
+            artist: Artist,
+            album: Album,
+            genres: Set<Genre>,
+            comments: String?,
+            trackNumber: Short?,
+            discNumber: Short?,
+            bpm: Float?,
+            encoder: String?,
+            encoding: String?,
+            dateOfCreation: LocalDateTime,
+            lastDateModified: LocalDateTime,
+            playCount: Short
+        ): ObservableAudioItem =
+            FXAudioItem(
+                path = path,
+                id = id,
+                title = title,
+                duration = duration,
+                bitRate = bitRate,
+                artist = artist,
+                album = album,
+                genres = genres,
+                comments = comments,
+                trackNumber = trackNumber,
+                discNumber = discNumber,
+                bpm = bpm,
+                encoder = encoder,
+                encoding = encoding,
+                dateOfCreation = dateOfCreation,
+                lastDateModified = lastDateModified,
+                playCount = playCount
+            )
+    }

--- a/music-commons-fx/src/test/kotlin/net/transgressoft/commons/fx/music/FXMusicLibraryTest.kt
+++ b/music-commons-fx/src/test/kotlin/net/transgressoft/commons/fx/music/FXMusicLibraryTest.kt
@@ -76,7 +76,7 @@ internal class FXMusicLibraryTest : StringSpec({
     }
 
     "FXMusicLibrary curated methods work for audio items and playlists" {
-        val library = FXMusicLibrary.builder().build()
+        val library = FXMusicLibrary.Builder(files.metadataUtils).build()
 
         val audioPath = files.virtualAudioFile().next()
         val audioItem = library.audioItemFromFile(audioPath)
@@ -106,7 +106,7 @@ internal class FXMusicLibraryTest : StringSpec({
     }
 
     "FXMusicLibrary createPlaylist with non-empty audioItemIds resolves the playlist cover image after lirp binding" {
-        val library = FXMusicLibrary.builder().build()
+        val library = FXMusicLibrary.Builder(files.metadataUtils).build()
 
         val audioPath = files.virtualAudioFile().next()
         val audioItem = library.audioItemFromFile(audioPath)
@@ -155,7 +155,7 @@ internal class FXMusicLibraryTest : StringSpec({
     }
 
     "FXMusicLibrary close releases all resources" {
-        val library = FXMusicLibrary.builder().build()
+        val library = FXMusicLibrary.Builder(files.metadataUtils).build()
 
         val audioItem = library.audioItemFromFile(files.virtualAudioFile().next())
 

--- a/music-commons-fx/src/test/kotlin/net/transgressoft/commons/fx/music/audio/FXArtistCatalogTest.kt
+++ b/music-commons-fx/src/test/kotlin/net/transgressoft/commons/fx/music/audio/FXArtistCatalogTest.kt
@@ -39,7 +39,7 @@ internal class FXArtistCatalogTest : StringSpec({
                 this.artist = artist
                 this.album = album
             }.next()
-        val audioItem = FXAudioItem(path)
+        val audioItem = FXAudioItem(path, metadataUtils = files.metadataUtils)
 
         catalog1.addAudioItem(audioItem)
 
@@ -55,7 +55,7 @@ internal class FXArtistCatalogTest : StringSpec({
                 this.artist = artist
                 this.album = album
             }.next()
-        val audioItem = FXAudioItem(path)
+        val audioItem = FXAudioItem(path, metadataUtils = files.metadataUtils)
 
         catalog1.addAudioItem(audioItem)
         catalog2.addAudioItem(audioItem)
@@ -72,7 +72,7 @@ internal class FXArtistCatalogTest : StringSpec({
                 this.artist = artist
                 this.album = album
             }.next()
-        val audioItem = FXAudioItem(path)
+        val audioItem = FXAudioItem(path, metadataUtils = files.metadataUtils)
 
         catalog1.addAudioItem(audioItem)
 
@@ -88,7 +88,7 @@ internal class FXArtistCatalogTest : StringSpec({
                 this.artist = artist
                 this.album = album
             }.next()
-        val audioItem = FXAudioItem(path)
+        val audioItem = FXAudioItem(path, metadataUtils = files.metadataUtils)
         catalog.addAudioItem(audioItem)
 
         cloneBefore shouldNotBe catalog
@@ -105,7 +105,7 @@ internal class FXArtistCatalogTest : StringSpec({
                     this.artist = artist
                     this.album = album
                 }.next()
-            catalog.addAudioItem(FXAudioItem(path))
+            catalog.addAudioItem(FXAudioItem(path, metadataUtils = files.metadataUtils))
         }
 
         reactive.advance()

--- a/music-commons-fx/src/test/kotlin/net/transgressoft/commons/fx/music/audio/FXAudioItemTest.kt
+++ b/music-commons-fx/src/test/kotlin/net/transgressoft/commons/fx/music/audio/FXAudioItemTest.kt
@@ -49,7 +49,7 @@ internal class FXAudioItemTest : StringSpec({
     "Changes its properties when observable properties are updated" {
         val path = files.virtualAudioFile().next()
 
-        val fxAudioItem = FXAudioItem(path)
+        val fxAudioItem = FXAudioItem(path, metadataUtils = files.metadataUtils)
         assertSoftly {
             fxAudioItem.titleProperty.value shouldBe fxAudioItem.title
             fxAudioItem.artistProperty.value shouldBe fxAudioItem.artist
@@ -158,9 +158,9 @@ internal class FXAudioItemTest : StringSpec({
         val testAudioFile = Arb.realAudioFile().next()
         val fxAudioItem = FXAudioItem(testAudioFile)
 
-        json.encodeToString(ObservableAudioItemSerializer, fxAudioItem).let {
+        json.encodeToString(ObservableAudioItemSerializer(), fxAudioItem).let {
             it.shouldEqualJson(fxAudioItem.asJsonValue())
-            json.decodeFromString<FXAudioItem>(it) shouldBe fxAudioItem
+            (json.decodeFromString(ObservableAudioItemSerializer(), it) as FXAudioItem) shouldBe fxAudioItem
         }
 
         val audioItemChanges = Arb.audioItemChange().next()
@@ -212,8 +212,8 @@ internal class FXAudioItemTest : StringSpec({
 
         fxAudioItem.writeMetadata().join()
 
-        val encodedAudioItem = json.encodeToString(ObservableAudioItemSerializer, fxAudioItem)
-        val decodedAudioItem = json.decodeFromString<FXAudioItem>(encodedAudioItem)
+        val encodedAudioItem = json.encodeToString(ObservableAudioItemSerializer(), fxAudioItem)
+        val decodedAudioItem = json.decodeFromString(ObservableAudioItemSerializer(), encodedAudioItem) as FXAudioItem
 
         decodedAudioItem.coverImageBytes shouldBe testCoverBytes
         decodedAudioItem.coverImageProperty.value shouldBePresent {

--- a/music-commons-fx/src/test/kotlin/net/transgressoft/commons/fx/music/audio/ObservableAudioItemSerializerTest.kt
+++ b/music-commons-fx/src/test/kotlin/net/transgressoft/commons/fx/music/audio/ObservableAudioItemSerializerTest.kt
@@ -12,10 +12,14 @@ import io.kotest.matchers.string.shouldContain
 import io.kotest.property.arbitrary.next
 import java.nio.file.Files
 import java.time.temporal.ChronoUnit.SECONDS
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.put
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.polymorphic
 
 /**
  * Tests for [ObservableAudioItemSerializer] verifying golden JSON structure and round-trip fidelity.
@@ -23,16 +27,23 @@ import kotlinx.serialization.json.put
 internal class ObservableAudioItemSerializerTest : StringSpec({
     val files = virtualFiles()
 
+    // Bind the serializer to the Jimfs filesystem so encoded `file://` URIs deserialize back to
+    // the same Jimfs path tree on round-trip.
+    val fxSerializer = ObservableAudioItemSerializer(files.fileSystem)
     val json =
         Json {
-            serializersModule = observableAudioItemSerializerModule
+            serializersModule =
+                SerializersModule {
+                    polymorphic(ObservableAudioItem::class, fxSerializer)
+                }
         }
+    val fxMapSerializer = MapSerializer(Int.serializer(), fxSerializer)
 
     "ObservableAudioItemSerializer encodes all required JSON fields" {
         val path = files.virtualAudioFile().next()
-        val fxAudioItem = FXAudioItem(path, AudioItemTestFactory.nextTestId())
+        val fxAudioItem = FXAudioItem(path, AudioItemTestFactory.nextTestId(), files.metadataUtils)
 
-        val encoded = json.encodeToString(ObservableAudioItemSerializer, fxAudioItem)
+        val encoded = json.encodeToString(fxSerializer, fxAudioItem)
 
         encoded shouldContainJsonKey "path"
         encoded shouldContainJsonKey "id"
@@ -49,10 +60,10 @@ internal class ObservableAudioItemSerializerTest : StringSpec({
 
     "ObservableAudioItemSerializer round-trip preserves all fields" {
         val path = files.virtualAudioFile().next()
-        val original = FXAudioItem(path, AudioItemTestFactory.nextTestId())
+        val original = FXAudioItem(path, AudioItemTestFactory.nextTestId(), files.metadataUtils)
 
-        val encoded = json.encodeToString(ObservableAudioItemSerializer, original)
-        val decoded = json.decodeFromString(ObservableAudioItemSerializer, encoded)
+        val encoded = json.encodeToString(fxSerializer, original)
+        val decoded = json.decodeFromString(fxSerializer, encoded)
 
         decoded.id shouldBe original.id
         decoded.path shouldBe original.path
@@ -78,9 +89,9 @@ internal class ObservableAudioItemSerializerTest : StringSpec({
             files.virtualAudioFile {
                 this.genres = setOf(Genre.Rock)
             }.next()
-        val original = FXAudioItem(path, AudioItemTestFactory.nextTestId())
+        val original = FXAudioItem(path, AudioItemTestFactory.nextTestId(), files.metadataUtils)
 
-        val encoded = json.encodeToString(ObservableAudioItemSerializer, original)
+        val encoded = json.encodeToString(fxSerializer, original)
 
         // Replace "genres" array with legacy "genre" single-string field
         val jsonTree = Json.parseToJsonElement(encoded).jsonObject
@@ -92,15 +103,15 @@ internal class ObservableAudioItemSerializerTest : StringSpec({
                 put("genre", "Rock")
             }
 
-        val decoded = json.decodeFromString(ObservableAudioItemSerializer, legacyItem.toString())
+        val decoded = json.decodeFromString(fxSerializer, legacyItem.toString())
         decoded.genres shouldBe setOf(Genre.Rock)
     }
 
     "ObservableAudioItemSerializer inherits file:// URI format from ReactiveAudioItem.toJsonObject" {
         val path = files.virtualAudioFile().next()
-        val fxAudioItem = FXAudioItem(path, AudioItemTestFactory.nextTestId())
+        val fxAudioItem = FXAudioItem(path, AudioItemTestFactory.nextTestId(), files.metadataUtils)
 
-        val encoded = json.encodeToString(ObservableAudioItemSerializer, fxAudioItem)
+        val encoded = json.encodeToString(fxSerializer, fxAudioItem)
 
         encoded shouldContain "\"path\":\"file://"
     }
@@ -138,7 +149,7 @@ internal class ObservableAudioItemSerializerTest : StringSpec({
             """.trimIndent()
 
         shouldThrow<InvalidAudioFilePathException> {
-            json.decodeFromString(ObservableAudioItemSerializer, offlineDriveJson)
+            json.decodeFromString(fxSerializer, offlineDriveJson)
         }
     }
 
@@ -147,12 +158,12 @@ internal class ObservableAudioItemSerializerTest : StringSpec({
         val path2 = files.virtualAudioFile().next()
         val id1 = AudioItemTestFactory.nextTestId()
         val id2 = AudioItemTestFactory.nextTestId()
-        val item1 = FXAudioItem(path1, id1)
-        val item2 = FXAudioItem(path2, id2)
+        val item1 = FXAudioItem(path1, id1, files.metadataUtils)
+        val item2 = FXAudioItem(path2, id2, files.metadataUtils)
         val originalMap = mapOf(id1 to item1, id2 to item2)
 
-        val encoded = json.encodeToString(ObservableAudioItemMapSerializer, originalMap)
-        val decoded = json.decodeFromString(ObservableAudioItemMapSerializer, encoded)
+        val encoded = json.encodeToString(fxMapSerializer, originalMap)
+        val decoded = json.decodeFromString(fxMapSerializer, encoded)
 
         decoded.size shouldBe 2
         decoded[id1]!!.id shouldBe item1.id

--- a/music-commons-fx/src/test/kotlin/net/transgressoft/commons/fx/music/audio/ObservableAudioLibraryTest.kt
+++ b/music-commons-fx/src/test/kotlin/net/transgressoft/commons/fx/music/audio/ObservableAudioLibraryTest.kt
@@ -29,6 +29,8 @@ import java.io.File
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.builtins.serializer
 
 @ExperimentalCoroutinesApi
 internal class ObservableAudioLibraryTest : StringSpec({
@@ -45,8 +47,8 @@ internal class ObservableAudioLibraryTest : StringSpec({
 
     beforeEach {
         jsonFile = tempfile("observableAudioLibrary-test", ".json").also { it.deleteOnExit() }
-        jsonFileRepository = JsonFileRepository(jsonFile, ObservableAudioItemMapSerializer)
-        repository = FXAudioLibrary(jsonFileRepository)
+        jsonFileRepository = JsonFileRepository(jsonFile, MapSerializer(Int.serializer(), ObservableAudioItemSerializer(files.fileSystem)))
+        repository = FXAudioLibrary(jsonFileRepository, files.metadataUtils)
     }
 
     afterEach {
@@ -108,7 +110,7 @@ internal class ObservableAudioLibraryTest : StringSpec({
 
         // Close the existing library before recreating from the same repository
         repository.close()
-        repository = FXAudioLibrary(jsonFileRepository)
+        repository = FXAudioLibrary(jsonFileRepository, files.metadataUtils)
 
         reactive.advance()
         WaitForAsyncUtils.waitForFxEvents()

--- a/music-commons-media/src/main/kotlin/net/transgressoft/commons/media/waveform/AudioWaveformSerializer.kt
+++ b/music-commons-media/src/main/kotlin/net/transgressoft/commons/media/waveform/AudioWaveformSerializer.kt
@@ -21,6 +21,8 @@ import net.transgressoft.commons.music.common.toJsonUri
 import net.transgressoft.commons.music.common.toPathFromJsonUri
 import net.transgressoft.commons.music.waveform.AudioWaveform
 import java.nio.ByteBuffer
+import java.nio.file.FileSystem
+import java.nio.file.FileSystems
 import java.util.Base64
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerializationException
@@ -40,7 +42,7 @@ import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 
 @get:JvmName("AudioWaveformMapSerializer")
-val AudioWaveformMapSerializer: KSerializer<Map<Int, AudioWaveform>> = MapSerializer(Int.serializer(), AudioWaveformSerializer)
+val AudioWaveformMapSerializer: KSerializer<Map<Int, AudioWaveform>> = MapSerializer(Int.serializer(), AudioWaveformSerializer())
 
 /**
  * Kotlinx serialization serializer for [AudioWaveform] instances.
@@ -51,68 +53,80 @@ val AudioWaveformMapSerializer: KSerializer<Map<Int, AudioWaveform>> = MapSerial
  *
  * All four fields (`id`, `audioFilePath`, `cachedWidth`, `normalizedAmplitudes`) are required.
  * Malformed Base64 payloads and cache size mismatches produce [kotlinx.serialization.SerializationException].
+ *
+ * @param fileSystem the [FileSystem] used to materialize the [java.nio.file.Path] backing
+ *  the deserialized waveform. Defaults to [FileSystems.getDefault]; tests may pass a
+ *  Jimfs filesystem to round-trip waveform JSON against an in-memory tree.
  */
-object AudioWaveformSerializer : KSerializer<AudioWaveform> {
+class AudioWaveformSerializer
+    @JvmOverloads
+    constructor(
+        private val fileSystem: FileSystem = FileSystems.getDefault()
+    ) : KSerializer<AudioWaveform> {
 
-    override val descriptor: SerialDescriptor =
-        buildClassSerialDescriptor("AudioWaveform") {
-            element<String>("id")
-            element<String>("audioFilePath")
-            element<Int>("cachedWidth")
-            element<String>("normalizedAmplitudes")
-        }
-
-    override fun deserialize(decoder: Decoder): AudioWaveform {
-        val jsonInput = decoder as? JsonDecoder ?: throw SerializationException("This class can be saved only by Json")
-        val jsonObject = jsonInput.decodeJsonElement().jsonObject
-        val id =
-            (jsonObject["id"] ?: throw SerializationException("Missing required field 'id' in AudioWaveform JSON"))
-                .jsonPrimitive.int
-        val audioFilePathString =
-            (jsonObject["audioFilePath"] ?: throw SerializationException("Missing required field 'audioFilePath' in AudioWaveform JSON"))
-                .jsonPrimitive.content
-        val cachedWidth =
-            (jsonObject["cachedWidth"] ?: throw SerializationException("Missing required field 'cachedWidth' in AudioWaveform JSON"))
-                .jsonPrimitive.int
-        val normalizedAmplitudesBase64 =
-            (jsonObject["normalizedAmplitudes"] ?: throw SerializationException("Missing required field 'normalizedAmplitudes' in AudioWaveform JSON"))
-                .jsonPrimitive.content
-
-        val decodedAmplitudes =
-            try {
-                normalizedAmplitudesBase64.toFloatArrayFromBase64()
-            } catch (e: IllegalArgumentException) {
-                throw SerializationException("Malformed Base64 in normalizedAmplitudes for AudioWaveform id=$id", e)
+        override val descriptor: SerialDescriptor =
+            buildClassSerialDescriptor("AudioWaveform") {
+                element<String>("id")
+                element<String>("audioFilePath")
+                element<Int>("cachedWidth")
+                element<String>("normalizedAmplitudes")
             }
 
-        if (decodedAmplitudes.size != cachedWidth) {
-            throw SerializationException(
-                "Cache mismatch for AudioWaveform id=$id: cachedWidth=$cachedWidth but decoded ${decodedAmplitudes.size} amplitudes"
+        override fun deserialize(decoder: Decoder): AudioWaveform {
+            val jsonInput = decoder as? JsonDecoder ?: throw SerializationException("This class can be saved only by Json")
+            val jsonObject = jsonInput.decodeJsonElement().jsonObject
+            val id =
+                (jsonObject["id"] ?: throw SerializationException("Missing required field 'id' in AudioWaveform JSON"))
+                    .jsonPrimitive.int
+            val audioFilePathString =
+                (jsonObject["audioFilePath"] ?: throw SerializationException("Missing required field 'audioFilePath' in AudioWaveform JSON"))
+                    .jsonPrimitive.content
+            val cachedWidth =
+                (jsonObject["cachedWidth"] ?: throw SerializationException("Missing required field 'cachedWidth' in AudioWaveform JSON"))
+                    .jsonPrimitive.int
+            val normalizedAmplitudesBase64 =
+                (jsonObject["normalizedAmplitudes"] ?: throw SerializationException("Missing required field 'normalizedAmplitudes' in AudioWaveform JSON"))
+                    .jsonPrimitive.content
+
+            val decodedAmplitudes =
+                try {
+                    normalizedAmplitudesBase64.toFloatArrayFromBase64()
+                } catch (e: IllegalArgumentException) {
+                    throw SerializationException("Malformed Base64 in normalizedAmplitudes for AudioWaveform id=$id", e)
+                }
+
+            if (decodedAmplitudes.size != cachedWidth) {
+                throw SerializationException(
+                    "Cache mismatch for AudioWaveform id=$id: cachedWidth=$cachedWidth but decoded ${decodedAmplitudes.size} amplitudes"
+                )
+            }
+
+            return ScalableAudioWaveform(
+                id,
+                if (fileSystem == FileSystems.getDefault()) {
+                    audioFilePathString.toPathFromJsonUri()
+                } else {
+                    audioFilePathString.toPathFromJsonUri(fileSystem)
+                },
+                cachedWidth,
+                decodedAmplitudes
             )
         }
 
-        return ScalableAudioWaveform(
-            id,
-            audioFilePathString.toPathFromJsonUri(),
-            cachedWidth,
-            decodedAmplitudes
-        )
+        override fun serialize(encoder: Encoder, value: AudioWaveform) {
+            val jsonOutput = encoder as? JsonEncoder ?: throw SerializationException("This class can be saved only by Json")
+            val sw = value as ScalableAudioWaveform
+            val snapshot = sw.normalizedAmplitudesSnapshot ?: FloatArray(0)
+            val jsonObject =
+                buildJsonObject {
+                    put("id", value.id)
+                    put("audioFilePath", value.audioFilePath.toJsonUri())
+                    put("cachedWidth", sw.cachedWidth)
+                    put("normalizedAmplitudes", snapshot.toBase64String())
+                }
+            jsonOutput.encodeJsonElement(jsonObject)
+        }
     }
-
-    override fun serialize(encoder: Encoder, value: AudioWaveform) {
-        val jsonOutput = encoder as? JsonEncoder ?: throw SerializationException("This class can be saved only by Json")
-        val sw = value as ScalableAudioWaveform
-        val snapshot = sw.normalizedAmplitudesSnapshot ?: FloatArray(0)
-        val jsonObject =
-            buildJsonObject {
-                put("id", value.id)
-                put("audioFilePath", value.audioFilePath.toJsonUri())
-                put("cachedWidth", sw.cachedWidth)
-                put("normalizedAmplitudes", snapshot.toBase64String())
-            }
-        jsonOutput.encodeJsonElement(jsonObject)
-    }
-}
 
 /**
  * Encodes this [FloatArray] to a Base64 string using IEEE 754 big-endian byte representation.

--- a/music-commons-media/src/main/kotlin/net/transgressoft/commons/media/waveform/AudioWaveformSerializer.kt
+++ b/music-commons-media/src/main/kotlin/net/transgressoft/commons/media/waveform/AudioWaveformSerializer.kt
@@ -66,7 +66,7 @@ class AudioWaveformSerializer
 
         override val descriptor: SerialDescriptor =
             buildClassSerialDescriptor("AudioWaveform") {
-                element<String>("id")
+                element<Int>("id")
                 element<String>("audioFilePath")
                 element<Int>("cachedWidth")
                 element<String>("normalizedAmplitudes")

--- a/music-commons-media/src/test/kotlin/net/transgressoft/commons/media/waveform/DefaultAudioWaveformRepositoryTest.kt
+++ b/music-commons-media/src/test/kotlin/net/transgressoft/commons/media/waveform/DefaultAudioWaveformRepositoryTest.kt
@@ -15,6 +15,8 @@ import io.kotest.matchers.shouldBe
 import io.kotest.property.arbitrary.next
 import java.io.File
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.builtins.serializer
 
 @ExperimentalCoroutinesApi
 internal class DefaultAudioWaveformRepositoryTest : StringSpec({
@@ -27,7 +29,7 @@ internal class DefaultAudioWaveformRepositoryTest : StringSpec({
 
     beforeEach {
         jsonFile = tempfile("audioWaveformRepository-test", ".json").also { it.deleteOnExit() }
-        jsonFileRepository = JsonFileRepository(jsonFile, AudioWaveformMapSerializer)
+        jsonFileRepository = JsonFileRepository(jsonFile, MapSerializer(Int.serializer(), AudioWaveformSerializer(files.fileSystem)))
         val subscriber =
             object : LirpEventSubscriberBase<
                 net.transgressoft.commons.music.audio.AudioItem,

--- a/music-commons-test/src/main/kotlin/net/transgressoft/commons/music/audio/FakeAudioMetadataIO.kt
+++ b/music-commons-test/src/main/kotlin/net/transgressoft/commons/music/audio/FakeAudioMetadataIO.kt
@@ -1,0 +1,158 @@
+/******************************************************************************
+ * Copyright (C) 2025  Octavio Calleya Garcia                                 *
+ *                                                                            *
+ * This program is free software: you can redistribute it and/or modify       *
+ * it under the terms of the GNU General Public License as published by       *
+ * the Free Software Foundation, either version 3 of the License, or          *
+ * (at your option) any later version.                                        *
+ *                                                                            *
+ * This program is distributed in the hope that it will be useful,            *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
+ * GNU General Public License for more details.                               *
+ *                                                                            *
+ * You should have received a copy of the GNU General Public License          *
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.     *
+ ******************************************************************************/
+
+package net.transgressoft.commons.music.audio
+
+import org.jaudiotagger.audio.AudioFileIO
+import org.jaudiotagger.tag.Tag
+import java.nio.file.FileSystems
+import java.nio.file.Path
+
+/**
+ * In-memory test fake of [AudioMetadataIO] backed by per-[Path] maps of real JAudioTagger tags,
+ * header info, and cover bytes.
+ *
+ * Specs stub the metadata they need with [stub], [stubHeader], and [stubCover], then inject the
+ * fake into the system under test. No JVM-global static interception and no
+ * `mockk<Tag>()` plumbing for individual fields — the fake constructs **real** format-specific
+ * tag instances via [AudioFileTagType.newActualTag] so `setField`/`getFirst`/`hasField` behave
+ * exactly as they do against on-disk files. This preserves format-specific quirks (e.g. `WavTag`
+ * throwing `UnsupportedOperationException` for unsupported fields) which the production
+ * `getFieldIfExisting` helper already handles.
+ *
+ * Tags returned from [readTag] reflect format-correct behavior; new `FieldKey`s require no
+ * fake-side maintenance because `setField`/`getFirst` work natively on the real tag types.
+ *
+ * Example:
+ * ```
+ * val io = FakeAudioMetadataIO()
+ * io.stub(path, AudioFileTagType.ID3_V_24) {
+ *     setField(FieldKey.ARTIST, "Some Artist")
+ *     setField(FieldKey.ALBUM, "Some Album")
+ * }
+ * io.stubHeader(path, HeaderInfo("MPEG-1 Layer 3", 320, 180L, "MPEG-1 Layer 3"))
+ * io.stubCover(path, coverBytes)
+ *
+ * // Inject into SUT:
+ * val item = MutableAudioItem(path, metadataIO = io)
+ * ```
+ *
+ * [readHeaderInfo] returns [DEFAULT_HEADER] for paths that have not been stubbed via
+ * [stubHeader]. Specs that assert on header values must call [stubHeader] explicitly.
+ */
+class FakeAudioMetadataIO : AudioMetadataIO {
+
+    val tags = mutableMapOf<Path, Tag>()
+    val covers = mutableMapOf<Path, ByteArray?>()
+    val headers = mutableMapOf<Path, HeaderInfo>()
+
+    /**
+     * Stubs a real format-specific [Tag] for [path], populated by [build].
+     *
+     * The tag is constructed via [AudioFileTagType.newActualTag] so it behaves identically to one
+     * read from disk by JAudioTagger.
+     *
+     * @param path the file path to associate with the tag
+     * @param tagType which JAudioTagger tag implementation to create (defaults to ID3v2.4)
+     * @param build builder lambda that receives the freshly-created tag for field population
+     * @return the constructed tag, also stored for subsequent [readTag] calls on [path]
+     */
+    @JvmOverloads
+    fun stub(path: Path, tagType: AudioFileTagType = AudioFileTagType.ID3_V_24, build: Tag.() -> Unit = {}): Tag {
+        val tag = tagType.newActualTag().apply(build)
+        tags[path] = tag
+        return tag
+    }
+
+    /**
+     * Stubs the raw cover bytes returned by [readCoverBytes] for [path]. Pass `null` to simulate a
+     * file without artwork.
+     */
+    fun stubCover(path: Path, bytes: ByteArray?) {
+        covers[path] = bytes
+    }
+
+    /**
+     * Stubs the [HeaderInfo] returned by [readHeaderInfo] for [path]. Paths not stubbed fall back
+     * to [DEFAULT_HEADER].
+     */
+    fun stubHeader(path: Path, header: HeaderInfo) {
+        headers[path] = header
+    }
+
+    override fun readTag(path: Path): Tag =
+        tags[path] ?: if (path.fileSystem == FileSystems.getDefault()) {
+            // Real on-disk audio files (e.g. `Arb.realAudioFile()` fixtures) are not pre-stubbed —
+            // fall through to JAudioTagger so specs that mix Jimfs and real-disk paths via the same
+            // VirtualFiles fixture still work.
+            AudioFileIO.read(path.toFile()).tag
+        } else {
+            error("No tag stubbed for $path. Call FakeAudioMetadataIO.stub(path) first.")
+        }
+
+    override fun readCoverBytes(path: Path): ByteArray? =
+        covers[path] ?: if (path.fileSystem == FileSystems.getDefault()) {
+            val file = path.toFile()
+            if (!file.exists() || !file.canRead()) null
+            else
+                runCatching { AudioFileIO.read(file).tag }
+                    .getOrNull()
+                    ?.let { tag -> if (tag.artworkList.isNotEmpty()) tag.firstArtwork.binaryData else null }
+        } else {
+            null
+        }
+
+    override fun writeTag(path: Path, tag: Tag) {
+        if (path.fileSystem == FileSystems.getDefault() && !tags.containsKey(path)) {
+            // Persist real on-disk audio files through JAudioTagger so writeMetadata() tests against
+            // `Arb.realAudioFile()` continue to mutate the underlying file.
+            val audioFile = AudioFileIO.read(path.toFile())
+            audioFile.tag = tag
+            audioFile.commit()
+        }
+        tags[path] = tag
+    }
+
+    override fun readHeaderInfo(path: Path): HeaderInfo =
+        headers[path] ?: if (path.fileSystem == FileSystems.getDefault()) {
+            val header = AudioFileIO.read(path.toFile()).audioHeader
+            val bitRateStr = header.bitRate
+            HeaderInfo(
+                encodingType = header.encodingType,
+                bitRate = if (bitRateStr.startsWith("~")) bitRateStr.substring(1).toInt() else bitRateStr.toInt(),
+                trackLengthSeconds = header.trackLength.toLong(),
+                format = header.format
+            )
+        } else {
+            DEFAULT_HEADER
+        }
+
+    companion object {
+
+        /**
+         * Reasonable default header returned for paths that have not been explicitly stubbed via
+         * [stubHeader] — encoding/format of MP3 at 320kbps, 3-minute duration.
+         */
+        val DEFAULT_HEADER =
+            HeaderInfo(
+                encodingType = "MPEG-1 Layer 3",
+                bitRate = 320,
+                trackLengthSeconds = 180L,
+                format = "MPEG-1 Layer 3"
+            )
+    }
+}

--- a/music-commons-test/src/main/kotlin/net/transgressoft/commons/music/audio/VirtualTestFiles.kt
+++ b/music-commons-test/src/main/kotlin/net/transgressoft/commons/music/audio/VirtualTestFiles.kt
@@ -126,9 +126,8 @@ class VirtualFiles internal constructor() {
     fun createAt(
         targetPath: Path,
         attributes: AudioItemTestAttributes,
-        tagType: AudioFileTagType,
-        fileSystem: FileSystem = targetPath.fileSystem
-    ): Path = createPathAt(targetPath, tagType, attributes, fileSystem)
+        tagType: AudioFileTagType
+    ): Path = createPathAt(targetPath, tagType, attributes)
 
     // Strips characters forbidden in Windows path segments (< > : " / \ | ? * and control chars 0-31),
     // trims leading/trailing dots and spaces, and prefixes Windows reserved stems (CON, NUL, COM1..9,
@@ -172,14 +171,13 @@ class VirtualFiles internal constructor() {
         Files.createDirectories(dir)
 
         val targetPath = dir.resolve("$fileName.$extension")
-        return createPathAt(targetPath, tagType, attributes, fileSystem)
+        return createPathAt(targetPath, tagType, attributes)
     }
 
     private fun createPathAt(
         targetPath: Path,
         tagType: AudioFileTagType,
-        attributes: AudioItemTestAttributes,
-        @Suppress("UNUSED_PARAMETER") fileSystem: FileSystem
+        attributes: AudioItemTestAttributes
     ): Path {
         val parent = targetPath.parent
         if (parent != null && !Files.exists(parent)) {

--- a/music-commons-test/src/main/kotlin/net/transgressoft/commons/music/audio/VirtualTestFiles.kt
+++ b/music-commons-test/src/main/kotlin/net/transgressoft/commons/music/audio/VirtualTestFiles.kt
@@ -137,19 +137,30 @@ class VirtualFiles internal constructor() {
     // through native java.nio.file.Path during JSON deserialization. The fake tag still receives the original
     // (unsanitized) values so round-trip assertions on artist/album/title continue to hold.
     private fun String.sanitizePathSegment(): String {
+        // Truncate before sanitizing so each path segment stays well under Windows MAX_PATH (260
+        // chars). Arb.string() default range is 0..100 chars; three deep segments + path prefix +
+        // extension can otherwise exceed MAX_PATH on Windows. Truncating to ~60 chars per segment
+        // leaves headroom for the directory prefix and filename suffix.
+        val truncated = if (length > 60) substring(0, 60) else this
         val cleaned =
-            replace(Regex("""[<>:"/\\|?*\x00-\x1F]"""), "_")
+            truncated
+                .replace(Regex("""[<>:"/\\|?*\x00-\x1F]"""), "_")
                 .trim('.', ' ')
                 .ifEmpty { "_" }
         val stem = cleaned.substringBefore(".")
         return if (stem.uppercase() in WINDOWS_RESERVED_STEMS) "_$cleaned" else cleaned
     }
 
+    // Must match WindowsPathValidator.RESERVED_NAMES exactly, including the superscript variants —
+    // Arb.string() generates arbitrary Unicode and can produce "COM¹"/"COM²"/"COM³"/"LPT¹" etc.
+    // which the production validator rejects.
     private val WINDOWS_RESERVED_STEMS =
         setOf(
             "CON", "PRN", "AUX", "NUL",
             "COM0", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
-            "LPT0", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9"
+            "COM¹", "COM²", "COM³",
+            "LPT0", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9",
+            "LPT¹", "LPT²", "LPT³"
         )
 
     private fun createPath(

--- a/music-commons-test/src/main/kotlin/net/transgressoft/commons/music/audio/VirtualTestFiles.kt
+++ b/music-commons-test/src/main/kotlin/net/transgressoft/commons/music/audio/VirtualTestFiles.kt
@@ -17,7 +17,6 @@
 
 package net.transgressoft.commons.music.audio
 
-import net.transgressoft.commons.music.common.toJsonUri
 import com.google.common.jimfs.Configuration
 import com.google.common.jimfs.Jimfs
 import io.kotest.core.extensions.SpecExtension
@@ -27,54 +26,35 @@ import io.kotest.property.arbitrary.arbitrary
 import io.kotest.property.arbitrary.enum
 import io.kotest.property.arbitrary.int
 import io.kotest.property.arbitrary.next
-import io.mockk.every
-import io.mockk.mockk
-import io.mockk.mockkStatic
-import io.mockk.spyk
-import io.mockk.unmockkStatic
-import org.jaudiotagger.audio.AudioFile
-import org.jaudiotagger.audio.AudioFileIO
 import org.jaudiotagger.tag.FieldKey
 import org.jaudiotagger.tag.Tag
-import org.jaudiotagger.tag.images.Artwork
-import java.io.File
+import org.jaudiotagger.tag.images.ArtworkFactory
 import java.nio.file.FileSystem
 import java.nio.file.Files
 import java.nio.file.Path
-import java.nio.file.Paths
 import java.nio.file.StandardOpenOption
-import kotlin.io.path.absolutePathString
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
-
-// Process-wide mutex shared by every [VirtualFilesExtension] instance. Serializes any pair
-// of specs whose `virtualFiles()` factories race on the JVM-global `mockkStatic` interceptors
-// (java.nio.file.Paths, org.jaudiotagger.audio.AudioFileIO, kotlin.io.FilesKt__*, and the
-// PathJsonExtensions extension functions). Mirrors lirp's `reactiveScopeMutex`.
-internal val virtualFilesMutex = Mutex()
-
-private val STATIC_MOCK_TARGETS =
-    listOf(
-        "kotlin.io.FilesKt__FileReadWriteKt",
-        "kotlin.io.FilesKt__UtilsKt",
-        "java.nio.file.Paths",
-        "org.jaudiotagger.audio.AudioFileIO",
-        "net.transgressoft.commons.music.common.PathJsonExtensionsKt"
-    )
 
 /**
- * Per-spec test fixture that materializes Jimfs-backed virtual audio files with mocked
- * JAudioTagger metadata. One instance is created per spec by [virtualFiles], and lifecycle
- * (mockkStatic install/uninstall) is managed by [VirtualFilesExtension].
+ * Per-spec test fixture that materializes Jimfs-backed virtual audio files with real
+ * JAudioTagger tag instances served by a [FakeAudioMetadataIO]. One instance is created
+ * per spec by [virtualFiles], and the per-spec Jimfs filesystem is closed by
+ * [VirtualFilesExtension] when the spec finishes.
  *
  * Each instance owns its own in-memory [FileSystem], so two specs never collide on Jimfs
- * inodes. Static interceptors are JVM-global and shared between concurrent specs via
- * [virtualFilesMutex] — specs using `virtualFiles()` run serialized against each other, but
- * remain free to run in parallel with specs that don't use this fixture.
+ * inodes. No JVM-global mutable state is used — specs execute fully in parallel.
+ *
+ * Tests inject [metadataUtils] (or [audioMetadataIO]) into [MutableAudioItem] / [FXAudioItem]
+ * / library constructors so reads/writes route through the fake instead of the real
+ * `DefaultAudioMetadataIO`. The [fileSystem] is passed into serializer constructors when
+ * JSON round-trip against Jimfs paths is required.
  */
 class VirtualFiles internal constructor() {
 
     val fileSystem: FileSystem = Jimfs.newFileSystem(Configuration.unix())
+
+    val audioMetadataIO: FakeAudioMetadataIO = FakeAudioMetadataIO()
+
+    val metadataUtils: AudioItemMetadataUtils = AudioItemMetadataUtils(audioMetadataIO)
 
     fun virtualAlbumAudioFiles(
         artist: Artist? = null,
@@ -126,22 +106,21 @@ class VirtualFiles internal constructor() {
                 append("/").append(attributes.artist.name.sanitizePathSegment()).append("/")
                 append(attributes.album.name.sanitizePathSegment()).append("/")
             }
-        val tag = createMockedTag(tagType.newMockedTag(), attributes)
-        val path = createPath(filePath, fileName, tagType.fileType.extension, tag, fileSystem)
-        return path
+        return createPath(filePath, fileName, tagType.fileType.extension, tagType, attributes, fileSystem)
     }
 
     /**
      * Materializes a virtual audio file at the exact [targetPath] on [fileSystem],
-     * stubbing JAudioTagger reads and `java.nio.file` membership so that downstream
-     * services (e.g. `audioItemFromFile(path)`) see a fully readable audio file.
+     * stubbing the [FakeAudioMetadataIO] so that downstream services (e.g.
+     * `audioItemFromFile(path)`) see a fully readable audio file with the supplied tag.
      *
      * The codec/container is derived from the file extension on [targetPath]. The
-     * supplied [attributes] populate the mocked tag.
+     * supplied [attributes] populate the real tag instance returned by
+     * [FakeAudioMetadataIO.readTag] for [targetPath].
      *
      * @param targetPath absolute path on [fileSystem] where the virtual file should appear
-     * @param attributes tag values to expose through the mocked [Tag]
-     * @param tagType    mocked tag implementation matching the desired codec
+     * @param attributes tag values to expose through the stubbed [Tag]
+     * @param tagType    tag implementation matching the desired codec
      * @return the same [targetPath], usable as the audio item's path
      */
     fun createAt(
@@ -149,25 +128,14 @@ class VirtualFiles internal constructor() {
         attributes: AudioItemTestAttributes,
         tagType: AudioFileTagType,
         fileSystem: FileSystem = targetPath.fileSystem
-    ): Path {
-        val tag = createMockedTag(tagType.newMockedTag(), attributes)
-        return createPathAt(targetPath, tag, fileSystem)
-    }
-
-    internal fun installStaticMocks() {
-        STATIC_MOCK_TARGETS.forEach { mockkStatic(it) }
-    }
-
-    internal fun uninstallStaticMocks() {
-        STATIC_MOCK_TARGETS.forEach { unmockkStatic(it) }
-    }
+    ): Path = createPathAt(targetPath, tagType, attributes, fileSystem)
 
     // Strips characters forbidden in Windows path segments (< > : " / \ | ? * and control chars 0-31),
     // trims leading/trailing dots and spaces, and prefixes Windows reserved stems (CON, NUL, COM1..9,
     // LPT1..9) with an underscore. Artist, album, and title attributes are generated by Arb.string(),
     // which produces arbitrary Unicode — passing those raw into Path.of(...) triggers InvalidPathException
     // on Windows even though the virtual filesystem is Jimfs-unix, because the serialized path round-trips
-    // through native java.nio.file.Path during JSON deserialization. Tag mocks still receive the original
+    // through native java.nio.file.Path during JSON deserialization. The fake tag still receives the original
     // (unsanitized) values so round-trip assertions on artist/album/title continue to hold.
     private fun String.sanitizePathSegment(): String {
         val cleaned =
@@ -185,66 +153,14 @@ class VirtualFiles internal constructor() {
             "LPT0", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9"
         )
 
-    private fun createMockedTag(tag: Tag, attributes: AudioItemTestAttributes): Tag {
-        val artist = attributes.artist.name
-        val album = attributes.album.name
-        val albumArtist = attributes.album.albumArtist.name
-        val title = attributes.title
-        val genre = Genre.joinGenres(attributes.genres)
-        val year = attributes.album.year
-        val trackNumber = attributes.trackNumber
-        val discNumber = attributes.discNumber
-        val bpm = attributes.bpm
-        val comment = attributes.comments
-        val encoder = attributes.encoder
-        val grouping = attributes.album.label.name
-        val isCompilation = attributes.album.isCompilation
-        val country = attributes.artist.countryCode.name
-        val coverBytes = attributes.coverImageBytes
-
-        every { tag.getFirst(FieldKey.TITLE) } returns title
-        every { tag.getFirst(FieldKey.ALBUM) } returns album
-        every { tag.getFirst(FieldKey.ARTIST) } returns artist
-        every { tag.getFirst(FieldKey.ALBUM_ARTIST) } returns albumArtist
-        every { tag.getFirst(FieldKey.GENRE) } returns genre
-        every { tag.getFirst(FieldKey.YEAR) } returns year.toString()
-        every { tag.getFirst(FieldKey.GROUPING) } returns grouping
-        every { tag.getFirst(FieldKey.IS_COMPILATION) } returns isCompilation.toString()
-        every { tag.getFirst(FieldKey.COUNTRY) } returns country
-
-        comment?.let { every { tag.getFirst(FieldKey.COMMENT) } returns it }
-        trackNumber?.let { every { tag.getFirst(FieldKey.TRACK) } returns it.toString() }
-        discNumber?.let { every { tag.getFirst(FieldKey.DISC_NO) } returns it.toString() }
-        bpm?.let { every { tag.getFirst(FieldKey.BPM) } returns it.toString() }
-        encoder?.let { every { tag.getFirst(FieldKey.ENCODER) } returns it }
-
-        every { tag.hasField(FieldKey.TITLE) } returns true
-        every { tag.hasField(FieldKey.ALBUM) } returns true
-        every { tag.hasField(FieldKey.ARTIST) } returns true
-        every { tag.hasField(FieldKey.ALBUM_ARTIST) } returns true
-        every { tag.hasField(FieldKey.GENRE) } returns true
-        every { tag.hasField(FieldKey.YEAR) } returns true
-        every { tag.hasField(FieldKey.GROUPING) } returns true
-        every { tag.hasField(FieldKey.IS_COMPILATION) } returns true
-        every { tag.hasField(FieldKey.COUNTRY) } returns true
-        every { tag.hasField(FieldKey.TRACK) } returns (trackNumber != null)
-        every { tag.hasField(FieldKey.DISC_NO) } returns (discNumber != null)
-        every { tag.hasField(FieldKey.BPM) } returns (bpm != null)
-        every { tag.hasField(FieldKey.COMMENT) } returns (comment != null)
-        every { tag.hasField(FieldKey.ENCODER) } returns (encoder != null)
-
-        coverBytes?.let {
-            every { tag.firstArtwork } returns
-                mockk<Artwork> {
-                    every { binaryData } returns it
-                }
-            every { tag.artworkList } returns listOf(mockk<Artwork>())
-        }
-
-        return tag
-    }
-
-    private fun createPath(pathToFile: String, fileName: String, extension: String, tag: Tag, fileSystem: FileSystem): Path {
+    private fun createPath(
+        pathToFile: String,
+        fileName: String,
+        extension: String,
+        tagType: AudioFileTagType,
+        attributes: AudioItemTestAttributes,
+        fileSystem: FileSystem
+    ): Path {
         // Build the parent directory under the injected filesystem's native root so the same
         // generator works for Jimfs unix ("/"), osx ("/"), and windows ("C:\") configurations.
         val root = fileSystem.rootDirectories.first()
@@ -256,86 +172,131 @@ class VirtualFiles internal constructor() {
         Files.createDirectories(dir)
 
         val targetPath = dir.resolve("$fileName.$extension")
-        return createPathAt(targetPath, tag, fileSystem)
+        return createPathAt(targetPath, tagType, attributes, fileSystem)
     }
 
-    private fun createPathAt(targetPath: Path, tag: Tag, fileSystem: FileSystem): Path {
+    private fun createPathAt(
+        targetPath: Path,
+        tagType: AudioFileTagType,
+        attributes: AudioItemTestAttributes,
+        @Suppress("UNUSED_PARAMETER") fileSystem: FileSystem
+    ): Path {
         val parent = targetPath.parent
         if (parent != null && !Files.exists(parent)) {
             Files.createDirectories(parent)
         }
-        val extension = targetPath.fileName.toString().substringAfterLast('.', missingDelimiterValue = "")
-        val filePath = spyk(targetPath)
-        // Rendered with the *injected* fileSystem's separator (Jimfs unix → "/", Jimfs windows → "\"),
-        // which is independent of the host JVM. Using that string as the stub key is what makes round-trip
-        // Paths.get(...) match after serialization encodes audioFilePath.absolutePathString().
-        val filePathString = filePath.toString()
-        val file = JimfsFileAdapter(filePath)
 
-        Files.write(filePath, byteArrayOf(), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)
+        Files.write(targetPath, byteArrayOf(), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)
 
-        // Produce a file:// URI from the native path string so that toJsonUri() returns a
-        // file:// URI instead of a jimfs:// URI. Path.of(filePathString) uses the default
-        // (real) filesystem to build a URI from the platform-native path string, giving the
-        // correct file:// form for all three Jimfs configs (unix/windows/osx).
-        val fileUri = Path.of(filePathString).toUri()
-        val fileUriString = fileUri.toString()
-        every { filePath.toFile() } returns file
-        every { filePath.absolutePathString() } returns filePathString
-        every { filePath.toAbsolutePath() } returns filePath
-        every { filePath.normalize() } returns filePath
-        // Stub toJsonUri() at the extension function level since Jimfs Path.toUri() returns
-        // a jimfs:// scheme that toPathFromJsonUri() would reject.
-        every { filePath.toJsonUri() } returns fileUriString
+        // Stub the real JAudioTagger tag and header values on the fake for this path.
+        audioMetadataIO.stub(targetPath, tagType) {
+            populateTag(this, attributes)
+            attributes.coverImageBytes?.let { coverBytes -> attachArtwork(this, coverBytes) }
+        }
+        audioMetadataIO.stubHeader(targetPath, headerInfoFor(targetPath))
+        audioMetadataIO.stubCover(targetPath, attributes.coverImageBytes)
 
-        val audioFile =
-            mockk<AudioFile> {
-                every { getTag() } returns tag
-                every { audioHeader } returns
-                    mockk {
-                        every { trackLength } returns 180
-                        every { sampleRateAsNumber } returns 44100
-                        every { format } returns extension
-                        every { encodingType } returns format.uppercase()
-                        every { bitRate } returns "320"
-                    }
-            }
+        return targetPath
+    }
+}
 
-        every { Paths.get(filePathString) } returns filePath
-        every { Paths.get(fileUri) } returns filePath
-        every { Files.exists(filePath) } returns true
-        every { Files.isRegularFile(filePath) } returns true
-        every { Files.isReadable(filePath) } returns true
-        every { AudioFileIO.read(file) } returns audioFile
+// Synthesizes header info per file extension — 320 kbps, 3-minute duration — matching the
+// per-extension `encoding` assertions in DefaultAudioLibraryTest's batch test.
+private fun headerInfoFor(path: Path): HeaderInfo {
+    val ext = path.fileName.toString().substringAfterLast('.', "").lowercase()
+    val encoding =
+        when (ext) {
+            "mp3" -> "MPEG-1 Layer 3"
+            "flac" -> "FLAC"
+            "wav" -> "WAV"
+            "m4a" -> "AAC"
+            "ogg" -> "Vorbis"
+            else -> ext.uppercase()
+        }
+    return HeaderInfo(
+        encodingType = encoding,
+        bitRate = 320,
+        trackLengthSeconds = 180L,
+        format = encoding
+    )
+}
 
-        return filePath
+// Populates a real JAudioTagger tag with the test attributes. The tag is constructed by
+// AudioFileTagType.newActualTag() and answers setField/getFirst/hasField natively — no MockK
+// plumbing on the caller side. Unsupported field/format combinations (e.g. WavTag + COUNTRY)
+// are swallowed via runCatching so they behave the same way the production `getFieldIfExisting`
+// helper handles them.
+@Suppress("LongMethod")
+private fun populateTag(tag: Tag, attributes: AudioItemTestAttributes) {
+    val artist = attributes.artist.name
+    val album = attributes.album.name
+    val albumArtist = attributes.album.albumArtist.name
+    val title = attributes.title
+    val genre = Genre.joinGenres(attributes.genres)
+    val year = attributes.album.year
+    val trackNumber = attributes.trackNumber
+    val discNumber = attributes.discNumber
+    val bpm = attributes.bpm
+    val comment = attributes.comments
+    val encoder = attributes.encoder
+    val grouping = attributes.album.label.name
+    val isCompilation = attributes.album.isCompilation
+    val country = attributes.artist.countryCode.name
+
+    setFieldQuietly(tag, FieldKey.TITLE, title)
+    setFieldQuietly(tag, FieldKey.ALBUM, album)
+    setFieldQuietly(tag, FieldKey.ARTIST, artist)
+    setFieldQuietly(tag, FieldKey.ALBUM_ARTIST, albumArtist)
+    setFieldQuietly(tag, FieldKey.GENRE, genre)
+    year?.let { setFieldQuietly(tag, FieldKey.YEAR, it.toString()) }
+    setFieldQuietly(tag, FieldKey.GROUPING, grouping)
+    setFieldQuietly(tag, FieldKey.IS_COMPILATION, isCompilation.toString())
+    setFieldQuietly(tag, FieldKey.COUNTRY, country)
+
+    comment?.let { setFieldQuietly(tag, FieldKey.COMMENT, it) }
+    trackNumber?.let { setFieldQuietly(tag, FieldKey.TRACK, it.toString()) }
+    discNumber?.let { setFieldQuietly(tag, FieldKey.DISC_NO, it.toString()) }
+    bpm?.let { setFieldQuietly(tag, FieldKey.BPM, it.toString()) }
+    encoder?.let { setFieldQuietly(tag, FieldKey.ENCODER, it) }
+}
+
+// Some tag/format combinations (notably WavTag + COUNTRY) throw UnsupportedOperationException
+// or KeyNotFoundException when setField is called for an unsupported field. The production
+// readers route these through runCatching; mirror that here so populateTag is robust across
+// every AudioFileTagType.
+private fun setFieldQuietly(tag: Tag, key: FieldKey, value: String) {
+    runCatching { tag.setField(key, value) }
+}
+
+// Attaches cover artwork to the real JAudioTagger tag so the production AudioItemMetadataUtils
+// can extract it via parseCoverBytes. Routes through ArtworkFactory.getNew() to avoid the
+// temp-file write that AudioItemMetadataUtils.createArtwork does for production write paths.
+private fun attachArtwork(tag: Tag, coverBytes: ByteArray) {
+    runCatching {
+        val artwork = ArtworkFactory.getNew()
+        artwork.binaryData = coverBytes
+        artwork.mimeType = "image/jpeg"
+        artwork.description = ""
+        artwork.pictureType = 3 // PictureTypes.DEFAULT_ID (Cover Front)
+        tag.addField(artwork)
     }
 }
 
 /**
- * Kotest [SpecExtension] that wraps a spec's execution in [virtualFilesMutex] and installs
- * the [VirtualFiles] static mocks before [execute] runs, then unmocks them and closes the
- * per-spec Jimfs filesystem after [execute] returns. Register per-spec via the
- * [virtualFiles] convenience factory.
+ * Kotest [SpecExtension] that closes the per-spec Jimfs filesystem after the spec finishes.
+ * Specs run fully in parallel: the fixture owns no JVM-global mutable state.
  */
 class VirtualFilesExtension : SpecExtension {
 
     val files: VirtualFiles = VirtualFiles()
 
     override suspend fun intercept(spec: Spec, execute: suspend (Spec) -> Unit) {
-        virtualFilesMutex.withLock {
-            files.installStaticMocks()
-            try {
-                execute(spec)
-            } finally {
-                try {
-                    files.uninstallStaticMocks()
-                } finally {
-                    // Jimfs FileSystem is Closeable; without this each spec leaks one in-memory
-                    // filesystem (inode/page caches included) for the lifetime of the JVM.
-                    files.fileSystem.close()
-                }
-            }
+        try {
+            execute(spec)
+        } finally {
+            // Jimfs FileSystem is Closeable; without this each spec leaks one in-memory
+            // filesystem (inode/page caches included) for the lifetime of the JVM.
+            files.fileSystem.close()
         }
     }
 }
@@ -348,6 +309,7 @@ class VirtualFilesExtension : SpecExtension {
  *         val files = virtualFiles()
  *         "test" {
  *             val path = files.virtualAudioFile().next()
+ *             val item = MutableAudioItem(path, 1, files.metadataUtils)
  *         }
  *     })
  */
@@ -355,16 +317,4 @@ fun Spec.virtualFiles(): VirtualFiles {
     val ext = VirtualFilesExtension()
     extension(ext)
     return ext.files
-}
-
-internal class JimfsFileAdapter(private val path: Path) : File(path.toString()) {
-    override fun exists() = Files.exists(path)
-
-    override fun getName() = path.fileName.toString()
-
-    override fun toPath() = path
-
-    override fun getAbsolutePath() = path.toAbsolutePath().toString()
-
-    override fun length() = Files.size(path)
 }

--- a/music-commons-test/src/main/kotlin/net/transgressoft/commons/music/m3u/M3uTestFixtures.kt
+++ b/music-commons-test/src/main/kotlin/net/transgressoft/commons/music/m3u/M3uTestFixtures.kt
@@ -124,7 +124,7 @@ object M3uTestFixtures {
                 materializeRecursive(nestedResource, resolved, baseDir, virtualFiles, visited, collected)
             } else {
                 val info = TrackInfo.from(entry, resolved)
-                virtualFiles.createAt(resolved, info.toAttributes(), info.tagType, baseDir.fileSystem)
+                virtualFiles.createAt(resolved, info.toAttributes(), info.tagType)
                 collected.add(info)
             }
         }


### PR DESCRIPTION
## Summary

Replace JVM-global static mocking in test fixtures with port-and-adapter seams in production code. Eliminates the process-wide `virtualFilesMutex` and removes all five `mockkStatic` interceptors from `VirtualTestFiles.kt`, enabling Kotest parallelism for `VirtualFiles`-using specs.

Closes #101

## What changed

### Production seams
- **`AudioMetadataIO` interface** (4 methods: `readTag`, `readHeaderInfo`, `readCoverBytes`, `writeTag`) + **`HeaderInfo`** data class in `music-commons-api`
- **`DefaultAudioMetadataIO`** in `music-commons-core` delegating to JAudioTagger, with fail-fast `require(path.fileSystem == FileSystems.getDefault())` guard
- **`AudioItemMetadataUtils`** refactored from `object` to `class` accepting `AudioMetadataIO` via `@JvmOverloads` constructor
- **`MutableAudioItem`, `FXAudioItem`, `DefaultAudioLibrary`, `FXAudioLibrary`** all accept the seam via `@JvmOverloads` with sensible defaults
- **`ItunesImportService`** accepts `FileSystem` ctor param via `@JvmOverloads`; uses `fileSystem.getPath(uri.path)` instead of `Paths.get(uri)`
- **`path.toFile().length()` → `Files.size(path)`** in `MutableAudioItem.length` and `FXAudioItem.length` (would otherwise throw `UnsupportedOperationException` on real Jimfs paths)
- **Serializers** (`AudioItemSerializer`, `AudioWaveformSerializer`, `ObservableAudioItemSerializer`) converted from `object` to `class` with `fileSystem` ctor param. `@Serializable(with=...)` annotations dropped in favor of polymorphic module registration (kotlinx-serialization rejects class serializers with non-KSerializer constructor params).
- **`Path.toJsonUri()`** synthesizes `file:///` URIs for non-default-FS (Jimfs) paths so JSON round-trip works through `toPathFromJsonUri(fileSystem)`

### Test seam — internal Builder constructor
The `metadataUtils` seam is **not** exposed on the public Builder API. Each Builder gains an `internal constructor(metadataUtils: AudioItemMetadataUtils)`:

```kotlin
// End-user (different Gradle module) — public API unchanged
CoreMusicLibrary.builder().audioLibraryJsonFile(file).build()

// In-module tests only
CoreMusicLibrary.Builder(files.metadataUtils).build()
```

This keeps the Builder facade clean for production while letting same-module tests inject `FakeAudioMetadataIO` cleanly.

### Test infrastructure
- **`FakeAudioMetadataIO`** in `music-commons-test` with map-based `stub(path, tagType) { setField(...) }` API; uses real `ID3v24Tag`/`FlacTag`/`Mp4Tag`/`WavTag`/`VorbisCommentTag` instances via `AudioFileTagType.newActualTag` — no `mockk<Tag>()`
- **`VirtualTestFiles.kt`** rewritten: `virtualFilesMutex` removed, `STATIC_MOCK_TARGETS` removed, `JimfsFileAdapter` removed, all `install/uninstallStaticMocks` helpers removed; `VirtualFiles` exposes `audioMetadataIO`, `metadataUtils`, and `fileSystem` for spec injection
- **17 specs migrated** to inject `files.metadataUtils` into items/libraries and pass `files.fileSystem` to serializers via a custom `Json { serializersModule = SerializersModule { polymorphic(...) } }` recipe (bare serializer instances would be silently ignored by module-driven dispatch)

## Parallelism gain (the actual phase goal)

| Module test | Before | After | Delta |
|---|---|---|---|
| `music-commons-core:test` | ~29s | ~24s | **~17% faster** |
| `music-commons-fx:test` | unchanged | unchanged | Sequential by design (JavaFX toolkit is process-global) |
| `music-commons-media:test` | unchanged | unchanged | — |

## Success-gate (per phase definition)

| Grep | Result |
|---|---|
| `grep -rn "mockkStatic" --include='*.kt' .` | **0 matches** |
| `grep -rn "virtualFilesMutex\|STATIC_MOCK_TARGETS"` | **0 matches** |
| `grep -rn "installStaticMocks\|uninstallStaticMocks"` | **0 matches** |
| `grep -rn "JimfsFileAdapter"` | **0 matches** |
| `gradle clean build` | **BUILD SUCCESSFUL** |

## Out of scope (deferred)

- `OsDetector` port-and-adapter refactor (handled by existing `@Isolate` markers; future hardening)
- MockK removal (audit after this lands)
- KMP-friendly interface changes (`Path`/`Tag` remain JVM types)
- JAudioTagger object-tree refactor beyond the 4-method seam

## Notable in-flight decisions

- **A6:** Fail-fast guard placement deferred from plan 39-01 → 39-05 because it would have preempted `mockkStatic(AudioFileIO)` interception in the intermediate states. CONTEXT.md was amended accordingly.
- **kotlinx-serialization rejected `@Serializable(with=X::class)`** for class serializers with non-`KSerializer` constructor params, even with `@JvmOverloads`. Polymorphic module registration replaces it.
- **`@JvmOverloads` propagated through builders** (`CoreMusicLibrary.Builder`, `FXMusicLibrary.Builder`) so the metadataUtils fake reaches `AudioLibrary` constructed via the fluent API.
- **`MutableAudioItem`/`FXAudioItem` 17-arg deserialization ctor** also threads `metadataUtils` — `clone()` on reactive mutation would have tripped the guard otherwise.
- **`Path.toJsonUri()` collapsed back to single function** (`FileSystem`-aware with default) after `mockkStatic` removal — eliminated the dual-overload pattern needed during plan 39-03's intermediate state.

## Test plan

- [x] `gradle clean build` green locally with verification metadata enforced (Phase 38)
- [x] All success-gate greps return 0
- [x] Kotlin stdlib leakage scan clean (no resolved stdlib < 2.3.20)
- [x] All anchored TOML version greps match
- [ ] CI: `branch-pr.yml` (Ubuntu + Windows) runs green
- [ ] CI: Dependency Review passes
- [ ] Codecov coverage maintained or improved

🤖 Generated with [Claude Code](https://claude.com/claude-code)