### PR TITLE
#111 iTunes import imports all library tracks regardless of playlist selection

### DIFF
--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/itunes/ItunesImportService.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/itunes/ItunesImportService.kt
@@ -37,7 +37,10 @@ import kotlinx.coroutines.future.future
  * Orchestrates importing tracks and playlists from a parsed [ItunesLibrary] into a [MusicLibrary].
  *
  * The import follows a two-step flow: the consumer first parses the XML via [ItunesLibraryParser],
- * selects playlists, then calls [importAsync] with the selection and a configured [ItunesImportPolicy].
+ * optionally selects a subset of playlists, then calls [importAsync] with the selection and a
+ * configured [ItunesImportPolicy]. Every track present in [ItunesLibrary.tracks] is considered for
+ * import regardless of the playlist selection; the selection only controls which playlists (and
+ * their ancestor folders) are recreated in the destination library.
  *
  * Track import behavior depends on [ItunesImportPolicy.useFileMetadata]:
  * - When `true`, audio items are created via [MusicLibrary.audioItemFromFile] which reads all
@@ -67,14 +70,21 @@ class ItunesImportService<I, P>
     private val logger = KotlinLogging.logger {}
 
     /**
-     * Imports tracks from [selectedPlaylists] (and their referenced tracks from [itunesLibrary])
-     * into the [MusicLibrary], applying the given [policy].
+     * Imports every track from [itunesLibrary] into the [MusicLibrary], applying the given [policy],
+     * and recreates the playlists named in [selectedPlaylists] (plus their ancestor folders).
+     *
+     * The imported track set is always the full content of [ItunesLibrary.tracks]; [selectedPlaylists]
+     * does not narrow it. Tracks that cannot be resolved (missing local file, unsupported extension,
+     * read error) are reported in [ImportResult.unresolved].
      *
      * Returns a [CompletableFuture] that completes with an [ImportResult] summarizing the import.
      * The future can be canceled via [CompletableFuture.cancel], which stops processing between tracks.
      *
-     * @param selectedPlaylists Playlists chosen by the consumer for import.
-     * @param itunesLibrary The full parsed iTunes library (for track lookup).
+     * @param selectedPlaylists Playlists chosen by the consumer for recreation in the destination
+     *  library. Does not narrow the set of imported tracks — every track in [itunesLibrary] is
+     *  considered for import.
+     * @param itunesLibrary The full parsed iTunes library; every entry in [ItunesLibrary.tracks]
+     *  is processed.
      * @param policy Import configuration controlling metadata source, play count, write-back, etc.
      * @param rootDirectoryName Optional name of an existing playlist directory to use as the
      *  parent for top-level imported playlists (those whose iTunes
@@ -94,7 +104,7 @@ class ItunesImportService<I, P>
     ): CompletableFuture<ImportResult> =
         CoroutineScope(Dispatchers.IO).future {
             val effectivePlaylists = expandWithAncestors(selectedPlaylists, itunesLibrary)
-            val trackImportResult = importTracks(effectivePlaylists, itunesLibrary, policy, onProgress)
+            val trackImportResult = importTracks(itunesLibrary, policy, onProgress)
             val rejectedNames = createPlaylists(effectivePlaylists, trackImportResult.trackIdToItem, rootDirectoryName)
 
             ImportResult(
@@ -120,17 +130,14 @@ class ItunesImportService<I, P>
     }
 
     private suspend fun importTracks(
-        selectedPlaylists: List<ItunesPlaylist>,
         itunesLibrary: ItunesLibrary,
         policy: ItunesImportPolicy,
         onProgress: (ImportProgress) -> Unit
     ): TrackImportAccumulator {
-        val uniqueTrackIds = selectedPlaylists.flatMap(ItunesPlaylist::trackIds).toSet()
-        val accumulator = TrackImportAccumulator(uniqueTrackIds.size)
+        val accumulator = TrackImportAccumulator(itunesLibrary.tracks.size)
 
-        for (trackId in uniqueTrackIds) {
+        for ((trackId, track) in itunesLibrary.tracks) {
             currentCoroutineContext().ensureActive()
-            val track = itunesLibrary.tracks[trackId] ?: continue
             processTrack(track, trackId, policy, accumulator)
             accumulator.itemsProcessed++
             onProgress(ImportProgress(accumulator.itemsProcessed, accumulator.totalItems, track.location))

--- a/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/itunes/ItunesImportServiceTest.kt
+++ b/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/itunes/ItunesImportServiceTest.kt
@@ -515,4 +515,87 @@ internal class ItunesImportServiceTest : StringSpec({
         result.imported shouldHaveSize 1
         result.unresolved.shouldBeEmpty()
     }
+
+    "ItunesImportService imports every library track when a subset of playlists is selected" {
+        val track1 = trackFor(1, mp3File, title = "Song One")
+        val track2 = trackFor(2, flacFile, title = "Song Two")
+        val track3 = trackFor(3, mp3File, title = "Song Three")
+        val playlistA = playlistFor("Playlist A", "PLA", listOf(1))
+        val playlistB = playlistFor("Playlist B", "PLB", listOf(2))
+        val library = ItunesLibrary(mapOf(1 to track1, 2 to track2, 3 to track3), listOf(playlistA, playlistB))
+        val policy = ItunesImportPolicy(useFileMetadata = true, writeMetadata = false)
+
+        val result = service.importAsync(listOf(playlistA), library, policy).get()
+
+        result.imported shouldHaveSize 3
+        result.unresolved.shouldBeEmpty()
+        musicLibrary.audioLibrary().size() shouldBe 3
+    }
+
+    "ItunesImportService imports every library track when no playlists are selected" {
+        val track1 = trackFor(1, mp3File, title = "Song One")
+        val track2 = trackFor(2, flacFile, title = "Song Two")
+        val track3 = trackFor(3, mp3File, title = "Song Three")
+        val playlistA = playlistFor("Playlist A", "PLA", listOf(1))
+        val playlistB = playlistFor("Playlist B", "PLB", listOf(2))
+        val library = ItunesLibrary(mapOf(1 to track1, 2 to track2, 3 to track3), listOf(playlistA, playlistB))
+        val policy = ItunesImportPolicy(useFileMetadata = true, writeMetadata = false)
+
+        val result = service.importAsync(emptyList(), library, policy).get()
+
+        result.imported shouldHaveSize 3
+        result.rejectedPlaylistNames.shouldBeEmpty()
+        musicLibrary.findPlaylistByName("Playlist A").isPresent shouldBe false
+        musicLibrary.findPlaylistByName("Playlist B").isPresent shouldBe false
+    }
+
+    "ItunesImportService recreates only selected playlists and ancestor folders while importing all tracks" {
+        val track1 = trackFor(1, mp3File, title = "Song One")
+        val track2 = trackFor(2, flacFile, title = "Song Two")
+        val track3 = trackFor(3, mp3File, title = "Song Three")
+        val folder = playlistFor("Music", "F1", isFolder = true)
+        val playlistA = playlistFor("Playlist A", "PLA", listOf(1), parentId = "F1")
+        val playlistB = playlistFor("Playlist B", "PLB", listOf(2))
+        val library = ItunesLibrary(mapOf(1 to track1, 2 to track2, 3 to track3), listOf(folder, playlistA, playlistB))
+        val policy = ItunesImportPolicy(useFileMetadata = true, writeMetadata = false)
+
+        val result = service.importAsync(listOf(playlistA), library, policy).get()
+
+        result.imported shouldHaveSize 3
+        musicLibrary.findPlaylistByName("Music").isPresent shouldBe true
+        musicLibrary.findPlaylistByName("Playlist A").isPresent shouldBe true
+        musicLibrary.findPlaylistByName("Playlist B").isPresent shouldBe false
+    }
+
+    "ItunesImportService reports totalItems equal to the iTunes library track count" {
+        val track1 = trackFor(1, mp3File, title = "Song One")
+        val track2 = trackFor(2, flacFile, title = "Song Two")
+        val track3 = trackFor(3, mp3File, title = "Song Three")
+        val track4 = trackFor(4, flacFile, title = "Song Four")
+        val playlist = playlistFor("Subset Playlist", "SUB1", listOf(1, 2))
+        val library = ItunesLibrary(mapOf(1 to track1, 2 to track2, 3 to track3, 4 to track4), listOf(playlist))
+        val policy = ItunesImportPolicy(useFileMetadata = true, writeMetadata = false)
+
+        val progresses = mutableListOf<ImportProgress>()
+        service.importAsync(listOf(playlist), library, policy) { progresses.add(it) }.get()
+
+        progresses.shouldHaveSize(4)
+        progresses.forEach { it.totalItems shouldBe library.tracks.size }
+        progresses.last().itemsProcessed shouldBe 4
+    }
+
+    "ItunesImportService surfaces iCloud-style tracks with no local file as UnresolvedTrack(FileNotFound)" {
+        val localTrack = trackFor(1, mp3File, title = "Local Song")
+        val iCloudPath = Paths.get("/icloud/missing/streaming-only.mp3")
+        val iCloudTrack = trackFor(2, iCloudPath, title = "iCloud Only Song")
+        val library = ItunesLibrary(mapOf(1 to localTrack, 2 to iCloudTrack), emptyList())
+        val policy = ItunesImportPolicy(useFileMetadata = true, writeMetadata = false)
+
+        val result = service.importAsync(emptyList(), library, policy).get()
+
+        result.imported shouldHaveSize 1
+        result.unresolved shouldHaveSize 1
+        result.unresolved.first().reason shouldBe UnresolvedReason.FileNotFound
+        result.unresolved.first().title shouldBe "iCloud Only Song"
+    }
 })

--- a/music-commons-media/src/test/kotlin/net/transgressoft/commons/media/waveform/DefaultAudioWaveformRepositoryTest.kt
+++ b/music-commons-media/src/test/kotlin/net/transgressoft/commons/media/waveform/DefaultAudioWaveformRepositoryTest.kt
@@ -1,5 +1,6 @@
 package net.transgressoft.commons.media.waveform
 
+import net.transgressoft.commons.music.audio.AudioItem
 import net.transgressoft.commons.music.audio.virtualFiles
 import net.transgressoft.commons.music.testing.reactiveScope
 import net.transgressoft.commons.music.waveform.AudioWaveform
@@ -15,8 +16,6 @@ import io.kotest.matchers.shouldBe
 import io.kotest.property.arbitrary.next
 import java.io.File
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.serialization.builtins.MapSerializer
-import kotlinx.serialization.builtins.serializer
 
 @ExperimentalCoroutinesApi
 internal class DefaultAudioWaveformRepositoryTest : StringSpec({
@@ -25,16 +24,16 @@ internal class DefaultAudioWaveformRepositoryTest : StringSpec({
     val files = virtualFiles()
     lateinit var jsonFile: File
     lateinit var jsonFileRepository: JsonRepository<Int, AudioWaveform>
-    lateinit var audioWaveformRepository: AudioWaveformRepository<AudioWaveform, net.transgressoft.commons.music.audio.AudioItem>
+    lateinit var audioWaveformRepository: AudioWaveformRepository<AudioWaveform, AudioItem>
 
     beforeEach {
         jsonFile = tempfile("audioWaveformRepository-test", ".json").also { it.deleteOnExit() }
-        jsonFileRepository = JsonFileRepository(jsonFile, MapSerializer(Int.serializer(), AudioWaveformSerializer(files.fileSystem)))
+        jsonFileRepository = JsonFileRepository(jsonFile, AudioWaveformMapSerializer)
         val subscriber =
             object : LirpEventSubscriberBase<
-                net.transgressoft.commons.music.audio.AudioItem,
+                AudioItem,
                 CrudEvent.Type,
-                CrudEvent<Int, net.transgressoft.commons.music.audio.AudioItem>
+                CrudEvent<Int, AudioItem>
             >("test-subscriber") {}
         audioWaveformRepository = DefaultAudioWaveformRepository(jsonFileRepository, subscriber)
     }
@@ -63,11 +62,11 @@ internal class DefaultAudioWaveformRepositoryTest : StringSpec({
 
         val subscriber =
             object : LirpEventSubscriberBase<
-                net.transgressoft.commons.music.audio.AudioItem,
+                AudioItem,
                 CrudEvent.Type,
-                CrudEvent<Int, net.transgressoft.commons.music.audio.AudioItem>
+                CrudEvent<Int, AudioItem>
             >("test-subscriber-2") {}
-        val loadedRepository = DefaultAudioWaveformRepository<net.transgressoft.commons.music.audio.AudioItem>(jsonFileRepository, subscriber)
+        val loadedRepository = DefaultAudioWaveformRepository(jsonFileRepository, subscriber)
         loadedRepository.size() shouldBe 1
         loadedRepository.findById(audioWaveform.id) shouldBePresent { found -> found shouldBe audioWaveform }
     }
@@ -75,9 +74,9 @@ internal class DefaultAudioWaveformRepositoryTest : StringSpec({
     "audioWaveformRepository factory function creates valid repository in media module" {
         val subscriber =
             object : LirpEventSubscriberBase<
-                net.transgressoft.commons.music.audio.AudioItem,
+                AudioItem,
                 CrudEvent.Type,
-                CrudEvent<Int, net.transgressoft.commons.music.audio.AudioItem>
+                CrudEvent<Int, AudioItem>
             >("factory-test") {}
         val repo = audioWaveformRepository(jsonFileRepository, subscriber)
 


### PR DESCRIPTION
## Summary

**Phase 41:** Decouple iTunes import track set from playlist selection.

Closes #111.

`ItunesImportService.importTracks()` previously derived the imported track set from `selectedPlaylists.flatMap(ItunesPlaylist::trackIds)`, which meant tracks not referenced by selected playlists were silently dropped. This PR inverts the semantic: every track in `itunesLibrary.tracks` is now considered for import; `selectedPlaylists` only drives which playlists/folders are recreated in the destination library.

## Changes

### `ItunesImportService.kt`
- `importTracks()` now iterates `itunesLibrary.tracks` directly. The `selectedPlaylists` parameter has been dropped from its signature — it was no longer consulted for choosing which tracks to process.
- `TrackImportAccumulator` is constructed with `itunesLibrary.tracks.size` so `ImportProgress.totalItems` reflects the full library size (consistent with what users see in iTunes).
- KDoc on `importAsync()` rewritten to document the new contract explicitly: `selectedPlaylists` does not narrow the imported track set.
- Playlist creation flow (`expandWithAncestors`, `createPlaylists`, `createFolderDirectories`, `createRegularPlaylists`, `wirePlaylistHierarchy`) is untouched.

### `ItunesImportServiceTest.kt`
Existing 19 tests still pass against the new semantic (their fixtures happened to construct selected playlists that referenced every library track). Added **5 regression tests** that lock in the new behavior:

| Test | Locks |
|------|-------|
| `imports every library track when a subset of playlists is selected` | Issue #111 AC1 |
| `imports every library track when no playlists are selected` | Issue #111 AC2 |
| `recreates only selected playlists and ancestor folders while importing all tracks` | Issue #111 AC3 |
| `reports totalItems equal to the iTunes library track count` | Progress baseline (D-PROGRESS) |
| `surfaces iCloud-style tracks with no local file as UnresolvedTrack(FileNotFound)` | Reuses existing `UnresolvedReason` taxonomy (D-UNRESOLVED) |

## Acceptance Criteria (#111)

- [x] Importing with a subset of playlists selected imports every valid library track
- [x] Importing with no playlists selected still imports every valid library track
- [x] Only selected playlists (+ ancestor folders) are recreated in the destination library
- [x] Tests cover both subset-selection and no-playlist scenarios

## Key Decisions

- **Pure breaking change** — no new `ItunesImportPolicy` flag. The issue's "should always" wording rules out opt-out semantics, and this matches the breaking-change posture of the recently-shipped Phase 40.
- **No new `UnresolvedReason` variant** — iCloud/streaming entries (no local file) surface as `FileNotFound`. Adding a `NonLocalTrack` variant is deferred until a consumer asks for it.
- **No iteration sort** — relies on the parser's `LinkedHashMap` preserving iTunes XML order.
- **Progress reports raw library size** — `totalItems = itunesLibrary.tracks.size`. Unresolved entries still count toward the total so progress bars reach 100% even when some tracks fail.

## Verification

- [x] `gradle :music-commons-core:compileKotlin :music-commons-core:compileTestKotlin :music-commons-core:ktlintCheck` — BUILD SUCCESSFUL
- [x] `gradle :music-commons-core:test --tests "net.transgressoft.commons.music.itunes.*"` — BUILD SUCCESSFUL (28 cases green)
- [x] Verifier confirmed all 4 acceptance criteria + 4 locked CONTEXT decisions

## Test plan

- [ ] CI passes on the PR
- [ ] Spot-check the 5 new test names in the test report
- [ ] Manual verification with a real iTunes library export (consumer-side, e.g. Musicott) — confirm tracks not referenced by selected playlists are now imported

🤖 Generated with [Claude Code](https://claude.com/claude-code)
