### PR TITLE
#115 Prevent catalog stalls during large Musicott imports

### DIFF
--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/MutableArtistCatalog.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/MutableArtistCatalog.kt
@@ -80,10 +80,25 @@ internal class MutableArtistCatalog<I>(override val artist: Artist)
         get() =
             synchronized(this) {
                 audioItemsByAlbumName
-                    .map { (albumName, audioItems) ->
-                        AlbumView(albumName, audioItems)
+                    .values
+                    .flatten()
+                    .distinctBy(::audioItemIdentity)
+                    .groupBy { it.album.name }
+                    .mapNotNull { (albumName, audioItems) ->
+                        if (audioItems.isEmpty()) {
+                            null
+                        } else {
+                            runCatching { AlbumView(albumName, audioItems) }.getOrNull()
+                        }
                     }.toSet()
             }
+
+    private fun audioItemIdentity(audioItem: I): Any =
+        if (audioItem.id != UNASSIGNED_ID) {
+            audioItem.id
+        } else {
+            audioItem.uniqueId
+        }
 
     override fun albumAudioItems(albumName: String): Set<I> =
         synchronized(this) {
@@ -102,9 +117,7 @@ internal class MutableArtistCatalog<I>(override val artist: Artist)
     /**
      * Adds an audio item to this catalog, maintaining sorted order by disc and track number.
      *
-     * Uses binary search to find the correct insertion point, ensuring items remain sorted
-     * within their album. If the item already exists (based on [Comparable] equality), it
-     * is not added again.
+     * Uses item identity for duplicate detection and comparable ordering only for insertion.
      *
      * @param audioItem The audio item to add
      * @return true if the audio item was added
@@ -113,10 +126,11 @@ internal class MutableArtistCatalog<I>(override val artist: Artist)
         synchronized(this) {
             mutateAndPublish {
                 val audioItems = audioItemsByAlbumName.getOrPut(audioItem.album.name) { mutableListOf() }
-                val existingIndex = audioItems.binarySearch(audioItem)
-
-                if (existingIndex < 0) {
-                    val insertionPoint = -(existingIndex + 1)
+                if (audioItems.none { isSameAudioItem(it, audioItem) }) {
+                    val insertionPoint =
+                        audioItems.indexOfFirst { it > audioItem }.let {
+                            if (it >= 0) it else audioItems.size
+                        }
                     audioItems.add(insertionPoint, audioItem)
                     logger.debug { "AudioItem $audioItem was added to album ${audioItem.album}" }
                     true
@@ -124,6 +138,13 @@ internal class MutableArtistCatalog<I>(override val artist: Artist)
                     false
                 }
             }
+        }
+
+    private fun isSameAudioItem(left: I, right: I): Boolean =
+        if (left.id != UNASSIGNED_ID && right.id != UNASSIGNED_ID) {
+            left.id == right.id
+        } else {
+            left === right || left.uniqueId == right.uniqueId
         }
 
     /**
@@ -142,12 +163,12 @@ internal class MutableArtistCatalog<I>(override val artist: Artist)
                         ?.let { albumName to it }
                         ?: audioItemsByAlbumName.entries
                             .firstOrNull { (_, items) ->
-                                items.any { it.uniqueId == audioItem.uniqueId }
+                                items.any { isSameAudioItem(it, audioItem) }
                             }
                             ?.let { (key, items) -> key to items }
                         ?: return@mutateAndPublish false
 
-                val removed = audioItems.removeIf { it.uniqueId == audioItem.uniqueId }
+                val removed = audioItems.removeIf { isSameAudioItem(it, audioItem) }
 
                 if (removed) {
                     if (audioItems.isEmpty()) {
@@ -169,7 +190,13 @@ internal class MutableArtistCatalog<I>(override val artist: Artist)
      */
     internal fun containsAudioItem(audioItem: I): Boolean =
         synchronized(this) {
-            artist == audioItem.artist && (audioItemsByAlbumName[audioItem.album.name]?.contains(audioItem) ?: false)
+            artist == audioItem.artist &&
+                (
+                    audioItemsByAlbumName[audioItem.album.name]?.any { isSameAudioItem(it, audioItem) }
+                        ?: audioItemsByAlbumName.values.any { audioItems ->
+                            audioItems.any { isSameAudioItem(it, audioItem) }
+                        }
+                )
         }
 
     /**

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/util/SortedMultimap.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/util/SortedMultimap.kt
@@ -28,13 +28,16 @@ internal class SortedMultimap<K : Comparable<K>, V : Comparable<V>> {
 
     private val valuesByKey = TreeMap<K, TreeSet<V>>()
 
-    operator fun get(key: K): Set<V> = valuesByKey[key] ?: emptySet()
+    @Synchronized
+    operator fun get(key: K): Set<V> = valuesByKey[key]?.toCollection(LinkedHashSet()) ?: emptySet()
 
+    @Synchronized
     fun put(
         key: K,
         value: V
     ): Boolean = valuesByKey.getOrPut(key) { TreeSet() }.add(value)
 
+    @Synchronized
     fun putAll(
         key: K,
         values: Iterable<V>
@@ -46,6 +49,7 @@ internal class SortedMultimap<K : Comparable<K>, V : Comparable<V>> {
         return changed
     }
 
+    @Synchronized
     fun remove(
         key: K,
         value: V
@@ -58,10 +62,13 @@ internal class SortedMultimap<K : Comparable<K>, V : Comparable<V>> {
         }
     }
 
-    fun removeAll(key: K): Set<V> = valuesByKey.remove(key) ?: emptySet()
+    @Synchronized
+    fun removeAll(key: K): Set<V> = valuesByKey.remove(key)?.toCollection(LinkedHashSet()) ?: emptySet()
 
+    @Synchronized
     fun containsValue(value: Any?): Boolean = valuesByKey.values.any { value in it }
 
+    @Synchronized
     fun entries(): Set<Map.Entry<K, V>> =
         valuesByKey.flatMapTo(LinkedHashSet()) { (key, values) ->
             values.map { value -> AbstractMap.SimpleImmutableEntry(key, value) }

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/util/SortedMultimap.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/util/SortedMultimap.kt
@@ -23,6 +23,13 @@ import java.util.TreeSet
 
 /**
  * Small sorted multimap for internal relationships that need deterministic key and value traversal.
+ *
+ * Backed by a [TreeMap] of [TreeSet] guarded by `@Synchronized` to provide atomic snapshots
+ * to readers (`get`, `entries`, `containsValue`) while concurrent writers mutate the structure.
+ * A concurrent alternative (e.g. `ConcurrentSkipListMap`) would lose this snapshot guarantee
+ * and reintroduce the partial-state visibility that motivated locking here in the first place.
+ * Contention is low in practice since the only caller — playlist hierarchy bookkeeping —
+ * touches the map at most once per playlist mutation, not per audio item.
  */
 internal class SortedMultimap<K : Comparable<K>, V : Comparable<V>> {
 

--- a/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/audio/MutableArtistCatalogTest.kt
+++ b/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/audio/MutableArtistCatalogTest.kt
@@ -385,6 +385,62 @@ class MutableArtistCatalogTest : StringSpec({
         }
     }
 
+    "MutableArtistCatalog equals returns true for same artist and items" {
+        val audioItem = createAudioItem(files.virtualAudioFile().next())
+        val catalog1 = MutableArtistCatalog(audioItem)
+        val catalog2 = MutableArtistCatalog(audioItem)
+
+        (catalog1 == catalog2) shouldBe true
+        catalog1.hashCode() shouldBe catalog2.hashCode()
+    }
+
+    "MutableArtistCatalog equals returns false for different artist" {
+        val firstArtist = Arb.artist().next()
+        val secondArtist = Arb.artist().next()
+        val first = MutableArtistCatalog<AudioItem>(firstArtist)
+        val second = MutableArtistCatalog<AudioItem>(secondArtist)
+
+        (first == second) shouldBe false
+    }
+
+    "MutableArtistCatalog equals returns false for non-catalog types and null" {
+        val catalog = MutableArtistCatalog<AudioItem>(Arb.artist().next())
+
+        catalog.equals(null) shouldBe false
+        catalog.equals("not a catalog") shouldBe false
+    }
+
+    "MutableArtistCatalog toString includes artist and size" {
+        val audioItem = createAudioItem(files.virtualAudioFile().next())
+        val catalog = MutableArtistCatalog(audioItem)
+
+        catalog.toString() shouldBe "MutableArtistCatalog(artist=${audioItem.artist}, size=1)"
+    }
+
+    "MutableArtistCatalog compareTo orders by artist" {
+        val firstArtist = ImmutableArtist.of("A Artist")
+        val secondArtist = ImmutableArtist.of("Z Artist")
+        val first = MutableArtistCatalog<AudioItem>(firstArtist)
+        val second = MutableArtistCatalog<AudioItem>(secondArtist)
+
+        (first.compareTo(second) < 0) shouldBe true
+    }
+
+    "MutableArtistCatalog containsAudioItem falls back to scanning other buckets when album bucket is missing" {
+        val renamedAlbum = Arb.album().next()
+        val audioItem = createAudioItem(files.virtualAudioFile().next())
+        val catalog = MutableArtistCatalog(audioItem)
+
+        audioItem.album = renamedAlbum
+
+        catalog.containsAudioItem(audioItem) shouldBe true
+    }
+
+    "MutableArtistCatalog albumAudioItems returns empty set for unknown album" {
+        val catalog = MutableArtistCatalog<AudioItem>(Arb.artist().next())
+        catalog.albumAudioItems("Nonexistent") shouldBe emptySet()
+    }
+
     "multiple subscribers should all receive MUTATE events" {
         val expectedArtist = Arb.artist().next()
         val catalog = MutableArtistCatalog<AudioItem>(expectedArtist)

--- a/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/audio/MutableArtistCatalogTest.kt
+++ b/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/audio/MutableArtistCatalogTest.kt
@@ -43,6 +43,9 @@ class MutableArtistCatalogTest : StringSpec({
     fun createAudioItem(path: Path): AudioItem =
         MutableAudioItemTestBridge.createAudioItem(path, files.metadataIO)
 
+    fun createAudioItem(path: Path, id: Int): AudioItem =
+        MutableAudioItemTestBridge.createAudioItem(path, id, files.metadataIO)
+
     "MUTATE event is published when audio item is added to empty catalog" {
         val expectedArtist = Arb.artist().next()
         val expectedAlbum = Arb.album().next()
@@ -82,6 +85,27 @@ class MutableArtistCatalogTest : StringSpec({
             catalogSnapshot.albums.size shouldBe 0
             catalogSnapshot.isEmpty shouldBe true
         }
+    }
+
+    "MutableArtistCatalog stores items with the same ordering and unique id when repository ids differ" {
+        val expectedArtist = Arb.artist().next()
+        val expectedAlbum = ImmutableAlbum("Shared Album", expectedArtist)
+        val path =
+            files.virtualAudioFile {
+                artist = expectedArtist
+                album = expectedAlbum
+                trackNumber = 1
+                discNumber = 1
+            }.next()
+        val firstAudioItem = createAudioItem(path, 1)
+        val secondAudioItem = createAudioItem(path, 2)
+        val catalog = MutableArtistCatalog<AudioItem>(expectedArtist)
+
+        catalog.addAudioItem(firstAudioItem) shouldBe true
+        catalog.addAudioItem(secondAudioItem) shouldBe true
+
+        catalog.size shouldBe 2
+        catalog.albumAudioItems(firstAudioItem.album.name) shouldBe setOf(firstAudioItem, secondAudioItem)
     }
 
     "MUTATE event is published when second audio item is added to same album" {

--- a/music-commons-core/src/test/kotlin/net/transgressoft/commons/util/SortedMultimapTest.kt
+++ b/music-commons-core/src/test/kotlin/net/transgressoft/commons/util/SortedMultimapTest.kt
@@ -1,0 +1,57 @@
+package net.transgressoft.commons.util
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.concurrent.thread
+
+/**
+ * Verifies the snapshot semantics expected by concurrent hierarchy readers.
+ */
+internal class SortedMultimapTest : StringSpec({
+
+    "SortedMultimap get returns a stable snapshot" {
+        val multimap = SortedMultimap<Int, Int>()
+        multimap.put(1, 1)
+        multimap.put(1, 2)
+
+        val values = multimap[1]
+        multimap.put(1, 3)
+
+        values shouldBe setOf(1, 2)
+    }
+
+    "SortedMultimap entries can be read while writes happen concurrently" {
+        val multimap = SortedMultimap<Int, Int>()
+        repeat(100) { multimap.put(0, it) }
+        val start = CountDownLatch(1)
+        val failure = AtomicReference<Throwable?>()
+
+        val reader =
+            thread {
+                start.await()
+                repeat(5_000) {
+                    runCatching {
+                        multimap.entries().forEach { entry -> entry.key + entry.value }
+                    }.onFailure { failure.compareAndSet(null, it) }
+                }
+            }
+
+        val writer =
+            thread {
+                start.await()
+                repeat(5_000) {
+                    val value = it % 200
+                    multimap.put(it % 10, value)
+                    multimap.remove((it + 1) % 10, value)
+                }
+            }
+
+        start.countDown()
+        reader.join()
+        writer.join()
+
+        failure.get() shouldBe null
+    }
+})

--- a/music-commons-core/src/test/kotlin/net/transgressoft/commons/util/SortedMultimapTest.kt
+++ b/music-commons-core/src/test/kotlin/net/transgressoft/commons/util/SortedMultimapTest.kt
@@ -22,6 +22,31 @@ internal class SortedMultimapTest : StringSpec({
         values shouldBe setOf(1, 2)
     }
 
+    "SortedMultimap putAll reports changed only when at least one value is new" {
+        val multimap = SortedMultimap<Int, Int>()
+        multimap.put(1, 1)
+
+        multimap.putAll(1, listOf(1)) shouldBe false
+        multimap.putAll(1, listOf(1, 2)) shouldBe true
+        multimap.putAll(1, listOf(1, 2)) shouldBe false
+    }
+
+    "SortedMultimap remove and removeAll behave correctly" {
+        val multimap = SortedMultimap<Int, Int>()
+        multimap.put(1, 1)
+        multimap.put(1, 2)
+        multimap.put(2, 3)
+
+        multimap.remove(99, 99) shouldBe false
+        multimap.remove(1, 1) shouldBe true
+        multimap[1] shouldBe setOf(2)
+        multimap.removeAll(1) shouldBe setOf(2)
+        multimap[1] shouldBe emptySet()
+        multimap.removeAll(99) shouldBe emptySet()
+        multimap.containsValue(3) shouldBe true
+        multimap.containsValue(999) shouldBe false
+    }
+
     "SortedMultimap entries can be read while writes happen concurrently" {
         val multimap = SortedMultimap<Int, Int>()
         repeat(100) { multimap.put(0, it) }

--- a/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/audio/FXArtistCatalog.kt
+++ b/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/audio/FXArtistCatalog.kt
@@ -21,6 +21,7 @@ import net.transgressoft.commons.music.audio.Album
 import net.transgressoft.commons.music.audio.AlbumSet
 import net.transgressoft.commons.music.audio.AlbumView
 import net.transgressoft.commons.music.audio.Artist
+import net.transgressoft.commons.music.audio.UNASSIGNED_ID
 import net.transgressoft.commons.music.audio.id
 import net.transgressoft.lirp.entity.ReactiveEntityBase
 import net.transgressoft.lirp.event.ReactiveScope
@@ -111,10 +112,26 @@ internal class FXArtistCatalog(
         get() =
             synchronized(this) {
                 audioItemsByAlbumName
-                    .map { (albumName, audioItems) ->
-                        AlbumView(albumName, audioItems)
+                    .values
+                    .flatten()
+                    .distinctBy(::audioItemIdentity)
+                    .groupBy { it.album.name }
+                    .mapNotNull { (albumName, audioItems) ->
+                        val stableAudioItems = audioItems.filter { it.album.name == albumName }
+                        if (stableAudioItems.isEmpty()) {
+                            null
+                        } else {
+                            runCatching { AlbumView(albumName, stableAudioItems) }.getOrNull()
+                        }
                     }.toSet()
             }
+
+    private fun audioItemIdentity(audioItem: ObservableAudioItem): Any =
+        if (audioItem.id != UNASSIGNED_ID) {
+            audioItem.id
+        } else {
+            audioItem.uniqueId
+        }
 
     override fun albumAudioItems(albumName: String): Set<ObservableAudioItem> =
         synchronized(this) {
@@ -134,10 +151,11 @@ internal class FXArtistCatalog(
         synchronized(this) {
             mutateAndPublish {
                 val audioItems = audioItemsByAlbumName.getOrPut(audioItem.album.name) { mutableListOf() }
-                val existingIndex = audioItems.binarySearch(audioItem)
-
-                if (existingIndex < 0) {
-                    val insertionPoint = -(existingIndex + 1)
+                if (audioItems.none { isSameAudioItem(it, audioItem) }) {
+                    val insertionPoint =
+                        audioItems.indexOfFirst { it > audioItem }.let {
+                            if (it >= 0) it else audioItems.size
+                        }
                     audioItems.add(insertionPoint, audioItem)
                     logger.debug { "AudioItem $audioItem was added to album ${audioItem.album}" }
                     queueFxRefresh()
@@ -148,17 +166,32 @@ internal class FXArtistCatalog(
             }
         }
 
+    private fun isSameAudioItem(left: ObservableAudioItem, right: ObservableAudioItem): Boolean =
+        if (left.id != UNASSIGNED_ID && right.id != UNASSIGNED_ID) {
+            left.id == right.id
+        } else {
+            left === right || left.uniqueId == right.uniqueId
+        }
+
     internal fun removeAudioItem(audioItem: ObservableAudioItem): Boolean =
         synchronized(this) {
             mutateAndPublish {
                 val albumName = audioItem.album.name
-                val audioItems = audioItemsByAlbumName[albumName] ?: return@mutateAndPublish false
+                val (resolvedAlbumName, audioItems) =
+                    audioItemsByAlbumName[albumName]
+                        ?.let { albumName to it }
+                        ?: audioItemsByAlbumName.entries
+                            .firstOrNull { (_, items) ->
+                                items.any { isSameAudioItem(it, audioItem) }
+                            }
+                            ?.let { (key, items) -> key to items }
+                        ?: return@mutateAndPublish false
 
-                val removed = audioItems.removeIf { it.uniqueId == audioItem.uniqueId }
+                val removed = audioItems.removeIf { isSameAudioItem(it, audioItem) }
 
                 if (removed) {
                     if (audioItems.isEmpty()) {
-                        audioItemsByAlbumName.remove(albumName)
+                        audioItemsByAlbumName.remove(resolvedAlbumName)
                         logger.debug { "Album ${audioItem.album} was removed from artist catalog of $artist" }
                     } else {
                         logger.debug { "AudioItem $audioItem was removed from album ${audioItem.album}" }
@@ -171,7 +204,13 @@ internal class FXArtistCatalog(
 
     internal fun containsAudioItem(audioItem: ObservableAudioItem): Boolean =
         synchronized(this) {
-            audioItemsByAlbumName[audioItem.album.name]?.contains(audioItem) ?: false
+            artist == audioItem.artist &&
+                (
+                    audioItemsByAlbumName[audioItem.album.name]?.any { isSameAudioItem(it, audioItem) }
+                        ?: audioItemsByAlbumName.values.any { audioItems ->
+                            audioItems.any { isSameAudioItem(it, audioItem) }
+                        }
+                )
         }
 
     internal fun mergeAudioItem(audioItem: ObservableAudioItem): Boolean =

--- a/music-commons-fx/src/test/kotlin/net/transgressoft/commons/fx/music/audio/FXArtistCatalogTest.kt
+++ b/music-commons-fx/src/test/kotlin/net/transgressoft/commons/fx/music/audio/FXArtistCatalogTest.kt
@@ -4,6 +4,7 @@ import net.transgressoft.commons.music.audio.ImmutableAlbum
 import net.transgressoft.commons.music.audio.ImmutableArtist
 import net.transgressoft.commons.music.audio.virtualFiles
 import net.transgressoft.commons.music.testing.reactiveScope
+import net.transgressoft.lirp.persistence.VolatileRepository
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
@@ -92,6 +93,88 @@ internal class FXArtistCatalogTest : StringSpec({
         catalog.addAudioItem(audioItem)
 
         cloneBefore shouldNotBe catalog
+    }
+
+    "FXArtistCatalog removes an item from the resolved album bucket when the item's album changed before removal" {
+        val renamedAlbum = ImmutableAlbum("Renamed Album", artist)
+        val catalog = FXArtistCatalog(artist)
+        val path =
+            files.virtualAudioFile {
+                this.artist = artist
+                this.album = album
+            }.next()
+        val audioItem = FXAudioItemTestBridge.createFxAudioItem(path, files.metadataIO)
+
+        catalog.addAudioItem(audioItem)
+        audioItem.album = renamedAlbum
+
+        catalog.containsAudioItem(audioItem) shouldBe true
+        catalog.removeAudioItem(audioItem) shouldBe true
+        catalog.albums shouldBe emptySet()
+    }
+
+    "FXArtistCatalog albums uses the current audio item album when a bucket is stale" {
+        val renamedAlbum = ImmutableAlbum("Renamed Album", artist)
+        val catalog = FXArtistCatalog(artist)
+        val path =
+            files.virtualAudioFile {
+                this.artist = artist
+                this.album = album
+            }.next()
+        val audioItem = FXAudioItemTestBridge.createFxAudioItem(path, files.metadataIO)
+
+        catalog.addAudioItem(audioItem)
+        audioItem.album = renamedAlbum
+
+        catalog.albums.single().albumName shouldBe renamedAlbum.name
+    }
+
+    "FXArtistCatalog stores items with the same ordering and unique id when repository ids differ" {
+        val catalog = FXArtistCatalog(artist)
+        val path =
+            files.virtualAudioFile {
+                this.artist = artist
+                this.album = album
+                trackNumber = 1
+                discNumber = 1
+            }.next()
+        val firstAudioItem = FXAudioItemTestBridge.createFxAudioItem(path, 1, files.metadataIO)
+        val secondAudioItem = FXAudioItemTestBridge.createFxAudioItem(path, 2, files.metadataIO)
+
+        catalog.addAudioItem(firstAudioItem) shouldBe true
+        catalog.addAudioItem(secondAudioItem) shouldBe true
+
+        catalog.size shouldBe 2
+        catalog.albumAudioItems(firstAudioItem.album.name) shouldBe setOf(firstAudioItem, secondAudioItem)
+    }
+
+    "FXAudioLibrary indexes same unique id items under different primary artists" {
+        val firstArtist = ImmutableArtist.of("First Artist")
+        val secondArtist = ImmutableArtist.of("Second Artist")
+        val path =
+            files.virtualAudioFile {
+                this.artist = firstArtist
+                this.album = ImmutableAlbum("Shared Album", firstArtist)
+                trackNumber = 1
+                discNumber = 1
+            }.next()
+        val firstAudioItem = FXAudioItemTestBridge.createFxAudioItem(path, 1, files.metadataIO)
+        val secondAudioItem =
+            FXAudioItemTestBridge.createFxAudioItem(path, 2, files.metadataIO).apply {
+                this.artist = secondArtist
+                this.album = ImmutableAlbum("Shared Album", secondArtist)
+            }
+        val audioLibrary = FXAudioLibrary(VolatileRepository("SameUniqueIdFxAudioLibrary"))
+
+        audioLibrary.add(firstAudioItem)
+        audioLibrary.add(secondAudioItem)
+        reactive.advance()
+
+        audioLibrary.getArtistCatalog(firstArtist).isPresent shouldBe true
+        audioLibrary.getArtistCatalog(secondArtist).isPresent shouldBe true
+        audioLibrary.getArtistCatalog(firstArtist).get().albumAudioItems("Shared Album") shouldBe setOf(firstAudioItem)
+        audioLibrary.getArtistCatalog(secondArtist).get().albumAudioItems("Shared Album") shouldBe setOf(secondAudioItem)
+        audioLibrary.close()
     }
 
     "FXArtistCatalog coalesces burst mutations into one JavaFX property refresh" {

--- a/music-commons-fx/src/test/kotlin/net/transgressoft/commons/fx/music/audio/FXArtistCatalogTest.kt
+++ b/music-commons-fx/src/test/kotlin/net/transgressoft/commons/fx/music/audio/FXArtistCatalogTest.kt
@@ -2,6 +2,7 @@ package net.transgressoft.commons.fx.music.audio
 
 import net.transgressoft.commons.music.audio.ImmutableAlbum
 import net.transgressoft.commons.music.audio.ImmutableArtist
+import net.transgressoft.commons.music.audio.id
 import net.transgressoft.commons.music.audio.virtualFiles
 import net.transgressoft.commons.music.testing.reactiveScope
 import net.transgressoft.lirp.persistence.VolatileRepository
@@ -164,17 +165,16 @@ internal class FXArtistCatalogTest : StringSpec({
                 this.artist = secondArtist
                 this.album = ImmutableAlbum("Shared Album", secondArtist)
             }
-        val audioLibrary = FXAudioLibrary(VolatileRepository("SameUniqueIdFxAudioLibrary"))
+        FXAudioLibrary(VolatileRepository("SameUniqueIdFxAudioLibrary")).use { audioLibrary ->
+            audioLibrary.add(firstAudioItem)
+            audioLibrary.add(secondAudioItem)
+            reactive.advance()
 
-        audioLibrary.add(firstAudioItem)
-        audioLibrary.add(secondAudioItem)
-        reactive.advance()
-
-        audioLibrary.getArtistCatalog(firstArtist).isPresent shouldBe true
-        audioLibrary.getArtistCatalog(secondArtist).isPresent shouldBe true
-        audioLibrary.getArtistCatalog(firstArtist).get().albumAudioItems("Shared Album") shouldBe setOf(firstAudioItem)
-        audioLibrary.getArtistCatalog(secondArtist).get().albumAudioItems("Shared Album") shouldBe setOf(secondAudioItem)
-        audioLibrary.close()
+            audioLibrary.getArtistCatalog(firstArtist).isPresent shouldBe true
+            audioLibrary.getArtistCatalog(secondArtist).isPresent shouldBe true
+            audioLibrary.getArtistCatalog(firstArtist).get().albumAudioItems("Shared Album") shouldBe setOf(firstAudioItem)
+            audioLibrary.getArtistCatalog(secondArtist).get().albumAudioItems("Shared Album") shouldBe setOf(secondAudioItem)
+        }
     }
 
     "FXArtistCatalog coalesces burst mutations into one JavaFX property refresh" {
@@ -204,5 +204,121 @@ internal class FXArtistCatalogTest : StringSpec({
 
         (catalog.equals(null)) shouldBe false
         (catalog.equals("not a catalog")) shouldBe false
+    }
+
+    "FXArtistCatalog mergeAudioItem reorders item when track number changed" {
+        val catalog = FXArtistCatalog(artist)
+        val firstPath =
+            files.virtualAudioFile {
+                this.artist = artist
+                this.album = album
+                trackNumber = 1
+                discNumber = 1
+            }.next()
+        val secondPath =
+            files.virtualAudioFile {
+                this.artist = artist
+                this.album = album
+                trackNumber = 2
+                discNumber = 1
+            }.next()
+        val first = FXAudioItemTestBridge.createFxAudioItem(firstPath, files.metadataIO)
+        val second = FXAudioItemTestBridge.createFxAudioItem(secondPath, files.metadataIO)
+
+        catalog.addAudioItem(first) shouldBe true
+        catalog.addAudioItem(second) shouldBe true
+
+        first.trackNumber = 10
+        catalog.mergeAudioItem(first) shouldBe true
+
+        val ordered = catalog.albumAudioItems(album.name).toList()
+        ordered.last() shouldBe first
+    }
+
+    "FXArtistCatalog mergeAudioItem returns false when album bucket is unknown" {
+        val catalog = FXArtistCatalog(artist)
+        val path =
+            files.virtualAudioFile {
+                this.artist = artist
+                this.album = album
+            }.next()
+        val audioItem = FXAudioItemTestBridge.createFxAudioItem(path, files.metadataIO)
+
+        catalog.mergeAudioItem(audioItem) shouldBe false
+    }
+
+    "FXArtistCatalog mergeAudioItem returns false for single-item album" {
+        val catalog = FXArtistCatalog(artist)
+        val path =
+            files.virtualAudioFile {
+                this.artist = artist
+                this.album = album
+            }.next()
+        val audioItem = FXAudioItemTestBridge.createFxAudioItem(path, files.metadataIO)
+
+        catalog.addAudioItem(audioItem) shouldBe true
+        audioItem.trackNumber = 99
+        catalog.mergeAudioItem(audioItem) shouldBe false
+    }
+
+    "FXArtistCatalog mergeAudioItem returns false when the position did not change" {
+        val catalog = FXArtistCatalog(artist)
+        val firstPath =
+            files.virtualAudioFile {
+                this.artist = artist
+                this.album = album
+                trackNumber = 1
+                discNumber = 1
+            }.next()
+        val secondPath =
+            files.virtualAudioFile {
+                this.artist = artist
+                this.album = album
+                trackNumber = 2
+                discNumber = 1
+            }.next()
+        val first = FXAudioItemTestBridge.createFxAudioItem(firstPath, files.metadataIO)
+        val second = FXAudioItemTestBridge.createFxAudioItem(secondPath, files.metadataIO)
+
+        catalog.addAudioItem(first) shouldBe true
+        catalog.addAudioItem(second) shouldBe true
+
+        catalog.mergeAudioItem(first) shouldBe false
+    }
+
+    "FXArtistCatalog mergeAudioItem returns false when the item reference is missing from the album list" {
+        val catalog = FXArtistCatalog(artist)
+        val firstPath =
+            files.virtualAudioFile {
+                this.artist = artist
+                this.album = album
+            }.next()
+        val secondPath =
+            files.virtualAudioFile {
+                this.artist = artist
+                this.album = album
+            }.next()
+        val tracked = FXAudioItemTestBridge.createFxAudioItem(firstPath, files.metadataIO)
+        val untracked = FXAudioItemTestBridge.createFxAudioItem(firstPath, files.metadataIO)
+        val sibling = FXAudioItemTestBridge.createFxAudioItem(secondPath, files.metadataIO)
+
+        catalog.addAudioItem(tracked) shouldBe true
+        catalog.addAudioItem(sibling) shouldBe true
+
+        catalog.mergeAudioItem(untracked) shouldBe false
+    }
+
+    "FXArtistCatalog exposes empty, artist and uniqueId properties consistent with state" {
+        val catalog = FXArtistCatalog(artist)
+
+        catalog.emptyProperty.get() shouldBe true
+        catalog.artistProperty.get() shouldBe artist
+        catalog.uniqueId shouldBe artist.id()
+        catalog.compareTo(FXArtistCatalog(artist)) shouldBe 0
+    }
+
+    "FXArtistCatalog albumAudioItems returns empty set for unknown album" {
+        val catalog = FXArtistCatalog(artist)
+        catalog.albumAudioItems("Nonexistent") shouldBe emptySet()
     }
 })


### PR DESCRIPTION
Fixes two regressions exposed by Musicott's large iTunes compilation import:
- playlist hierarchy reads now take synchronized snapshots instead of iterating a live multimap during mutation callbacks
- artist catalog membership now uses repository identity, so distinct tracks with matching ordering metadata do not collapse into one entry

Verified with targeted `music-commons-core`/`music-commons-fx` tests and the Musicott E2E that originally timed out.