### PR TITLE
#119 Fix playback progress for misidentified containerized M4A files

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ Music Commons is free software under GNU GPL version 3 license, available [here]
 This project builds upon several excellent open-source libraries:
 
 - **[JAudioTagger](https://github.com/ericfarng/jaudiotagger)**: Audio metadata reading and writing library
-- **JavaSound SPI providers** ([mp3spi](https://github.com/umjammer/mp3spi), [javasound-flac](https://github.com/Tianscar/javasound-flac), [javasound-vorbis](https://github.com/Tianscar/javasound-vorbis), [javasound-aac](https://github.com/Tianscar/javasound-aac), [JAAD](https://github.com/Almax/jaad)): pure-Java audio decoders for MP3, FLAC, OGG Vorbis, and AAC/M4A
+- **JavaSound SPI providers** ([mp3spi](https://github.com/umjammer/mp3spi), [javasound-flac](https://github.com/Tianscar/javasound-flac), [javasound-vorbis](https://github.com/Tianscar/javasound-vorbis), [javasound-aac](https://github.com/Tianscar/javasound-aac), [JAAD](https://github.com/Almax/jaad)): pure-Java audio decoders for MP3, FLAC, OGG Vorbis, and AAC/M4A; playback progress and seek ratios use the decoded PCM stream duration when available
 - **[Kotlin Coroutines](https://github.com/Kotlin/kotlinx.coroutines)**: Library support for Kotlin coroutines
 - **[kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization)**: Kotlin multiplatform serialization
 - **[lirp](https://github.com/octaviospain/lirp)**: Reactive entity framework and persistence infrastructure

--- a/music-commons-fx/src/test/kotlin/net/transgressoft/commons/fx/music/waveform/PlayableWaveformPaneDemo.kt
+++ b/music-commons-fx/src/test/kotlin/net/transgressoft/commons/fx/music/waveform/PlayableWaveformPaneDemo.kt
@@ -4,6 +4,7 @@ import net.transgressoft.commons.fx.music.FXMusicLibrary
 import net.transgressoft.commons.fx.music.audio.ObservableAudioItem
 import net.transgressoft.commons.fx.music.player.FXAudioItemPlayer
 import net.transgressoft.commons.media.waveform.ScalableAudioWaveform
+import net.transgressoft.commons.music.audio.AudioFileType
 import net.transgressoft.commons.music.player.AudioItemPlayer
 import javafx.application.Application
 import javafx.collections.FXCollections
@@ -14,6 +15,7 @@ import javafx.scene.control.Label
 import javafx.scene.control.Slider
 import javafx.scene.layout.BorderPane
 import javafx.scene.layout.HBox
+import javafx.stage.FileChooser
 import javafx.stage.Stage
 import java.nio.file.Files
 import java.nio.file.Path
@@ -73,7 +75,30 @@ class PlayableWaveformPaneDemo : Application() {
                 }
             }
 
-        val controls = HBox(10.0, Label("Fixture:"), formatSelector, playPauseButton, stopButton, Label("Vol:"), volumeSlider, statusLabel)
+        val browseButton =
+            Button("Browse...").apply {
+                setOnAction {
+                    try {
+                        val chooser = FileChooser()
+                        chooser.title = "Select Audio File"
+                        val extList = AudioFileType.extensions.map { "*.$it" }
+                        chooser.extensionFilters.add(
+                            FileChooser.ExtensionFilter("Audio Files", *extList.toTypedArray())
+                        )
+                        val file = chooser.showOpenDialog(primaryStage) ?: return@setOnAction
+                        stopPlayback()
+                        currentAudioItem = library.audioItemFromFile(file.toPath())
+                        playableWaveformPane.loadWaveform(ScalableAudioWaveform(1, file.toPath()))
+                        statusLabel.text = "Loaded: ${file.name}"
+                    } catch (e: Exception) {
+                        statusLabel.text = "Error loading file: ${e.message}"
+                        currentAudioItem = null
+                        e.printStackTrace()
+                    }
+                }
+            }
+
+        val controls = HBox(10.0, Label("Fixture:"), formatSelector, browseButton, playPauseButton, stopButton, Label("Vol:"), volumeSlider, statusLabel)
         borderPane.bottom = controls
 
         player.currentTimeProperty.addListener { _, _, newTime ->

--- a/music-commons-fx/src/test/kotlin/net/transgressoft/commons/fx/music/waveform/WaveformPaneDemo.kt
+++ b/music-commons-fx/src/test/kotlin/net/transgressoft/commons/fx/music/waveform/WaveformPaneDemo.kt
@@ -1,13 +1,16 @@
 package net.transgressoft.commons.fx.music.waveform
 
 import net.transgressoft.commons.media.waveform.ScalableAudioWaveform
+import net.transgressoft.commons.music.audio.AudioFileType
 import javafx.application.Application
 import javafx.collections.FXCollections
 import javafx.scene.Scene
+import javafx.scene.control.Button
 import javafx.scene.control.ComboBox
 import javafx.scene.layout.AnchorPane
 import javafx.scene.layout.HBox
 import javafx.scene.paint.Color
+import javafx.stage.FileChooser
 import javafx.stage.Stage
 import java.nio.file.Files
 import java.nio.file.Path
@@ -40,8 +43,31 @@ class WaveformPaneDemo : Application() {
                 setOnAction { loadWaveformForFixture(value) }
             }
 
+        val browseButton =
+            Button("Browse...").apply {
+                setOnAction {
+                    try {
+                        val chooser = FileChooser()
+                        chooser.title = "Select Audio File"
+                        val extList = AudioFileType.extensions.map { "*.$it" }
+                        chooser.extensionFilters.add(
+                            FileChooser.ExtensionFilter("Audio Files", *extList.toTypedArray())
+                        )
+                        val file = chooser.showOpenDialog(primaryStage) ?: return@setOnAction
+                        waveformPane.drawWaveformAsync(
+                            ScalableAudioWaveform(1, file.toPath()),
+                            Color.GREEN,
+                            Color.MAGENTA
+                        )
+                    } catch (e: Exception) {
+                        println("Error loading file: ${e.message}")
+                        e.printStackTrace()
+                    }
+                }
+            }
+
         val controls =
-            HBox(10.0, formatSelector).apply {
+            HBox(10.0, formatSelector, browseButton).apply {
                 AnchorPane.setBottomAnchor(this, 10.0)
                 AnchorPane.setLeftAnchor(this, 10.0)
             }

--- a/music-commons-media/src/main/kotlin/net/transgressoft/commons/media/player/CoreAudioItemPlayer.kt
+++ b/music-commons-media/src/main/kotlin/net/transgressoft/commons/media/player/CoreAudioItemPlayer.kt
@@ -171,7 +171,7 @@ open class CoreAudioItemPlayer private constructor(
         stopCurrentPlayback()
         seekTargetMillis.set(-1L)
         framePosition = 0L
-        sourceDurationMillis = durationMillis(audioFileFormat)
+        sourceDurationMillis = resolveSourceDurationMillis(file, audioFileFormat)
         currentAudioItem.set(audioItem)
         val mySession = sessionId.incrementAndGet()
         activeSessionId.set(mySession)
@@ -342,6 +342,10 @@ open class CoreAudioItemPlayer private constructor(
         val stream = pcmStreamFactory(file.toPath())
         val format = stream.format
         pcmFormat.set(format)
+        val streamDurationMillis = durationMillis(stream)
+        if (streamDurationMillis > 0L) {
+            sourceDurationMillis = streamDurationMillis
+        }
         val alignedOffset = requestedOffset.coerceAtLeast(0L).alignDown(format.frameSize.toLong())
         val skipped = skipFully(stream, alignedOffset)
         framePosition = skipped.alignDown(format.frameSize.toLong())
@@ -449,6 +453,52 @@ open class CoreAudioItemPlayer private constructor(
             (audioFileFormat.frameLength * 1000.0 / format.frameRate).toLong()
         } else {
             0L
+        }
+    }
+
+    private fun durationMillis(audioInputStream: AudioInputStream): Long {
+        val format = audioInputStream.format
+        return if (audioInputStream.frameLength > 0 && format.frameRate > 0f) {
+            (audioInputStream.frameLength * 1000.0 / format.frameRate).toLong()
+        } else {
+            0L
+        }
+    }
+
+    private fun resolveSourceDurationMillis(file: File, audioFileFormat: AudioFileFormat): Long {
+        val fileFormatDurationMillis = durationMillis(audioFileFormat)
+        if (!requiresDecodedDurationProbe(file, audioFileFormat)) {
+            return fileFormatDurationMillis
+        }
+
+        val decodedDurationMillis = durationMillisFromPcmStream(file)
+        return if (decodedDurationMillis > 0L) decodedDurationMillis else fileFormatDurationMillis
+    }
+
+    private fun requiresDecodedDurationProbe(file: File, audioFileFormat: AudioFileFormat): Boolean {
+        val containerExtension = file.extension.lowercase()
+        if (containerExtension !in setOf("m4a", "mp4", "aac")) {
+            return false
+        }
+        return audioFileFormat.type.extension.equals("mp3", ignoreCase = true)
+    }
+
+    private fun durationMillisFromPcmStream(file: File): Long {
+        val stream = pcmStreamFactory(file.toPath())
+        return stream.use { stream ->
+            val format = stream.format
+            val frameSize = format.frameSize.takeIf { it > 0 } ?: return 0L
+            val frameRate = format.frameRate
+            if (frameRate <= 0f) return 0L
+
+            val buffer = ByteArray(TRANSFER_BUFFER_SIZE)
+            var totalBytes = 0L
+            while (true) {
+                val bytesRead = stream.read(buffer)
+                if (bytesRead < 0) break
+                totalBytes += bytesRead
+            }
+            (totalBytes * 1000.0 / frameSize / frameRate).toLong()
         }
     }
 

--- a/music-commons-media/src/main/kotlin/net/transgressoft/commons/media/util/AudioDecoderUtil.kt
+++ b/music-commons-media/src/main/kotlin/net/transgressoft/commons/media/util/AudioDecoderUtil.kt
@@ -17,10 +17,16 @@
 
 package net.transgressoft.commons.media.util
 
+import net.transgressoft.commons.music.player.UnsupportedAudioPlaybackException
+import java.io.File
+import java.io.IOException
 import java.nio.file.Path
+import java.util.ServiceLoader
 import javax.sound.sampled.AudioFormat
 import javax.sound.sampled.AudioInputStream
 import javax.sound.sampled.AudioSystem
+import javax.sound.sampled.UnsupportedAudioFileException
+import javax.sound.sampled.spi.AudioFileReader
 
 /**
  * Decodes supported audio files to PCM_SIGNED data.
@@ -34,30 +40,125 @@ import javax.sound.sampled.AudioSystem
  *   `DecodedMP4AudioInputStream` (decoded PCM) when asked to convert AAC → PCM_SIGNED
  *   with matching channels, sample size, and endianness. We rely on this conversion
  *   path rather than reading raw bytes.
+ *
+ * The decoder probes every registered SPI reader end-to-end. A provider is skipped when
+ * it crashes while opening the file, cannot convert the stream to PCM, or throws while
+ * producing the first PCM bytes. That keeps a buggy reader from blocking a later one that
+ * can actually play the file.
  */
 fun decodeToPcmStream(path: Path): AudioInputStream {
-    val rawStream = AudioSystem.getAudioInputStream(path.toFile())
-    try {
-        val baseFormat = rawStream.format
-        val sampleSize = baseFormat.sampleSizeInBits.takeIf { it > 0 } ?: 16
-        val targetFormat =
-            AudioFormat(
-                AudioFormat.Encoding.PCM_SIGNED,
-                baseFormat.sampleRate,
-                sampleSize,
-                baseFormat.channels,
-                baseFormat.channels * (sampleSize / 8),
-                baseFormat.sampleRate,
-                baseFormat.isBigEndian
-            )
+    val file = path.toFile()
+    val readers = prioritizeAudioFileReaders(file, loadAudioFileReaders())
+    if (readers.isEmpty()) {
+        throw UnsupportedAudioPlaybackException("No AudioFileReader providers registered for '${file.name}'")
+    }
 
-        // M4A/AAC special handling: JAAD SPI returns MP4AudioInputStream (raw AAC-encoded bytes).
-        // AACFormatConversionProvider converts it to DecodedMP4AudioInputStream (decoded PCM)
-        // when the target format matches channels, sample size, and endianness of the source.
-        // Standard format conversion otherwise covers WAV, FLAC, OGG, MP3 (via their respective SPIs)
-        return AudioSystem.getAudioInputStream(targetFormat, rawStream)
-    } catch (e: Throwable) {
-        runCatching { rawStream.close() }
-        throw e
+    return decodeWithReaders(file, readers)
+}
+
+private fun decodeWithReaders(file: File, readers: List<AudioFileReader>): AudioInputStream {
+    var firstFailure: Throwable? = null
+    for (reader in readers) {
+        val openResult = openAudioInputStream(reader, file)
+        if (openResult.failure != null && firstFailure == null) {
+            firstFailure = openResult.failure
+        }
+        val rawStream = openResult.stream ?: continue
+
+        val decodeResult = decodePcmStream(rawStream)
+        if (decodeResult.failure != null && firstFailure == null) {
+            firstFailure = decodeResult.failure
+        }
+        decodeResult.stream?.let { return it }
+    }
+
+    throw UnsupportedAudioPlaybackException(
+        "Cannot decode '${file.name}': unsupported format (tried ${readers.size} providers)",
+        firstFailure
+    )
+}
+
+private fun openAudioInputStream(reader: AudioFileReader, file: File): ReaderAttempt =
+    try {
+        ReaderAttempt(reader.getAudioInputStream(file), null)
+    } catch (_: UnsupportedAudioFileException) {
+        ReaderAttempt(null, null)
+    } catch (e: IOException) {
+        ReaderAttempt(null, e)
+    } catch (e: RuntimeException) {
+        ReaderAttempt(null, e)
+    }
+
+private fun decodePcmStream(rawStream: AudioInputStream): ReaderAttempt {
+    var pcmStream: AudioInputStream? = null
+    var decodedStream: AudioInputStream? = null
+    return try {
+        pcmStream = convertToPcmStream(rawStream)
+        decodedStream = validateReadablePcmStream(pcmStream)
+        ReaderAttempt(decodedStream, null)
+    } catch (_: UnsupportedAudioFileException) {
+        ReaderAttempt(null, null)
+    } catch (e: RuntimeException) {
+        ReaderAttempt(null, e)
+    } finally {
+        if (decodedStream == null) {
+            closeQuietly(pcmStream)
+            closeQuietly(rawStream)
+        }
     }
 }
+
+private fun convertToPcmStream(rawStream: AudioInputStream): AudioInputStream {
+    val baseFormat = rawStream.format
+    val sampleSize = baseFormat.sampleSizeInBits.takeIf { it > 0 } ?: 16
+    val targetFormat =
+        AudioFormat(
+            AudioFormat.Encoding.PCM_SIGNED,
+            baseFormat.sampleRate,
+            sampleSize,
+            baseFormat.channels,
+            baseFormat.channels * (sampleSize / 8),
+            baseFormat.sampleRate,
+            baseFormat.isBigEndian
+        )
+
+    return AudioSystem.getAudioInputStream(targetFormat, rawStream)
+}
+
+private fun validateReadablePcmStream(pcmStream: AudioInputStream): AudioInputStream {
+    val frameSize = pcmStream.format.frameSize.takeIf { it > 0 } ?: 1
+    val probeSize = maxOf(frameSize, 4096)
+    val pushbackStream = java.io.PushbackInputStream(pcmStream, probeSize)
+    val probe = ByteArray(probeSize)
+    val bytesRead = pushbackStream.read(probe)
+    if (bytesRead > 0) {
+        pushbackStream.unread(probe, 0, bytesRead)
+    }
+    return AudioInputStream(pushbackStream, pcmStream.format, pcmStream.frameLength)
+}
+
+internal fun loadAudioFileReaders(): List<AudioFileReader> = ServiceLoader.load(AudioFileReader::class.java).toList()
+
+internal fun prioritizeAudioFileReaders(file: File, readers: List<AudioFileReader>): List<AudioFileReader> =
+    readers.sortedWith(compareBy<AudioFileReader> { readerPriority(file, it.javaClass.name) }.thenBy { it.javaClass.name })
+
+internal fun readerPriority(file: File, readerClassName: String): Int {
+    val extension = file.extension.lowercase()
+    val className = readerClassName.lowercase()
+    val preferredTokens =
+        when (extension) {
+            "mp3" -> listOf("mpeg", "mp3")
+            "m4a", "mp4", "aac" -> listOf("aac", "mp4")
+            "flac" -> listOf("flac")
+            "ogg", "oga", "opus" -> listOf("vorbis", "ogg", "opus")
+            "wav", "wave" -> listOf("wav", "wave")
+            else -> emptyList()
+        }
+
+    val preferredIndex = preferredTokens.indexOfFirst { className.contains(it) }
+    return if (preferredIndex >= 0) preferredIndex else preferredTokens.size
+}
+
+private fun closeQuietly(stream: AudioInputStream?) = runCatching { stream?.close() }
+
+private data class ReaderAttempt(val stream: AudioInputStream?, val failure: Throwable?)

--- a/music-commons-media/src/main/kotlin/net/transgressoft/commons/media/waveform/ScalableAudioWaveform.kt
+++ b/music-commons-media/src/main/kotlin/net/transgressoft/commons/media/waveform/ScalableAudioWaveform.kt
@@ -31,7 +31,6 @@ import javax.imageio.ImageIO
 import kotlin.io.path.exists
 import kotlin.io.path.extension
 import kotlin.math.abs
-import kotlin.math.pow
 import kotlin.math.roundToInt
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.sync.Mutex
@@ -58,15 +57,6 @@ class ScalableAudioWaveform(
     override val id: Int,
     override val audioFilePath: Path
 ) : ReactiveEntityBase<Int, AudioWaveform>(), AudioWaveform {
-
-    /*
-        This constant is used to scale the amplitude height of the waveform
-        For the waveform to be properly visible, the amplitude must be between 3.8 and 4.4
-        Below 3.8, the waveform is too big and touches the limits of the canvas
-        Above 4.2, the waveform can be too small and is not visible
-        This anyway depends on each waveform, but this value is the one I found more balanced
-     */
-    @Transient private val amplitudeCoefficient = 3.9
 
     @Transient private val cacheMutex = Mutex()
 
@@ -142,8 +132,7 @@ class ScalableAudioWaveform(
 
     /**
      * Computes width-normalized amplitude values from the raw PCM data, without applying
-     * a height factor. The returned values use [amplitudeCoefficient] as the divisor exponent
-     * and average samples per pixel. Height scaling is deferred to the [amplitudes] caller,
+     * a height factor. Height scaling is deferred to the [amplitudes] caller,
      * allowing the same normalized array to be reused across different height requests.
      *
      * Lazily memoizes [rawAudioPcm] on first invocation to avoid redundant audio file reads.
@@ -151,7 +140,7 @@ class ScalableAudioWaveform(
     private fun computeNormalized(width: Int): FloatArray {
         val pcm = rawAudioPcm ?: getRawAudioPcm(audioFilePath).also { rawAudioPcm = it }
         if (pcm.isEmpty()) return FloatArray(width) { 0f }
-        val divisor = 32767.0f * 2.0.pow(amplitudeCoefficient).toFloat()
+        val divisor = 32767.0f
         return FloatArray(width) { w ->
             val start = (w.toLong() * pcm.size / width).toInt()
             val endExclusive =

--- a/music-commons-media/src/test/kotlin/net/transgressoft/commons/media/player/CoreAudioItemPlayerUnitTest.kt
+++ b/music-commons-media/src/test/kotlin/net/transgressoft/commons/media/player/CoreAudioItemPlayerUnitTest.kt
@@ -23,9 +23,12 @@ import net.transgressoft.commons.music.player.UnsupportedAudioPlaybackException
 import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.comparables.shouldBeGreaterThan
+import io.kotest.matchers.comparables.shouldBeLessThan
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
+import java.io.ByteArrayInputStream
 import java.io.File
 import java.lang.reflect.Field
 import java.nio.file.Files
@@ -284,6 +287,76 @@ internal class CoreAudioItemPlayerUnitTest : StringSpec({
             durationMillis.invoke(player, metadataDuration) shouldBe 1_234L
             durationMillis.invoke(player, frameDuration) shouldBe 2_000L
             durationMillis.invoke(player, unknownDuration) shouldBe 0L
+        } finally {
+            player.dispose()
+        }
+    }
+
+    "resolveSourceDurationMillis scans containerized mp3 when the reader misidentifies the file" {
+        val decodeCount = AtomicInteger()
+        val stereoFormat = AudioFormat(44_100f, 16, 2, true, false)
+        val player =
+            CoreAudioItemPlayer(
+                pcmStreamFactory = {
+                    decodeCount.incrementAndGet()
+                    AudioInputStream(
+                        ByteArrayInputStream(ByteArray(5_299_200)),
+                        stereoFormat,
+                        5_299_200L / stereoFormat.frameSize.toLong()
+                    )
+                },
+                lineFactory = { fakeLine() },
+                nanoTime = { 0L },
+                stallThresholdNanos = Long.MAX_VALUE
+            )
+        val resolveSourceDurationMillis =
+            CoreAudioItemPlayer::class.java.getDeclaredMethod("resolveSourceDurationMillis", File::class.java, AudioFileFormat::class.java).apply {
+                isAccessible = true
+            }
+        val mp3Type = object : AudioFileFormat.Type("MP3", "mp3") {}
+        val suspiciousFormat =
+            AudioFileFormat(
+                mp3Type,
+                PCM_FORMAT,
+                692,
+                mapOf("duration" to 18_077_000L)
+            )
+
+        try {
+            val duration =
+                resolveSourceDurationMillis.invoke(player, File("track.m4a"), suspiciousFormat) as Long
+
+            duration shouldBeGreaterThan 29_000L
+            duration shouldBeLessThan 31_000L
+            decodeCount.get() shouldBe 1
+        } finally {
+            player.dispose()
+        }
+    }
+
+    "openStreamSession refreshes totalDuration from the decoded PCM stream" {
+        val player =
+            CoreAudioItemPlayer(
+                pcmStreamFactory = {
+                    streamOf(ByteArray(88_200))
+                },
+                lineFactory = { fakeLine() },
+                nanoTime = { 0L },
+                stallThresholdNanos = Long.MAX_VALUE
+            )
+        val openStreamSession =
+            CoreAudioItemPlayer::class.java.getDeclaredMethod("openStreamSession", File::class.java, Long::class.javaPrimitiveType).apply {
+                isAccessible = true
+            }
+
+        try {
+            val session = openStreamSession.invoke(player, File("unused.m4a"), 0L) as Any
+            val stream = session.javaClass.getDeclaredMethod("getStream").apply { isAccessible = true }.invoke(session) as AudioInputStream
+            try {
+                player.totalDuration shouldBe Duration.ofSeconds(1)
+            } finally {
+                stream.close()
+            }
         } finally {
             player.dispose()
         }

--- a/music-commons-media/src/test/kotlin/net/transgressoft/commons/media/util/AudioDecoderUtilRegressionTest.kt
+++ b/music-commons-media/src/test/kotlin/net/transgressoft/commons/media/util/AudioDecoderUtilRegressionTest.kt
@@ -1,10 +1,26 @@
 package net.transgressoft.commons.media.util
 
+import net.transgressoft.commons.music.player.UnsupportedAudioPlaybackException
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.ints.shouldBeGreaterThan
+import io.kotest.matchers.ints.shouldBeLessThan
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import java.io.ByteArrayInputStream
+import java.io.File
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
+import javax.sound.sampled.AudioFormat
+import javax.sound.sampled.AudioInputStream
+import javax.sound.sampled.AudioSystem
+import javax.sound.sampled.spi.AudioFileReader
+
+private val PCM_FORMAT = AudioFormat(44_100f, 16, 1, true, false)
 
 internal class AudioDecoderUtilRegressionTest : StringSpec({
 
@@ -18,6 +34,16 @@ internal class AudioDecoderUtilRegressionTest : StringSpec({
             temp
         }
     }
+
+    fun pcmStreamOf(vararg bytes: Byte): AudioInputStream =
+        AudioInputStream(ByteArrayInputStream(bytes), PCM_FORMAT, bytes.size.toLong() / PCM_FORMAT.frameSize.toLong())
+
+    fun crashingStream(): AudioInputStream =
+        object : AudioInputStream(ByteArrayInputStream(ByteArray(0)), PCM_FORMAT, AudioSystem.NOT_SPECIFIED.toLong()) {
+            override fun read(b: ByteArray, off: Int, len: Int): Int = throw NegativeArraySizeException("bad decode")
+
+            override fun read(): Int = throw NegativeArraySizeException("bad decode")
+        }
 
     "AAC M4A decodes to valid PCM with correct endianness and known sample size" {
         val temp = resourceToTemp("testeable_aac.m4a")
@@ -115,6 +141,74 @@ internal class AudioDecoderUtilRegressionTest : StringSpec({
         } finally {
             Files.deleteIfExists(temp)
         }
+    }
+
+    "decodeToPcmStream skips a crashing provider and uses the next SPI reader" {
+        val crashingReader =
+            mockk<AudioFileReader>(relaxed = true) {
+                every { getAudioInputStream(any<File>()) } returns crashingStream()
+            }
+        val successReader =
+            mockk<AudioFileReader>(relaxed = true) {
+                every { getAudioInputStream(any<File>()) } returns pcmStreamOf(0x00, 0x40, 0x00, 0xC0.toByte(), 0x00, 0x20, 0x00, 0xE0.toByte())
+            }
+
+        mockkStatic("net.transgressoft.commons.media.util.AudioDecoderUtilKt")
+        every { loadAudioFileReaders() } returns listOf(crashingReader, successReader)
+
+        val temp = Files.createTempFile("audio_", ".mp3")
+        try {
+            val decoded = decodeToPcmStream(temp)
+            val buffer = ByteArray(8)
+            val bytesRead = decoded.read(buffer)
+
+            decoded.format shouldBe PCM_FORMAT
+            bytesRead shouldBeGreaterThan 0
+        } finally {
+            Files.deleteIfExists(temp)
+            unmockkStatic("net.transgressoft.commons.media.util.AudioDecoderUtilKt")
+        }
+    }
+
+    "decodeToPcmStream reports unsupported playback when every provider fails" {
+        val crashingReader1 =
+            mockk<AudioFileReader>(relaxed = true) {
+                every { getAudioInputStream(any<File>()) } returns crashingStream()
+            }
+        val crashingReader2 =
+            mockk<AudioFileReader>(relaxed = true) {
+                every { getAudioInputStream(any<File>()) } returns crashingStream()
+            }
+
+        mockkStatic("net.transgressoft.commons.media.util.AudioDecoderUtilKt")
+        every { loadAudioFileReaders() } returns listOf(crashingReader1, crashingReader2)
+
+        val temp = Files.createTempFile("audio_", ".mp3")
+        try {
+            val error =
+                shouldThrow<UnsupportedAudioPlaybackException> {
+                    decodeToPcmStream(temp)
+                }
+
+            error.message shouldContain "tried 2 providers"
+        } finally {
+            Files.deleteIfExists(temp)
+            unmockkStatic("net.transgressoft.commons.media.util.AudioDecoderUtilKt")
+        }
+    }
+
+    "readerPriority prefers mp3spi over JAAD for mp3 files" {
+        val mp3spiClass = "javazoom.spi.mpeg.sampled.file.MpegAudioFileReader"
+        val jaadClass = "net.sourceforge.jaad.spi.javasound.AACAudioFileReader"
+
+        readerPriority(File("track.mp3"), mp3spiClass) shouldBeLessThan readerPriority(File("track.mp3"), jaadClass)
+    }
+
+    "readerPriority prefers JAAD over mp3spi for m4a files" {
+        val mp3spiClass = "javazoom.spi.mpeg.sampled.file.MpegAudioFileReader"
+        val jaadClass = "net.sourceforge.jaad.spi.javasound.AACAudioFileReader"
+
+        readerPriority(File("track.m4a"), jaadClass) shouldBeLessThan readerPriority(File("track.m4a"), mp3spiClass)
     }
 
     "FLAC converts to PCM with known sample size" {

--- a/music-commons-media/src/test/kotlin/net/transgressoft/commons/media/util/AudioDecoderUtilRegressionTest.kt
+++ b/music-commons-media/src/test/kotlin/net/transgressoft/commons/media/util/AudioDecoderUtilRegressionTest.kt
@@ -45,6 +45,14 @@ internal class AudioDecoderUtilRegressionTest : StringSpec({
             override fun read(): Int = throw NegativeArraySizeException("bad decode")
         }
 
+    fun validateReadablePcmStream(stream: AudioInputStream): AudioInputStream {
+        val method =
+            Class.forName("net.transgressoft.commons.media.util.AudioDecoderUtilKt")
+                .getDeclaredMethod("validateReadablePcmStream", AudioInputStream::class.java)
+                .apply { isAccessible = true }
+        return method.invoke(null, stream) as AudioInputStream
+    }
+
     "AAC M4A decodes to valid PCM with correct endianness and known sample size" {
         val temp = resourceToTemp("testeable_aac.m4a")
         try {
@@ -141,6 +149,15 @@ internal class AudioDecoderUtilRegressionTest : StringSpec({
         } finally {
             Files.deleteIfExists(temp)
         }
+    }
+
+    "validateReadablePcmStream preserves the decoded frame length" {
+        val stream = AudioInputStream(ByteArrayInputStream(ByteArray(8_820)), PCM_FORMAT, 4_410)
+
+        val wrapped = validateReadablePcmStream(stream)
+
+        wrapped.frameLength shouldBe 4_410
+        wrapped.close()
     }
 
     "decodeToPcmStream skips a crashing provider and uses the next SPI reader" {


### PR DESCRIPTION
Closes #119

Summary:
- Preserve decoded PCM frame length so playback progress uses the actual track duration when available.
- Fall back to a PCM-duration scan for containerized AAC/MP3 variants that are misidentified by the chosen SPI reader.
- Keep JavaSound SPI decode selection resilient and refactor the decoder path into smaller helpers.

Verification:
- `gradle :music-commons-media:test :music-commons-media:ktlintCheck`
- `gradle :music-commons-media:test :music-commons-media:ktlintCheck :music-commons-fx:test`