### PR TITLE
#122 Fix playback seek regressions and M4A fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ Music Commons is free software under GNU GPL version 3 license, available [here]
 This project builds upon several excellent open-source libraries:
 
 - **[JAudioTagger](https://github.com/ericfarng/jaudiotagger)**: Audio metadata reading and writing library
-- **JavaSound SPI providers** ([mp3spi](https://github.com/umjammer/mp3spi), [javasound-flac](https://github.com/Tianscar/javasound-flac), [javasound-vorbis](https://github.com/Tianscar/javasound-vorbis), [javasound-aac](https://github.com/Tianscar/javasound-aac), [JAAD](https://github.com/Almax/jaad)): pure-Java audio decoders for MP3, FLAC, OGG Vorbis, and AAC/M4A; playback progress and seek ratios use the decoded PCM stream duration when available
+- **JavaSound SPI providers** ([mp3spi](https://github.com/umjammer/mp3spi), [javasound-flac](https://github.com/Tianscar/javasound-flac), [javasound-vorbis](https://github.com/Tianscar/javasound-vorbis), [javasound-aac](https://github.com/Tianscar/javasound-aac), [JAAD](https://github.com/Almax/jaad)): pure-Java audio decoders for MP3, FLAC, OGG Vorbis, and AAC/M4A; metadata and decoding use prioritized provider fallback, native FLAC seeks use the decoder's random-access path, generic compressed seeks discard decoded PCM to stay decoder-aligned, and playback volume scales signed PCM sample widths up to 32-bit
 - **[Kotlin Coroutines](https://github.com/Kotlin/kotlinx.coroutines)**: Library support for Kotlin coroutines
 - **[kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization)**: Kotlin multiplatform serialization
 - **[lirp](https://github.com/octaviospain/lirp)**: Reactive entity framework and persistence infrastructure

--- a/music-commons-fx/README.md
+++ b/music-commons-fx/README.md
@@ -84,6 +84,8 @@ audioLibrary.playerSubscriber.addOnNextEventAction(PLAYED) { event ->
 }
 ```
 
+`FXAudioItemPlayer` mirrors `CoreAudioItemPlayer`'s playback position immediately after a seek request, so UI bindings can update the playhead before the decoder finishes repositioning. Native FLAC seeks use the decoder's random-access path, generic compressed seeks discard decoded PCM to remain decoder-aligned, and volume control applies to signed PCM streams up to 32-bit.
+
 ### Waveform Visualization
 
 ```kotlin

--- a/music-commons-fx/src/test/kotlin/net/transgressoft/commons/fx/music/waveform/PlayableWaveformPaneDemo.kt
+++ b/music-commons-fx/src/test/kotlin/net/transgressoft/commons/fx/music/waveform/PlayableWaveformPaneDemo.kt
@@ -44,7 +44,7 @@ class PlayableWaveformPaneDemo : Application() {
     override fun start(primaryStage: Stage) {
         playableWaveformPane = PlayableWaveformPane()
         val borderPane = BorderPane(playableWaveformPane)
-        borderPane.setPrefSize(700.0, 300.0)
+        borderPane.setPrefSize(900.0, 300.0)
 
         statusLabel = Label("Select a fixture to load")
 

--- a/music-commons-media/src/main/kotlin/net/transgressoft/commons/media/player/CoreAudioItemPlayer.kt
+++ b/music-commons-media/src/main/kotlin/net/transgressoft/commons/media/player/CoreAudioItemPlayer.kt
@@ -18,6 +18,7 @@
 package net.transgressoft.commons.media.player
 
 import net.transgressoft.commons.media.util.decodeToPcmStream
+import net.transgressoft.commons.media.util.readAudioFileFormat
 import net.transgressoft.commons.music.audio.ReactiveAudioItem
 import net.transgressoft.commons.music.player.AudioItemPlayer
 import net.transgressoft.commons.music.player.AudioItemPlayer.Status
@@ -28,8 +29,6 @@ import net.transgressoft.lirp.event.FlowEventPublisher
 import net.transgressoft.lirp.event.LirpEventPublisher
 import mu.KotlinLogging
 import java.io.File
-import java.nio.ByteBuffer
-import java.nio.ByteOrder
 import java.nio.file.Path
 import java.time.Duration
 import java.util.concurrent.atomic.AtomicLong
@@ -102,6 +101,7 @@ open class CoreAudioItemPlayer private constructor(
     private val lineRef = AtomicReference<SourceDataLine?>(null)
     private val currentAudioItem = AtomicReference<ReactiveAudioItem<*>?>(null)
     private val pumpThread = AtomicReference<Thread?>(null)
+    private val durationProbeThread = AtomicReference<Thread?>(null)
     private val onFinishCallback = AtomicReference<Runnable?>(null)
     private val internalStatus = AtomicReference(Status.UNKNOWN)
     private val pcmFormat = AtomicReference<AudioFormat?>(null)
@@ -118,6 +118,9 @@ open class CoreAudioItemPlayer private constructor(
 
     @Volatile
     private var framePosition: Long = 0L
+
+    @Volatile
+    private var seekPreviewMillis: Long = -1L
 
     private val seekTargetMillis = AtomicLong(-1L)
 
@@ -139,6 +142,11 @@ open class CoreAudioItemPlayer private constructor(
     override fun status(): Status = internalStatus.get()
 
     override fun getCurrentTime(): Duration {
+        val pendingSeekMillis = seekPreviewMillis
+        if (pendingSeekMillis >= 0L && (state.get() == InternalState.PLAYING || state.get() == InternalState.PAUSED)) {
+            return Duration.ofMillis(pendingSeekMillis)
+        }
+
         val line = lineRef.get()
         val fs = frameSize.toLong()
         val rate = frameRate
@@ -162,22 +170,27 @@ open class CoreAudioItemPlayer private constructor(
         if (!file.exists() || file.isDirectory) {
             throw UnsupportedAudioPlaybackException("Cannot play audio item '${audioItem.path.fileName}': file not found")
         }
-        val audioFileFormat =
-            try {
-                AudioSystem.getAudioFileFormat(file)
-            } catch (e: Exception) {
-                throw UnsupportedAudioPlaybackException("Cannot play audio item '${audioItem.path.fileName}': unsupported format", e)
-            }
         stopCurrentPlayback()
         seekTargetMillis.set(-1L)
+        seekPreviewMillis = -1L
         framePosition = 0L
-        sourceDurationMillis = resolveSourceDurationMillis(file, audioFileFormat)
+        val audioFileFormat = runCatching { readAudioFileFormat(file.toPath()) }.getOrNull()
+        sourceDurationMillis =
+            if (audioFileFormat != null) {
+                durationMillis(audioFileFormat)
+            } else {
+                ensurePlayableByOpeningStream(file, audioItem)
+                0L
+            }
         currentAudioItem.set(audioItem)
         val mySession = sessionId.incrementAndGet()
         activeSessionId.set(mySession)
         internalStatus.set(Status.PLAYING)
         pumpThread.set(createPumpThread(audioItem, mySession))
         pumpThread.get()?.start()
+        if (audioFileFormat == null || requiresDecodedDurationProbe(file, audioFileFormat)) {
+            launchDecodedDurationProbe(file, audioItem, mySession)
+        }
     }
 
     override fun pause() {
@@ -204,6 +217,7 @@ open class CoreAudioItemPlayer private constructor(
         framePosition = 0L
         lineStartFrameOffset = 0L
         seekTargetMillis.set(-1L)
+        seekPreviewMillis = -1L
         internalStatus.set(Status.STOPPED)
     }
 
@@ -212,6 +226,7 @@ open class CoreAudioItemPlayer private constructor(
         stopCurrentPlayback()
         pcmFormat.set(null)
         sourceDurationMillis = 0L
+        seekPreviewMillis = -1L
         state.set(InternalState.DISPOSED)
         internalStatus.set(Status.DISPOSED)
         onFinishCallback.set(null)
@@ -224,7 +239,18 @@ open class CoreAudioItemPlayer private constructor(
 
     override fun seek(position: Duration) {
         if (state.get() == InternalState.DISPOSED) return
-        seekTargetMillis.set(position.toMillis())
+        val requestedMillis = position.toMillis().coerceAtLeast(0L)
+        val targetMillis =
+            if (sourceDurationMillis > 0L) {
+                requestedMillis.coerceAtMost(sourceDurationMillis)
+            } else {
+                requestedMillis
+            }
+        seekTargetMillis.set(targetMillis)
+        if (state.get() == InternalState.PLAYING || state.get() == InternalState.PAUSED) {
+            seekPreviewMillis = targetMillis
+            lineRef.get()?.flush()
+        }
     }
 
     override fun onFinish(value: Runnable) {
@@ -236,6 +262,7 @@ open class CoreAudioItemPlayer private constructor(
         state.set(InternalState.STOPPED)
         val thread = pumpThread.getAndSet(null)
         thread?.interrupt()
+        durationProbeThread.getAndSet(null)?.interrupt()
         drainAndClose()
     }
 
@@ -303,6 +330,7 @@ open class CoreAudioItemPlayer private constructor(
         var session = openStreamSession(file, framePosition)
         var line = openLine(session.format)
         val buffer = ByteArray(TRANSFER_BUFFER_SIZE)
+        var clearSeekPreviewAfterWrite = false
 
         try {
             while (true) {
@@ -320,6 +348,7 @@ open class CoreAudioItemPlayer private constructor(
                     val targetOffset = millisToByteOffset(seekTarget, session.format)
                     session = openStreamSession(file, targetOffset)
                     line = openLine(session.format)
+                    clearSeekPreviewAfterWrite = true
                 }
 
                 val readStartedAt = nanoTime()
@@ -331,6 +360,10 @@ open class CoreAudioItemPlayer private constructor(
                 updateStallStatus(readDuration)
                 applyVolume(buffer, bytesRead, session.format)
                 framePosition += line.write(buffer, 0, bytesRead)
+                if (clearSeekPreviewAfterWrite) {
+                    seekPreviewMillis = -1L
+                    clearSeekPreviewAfterWrite = false
+                }
             }
         } finally {
             session.stream.close()
@@ -339,13 +372,18 @@ open class CoreAudioItemPlayer private constructor(
     }
 
     private fun openStreamSession(file: File, requestedOffset: Long): StreamSession {
+        val seekableFlacStream = SeekableFlacPcmStreams.open(file, requestedOffset)
+        if (seekableFlacStream != null) {
+            val stream = seekableFlacStream.stream
+            val format = stream.format
+            pcmFormat.set(format)
+            framePosition = seekableFlacStream.startByteOffset.alignDown(format.frameSize.toLong())
+            return StreamSession(stream, format)
+        }
+
         val stream = pcmStreamFactory(file.toPath())
         val format = stream.format
         pcmFormat.set(format)
-        val streamDurationMillis = durationMillis(stream)
-        if (streamDurationMillis > 0L) {
-            sourceDurationMillis = streamDurationMillis
-        }
         val alignedOffset = requestedOffset.coerceAtLeast(0L).alignDown(format.frameSize.toLong())
         val skipped = skipFully(stream, alignedOffset)
         framePosition = skipped.alignDown(format.frameSize.toLong())
@@ -361,9 +399,8 @@ open class CoreAudioItemPlayer private constructor(
         while (remaining > 0L) {
             val currentState = state.get()
             if (currentState == InternalState.STOPPED || currentState == InternalState.DISPOSED) break
-            val step = minOf(remaining, discard.size.toLong()).toInt()
-            val bytesRead = stream.read(discard, 0, step)
-            if (bytesRead < 0) break
+            val bytesRead = stream.read(discard, 0, minOf(remaining, discard.size.toLong()).toInt())
+            if (bytesRead <= 0) break
             skipped += bytesRead
             remaining -= bytesRead
         }
@@ -399,28 +436,72 @@ open class CoreAudioItemPlayer private constructor(
             buffer.fill(0, 0, chunk)
             return
         }
-        when (format.sampleSizeInBits) {
-            16 -> {
-                val byteOrder = if (format.isBigEndian) ByteOrder.BIG_ENDIAN else ByteOrder.LITTLE_ENDIAN
-                val bb = ByteBuffer.wrap(buffer, 0, chunk).order(byteOrder)
-                val sb = bb.asShortBuffer()
-                for (j in 0 until sb.remaining()) {
-                    val sample = sb[j]
-                    val scaled = (sample * gain).toInt().coerceIn(Short.MIN_VALUE.toInt(), Short.MAX_VALUE.toInt()).toShort()
-                    sb.put(j, scaled)
-                }
+        val sampleSizeInBits = format.sampleSizeInBits
+        if (sampleSizeInBits <= 0 || sampleSizeInBits % 8 != 0) {
+            logger.debug {
+                "Volume control skipped: sample size ${format.sampleSizeInBits}-bit not supported (requires byte-aligned PCM)"
             }
-            8 -> {
+            return
+        }
+
+        when (val bytesPerSample = sampleSizeInBits / 8) {
+            1 if format.encoding == AudioFormat.Encoding.PCM_UNSIGNED -> {
                 for (i in 0 until chunk) {
                     val signed = (buffer[i].toInt() and 0xFF) - 128
                     val scaled = (signed * gain).toInt().coerceIn(-128, 127)
                     buffer[i] = (scaled + 128).toByte()
                 }
             }
-            else ->
+            in 1..4 -> scaleSignedSamples(buffer, chunk, bytesPerSample, gain, format.isBigEndian)
+            else -> {
                 logger.debug {
-                    "Volume control skipped: sample size ${format.sampleSizeInBits}-bit not supported (only 8/16-bit)"
+                    "Volume control skipped: sample size ${format.sampleSizeInBits}-bit not supported (requires 8/16/24/32-bit PCM)"
                 }
+            }
+        }
+    }
+
+    private fun scaleSignedSamples(buffer: ByteArray, chunk: Int, bytesPerSample: Int, gain: Float, bigEndian: Boolean) {
+        val limit = chunk - chunk % bytesPerSample
+        val minValue = -(1L shl (bytesPerSample * 8 - 1))
+        val maxValue = (1L shl (bytesPerSample * 8 - 1)) - 1L
+        for (offset in 0 until limit step bytesPerSample) {
+            val sample = readSignedSample(buffer, offset, bytesPerSample, bigEndian)
+            val scaled = (sample * gain).toLong().coerceIn(minValue, maxValue)
+            writeSignedSample(buffer, offset, bytesPerSample, scaled, bigEndian)
+        }
+    }
+
+    private fun readSignedSample(buffer: ByteArray, offset: Int, bytesPerSample: Int, bigEndian: Boolean): Long {
+        var value = 0L
+        if (bigEndian) {
+            for (i in 0 until bytesPerSample) {
+                value = (value shl 8) or (buffer[offset + i].toLong() and 0xFF)
+            }
+        } else {
+            for (i in bytesPerSample - 1 downTo 0) {
+                value = (value shl 8) or (buffer[offset + i].toLong() and 0xFF)
+            }
+        }
+
+        val bits = bytesPerSample * 8
+        val signBit = 1L shl (bits - 1)
+        val extensionMask = (-1L) shl bits
+        return if (value and signBit != 0L) value or extensionMask else value
+    }
+
+    private fun writeSignedSample(buffer: ByteArray, offset: Int, bytesPerSample: Int, sample: Long, bigEndian: Boolean) {
+        var value = sample
+        if (bigEndian) {
+            for (i in bytesPerSample - 1 downTo 0) {
+                buffer[offset + i] = (value and 0xFF).toByte()
+                value = value shr 8
+            }
+        } else {
+            for (i in 0 until bytesPerSample) {
+                buffer[offset + i] = (value and 0xFF).toByte()
+                value = value shr 8
+            }
         }
     }
 
@@ -429,6 +510,7 @@ open class CoreAudioItemPlayer private constructor(
         // Stale pump (a newer play() has already started): do not mutate shared state
         // or fire callbacks that belong to the newly started playback.
         if (activeSessionId.get() != mySession) return
+        seekPreviewMillis = -1L
         val item = if (wasNaturalEnd) currentAudioItem.getAndSet(null) else null
         if (item != null) {
             publisher.emitAsync(Played(item))
@@ -488,6 +570,60 @@ open class CoreAudioItemPlayer private constructor(
         return audioFileFormat.type.extension.equals("mp3", ignoreCase = true)
     }
 
+    private fun resolvePlayableDurationMillis(file: File, audioItem: ReactiveAudioItem<*>): Long {
+        val audioFileFormat =
+            try {
+                readAudioFileFormat(file.toPath())
+            } catch (formatFailure: Exception) {
+                return resolveDurationFromDecodedPcmOrThrow(file, audioItem, formatFailure)
+            }
+        return resolveSourceDurationMillis(file, audioFileFormat)
+    }
+
+    private fun launchDecodedDurationProbe(file: File, audioItem: ReactiveAudioItem<*>, session: Long) {
+        val probeThread =
+            Thread(
+                {
+                    val resolvedDuration =
+                        runCatching { resolvePlayableDurationMillis(file, audioItem) }
+                            .onFailure {
+                                logger.debug(it) { "Decoded-duration probe failed for '${file.name}' after playback started" }
+                            }
+                            .getOrNull()
+                    if (
+                        resolvedDuration != null &&
+                        resolvedDuration > 0L &&
+                        activeSessionId.get() == session &&
+                        state.get() != InternalState.DISPOSED
+                    ) {
+                        sourceDurationMillis = resolvedDuration
+                    }
+                },
+                "CoreAudioPlayer-duration-probe"
+            ).apply {
+                isDaemon = true
+            }
+        durationProbeThread.set(probeThread)
+        probeThread.start()
+    }
+
+    private fun ensurePlayableByOpeningStream(file: File, audioItem: ReactiveAudioItem<*>) {
+        try {
+            pcmStreamFactory(file.toPath()).use { }
+        } catch (failure: Exception) {
+            throw UnsupportedAudioPlaybackException("Cannot play audio item '${audioItem.path.fileName}': unsupported format", failure)
+        }
+    }
+
+    private fun resolveDurationFromDecodedPcmOrThrow(file: File, audioItem: ReactiveAudioItem<*>, formatFailure: Exception): Long =
+        try {
+            durationMillisFromPcmStream(file)
+        } catch (decodeFailure: Exception) {
+            throw UnsupportedAudioPlaybackException("Cannot play audio item '${audioItem.path.fileName}': unsupported format", decodeFailure).apply {
+                addSuppressed(formatFailure)
+            }
+        }
+
     private fun durationMillisFromPcmStream(file: File): Long {
         val stream = pcmStreamFactory(file.toPath())
         return stream.use { stream ->
@@ -500,7 +636,7 @@ open class CoreAudioItemPlayer private constructor(
             var totalBytes = 0L
             while (true) {
                 val bytesRead = stream.read(buffer)
-                if (bytesRead < 0) break
+                if (bytesRead <= 0) break
                 totalBytes += bytesRead
             }
             (totalBytes * 1000.0 / frameSize / frameRate).toLong()

--- a/music-commons-media/src/main/kotlin/net/transgressoft/commons/media/player/SeekableFlacPcmStreams.kt
+++ b/music-commons-media/src/main/kotlin/net/transgressoft/commons/media/player/SeekableFlacPcmStreams.kt
@@ -1,0 +1,213 @@
+/******************************************************************************
+ * Copyright (C) 2026  Octavio Calleya Garcia                                 *
+ *                                                                            *
+ * This program is free software: you can redistribute it and/or modify       *
+ * it under the terms of the GNU General Public License as published by       *
+ * the Free Software Foundation, either version 3 of the License, or          *
+ * (at your option) any later version.                                        *
+ *                                                                            *
+ * This program is distributed in the hope that it will be useful,            *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
+ * GNU General Public License for more details.                               *
+ *                                                                            *
+ * You should have received a copy of the GNU General Public License          *
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.     *
+ ******************************************************************************/
+
+package net.transgressoft.commons.media.player
+
+import org.kc7bfi.jflac.FLACDecoder
+import org.kc7bfi.jflac.PCMProcessor
+import org.kc7bfi.jflac.frame.Frame
+import org.kc7bfi.jflac.io.RandomFileInputStream
+import org.kc7bfi.jflac.metadata.StreamInfo
+import org.kc7bfi.jflac.util.ByteData
+import java.io.ByteArrayInputStream
+import java.io.File
+import java.io.IOException
+import java.io.InputStream
+import java.io.PipedInputStream
+import java.io.PipedOutputStream
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
+import javax.sound.sampled.AudioFormat
+import javax.sound.sampled.AudioInputStream
+
+/**
+ * Opens FLAC PCM streams at a requested decoded sample offset using jflac's random-access decoder.
+ */
+internal object SeekableFlacPcmStreams {
+
+    fun open(file: File, requestedByteOffset: Long): SeekableFlacPcmStream? {
+        if (!file.extension.equals("flac", ignoreCase = true) || requestedByteOffset <= 0L) return null
+
+        val input = RandomFileInputStream(file)
+        var handedOffToDecoderThread = false
+        try {
+            val decoder = FLACDecoder(input)
+            decoder.readMetadata()
+            val streamInfo = decoder.streamInfo ?: return null
+            val format = pcmFormat(streamInfo) ?: return null
+            val totalSamples = streamInfo.totalSamples
+            if (totalSamples <= 0L) return null
+
+            val targetFrame = requestedByteOffset / format.frameSize.toLong()
+            if (targetFrame >= totalSamples) {
+                val endOffset = totalSamples * format.frameSize.toLong()
+                return SeekableFlacPcmStream(
+                    AudioInputStream(ByteArrayInputStream(ByteArray(0)), format, 0L),
+                    endOffset
+                )
+            }
+
+            decoder.seek(targetFrame) ?: return null
+            val currentFrame = decoder.currentFrame()
+            val skipFrames = (targetFrame - currentFrame.header.sampleNumber).coerceAtLeast(0L)
+            val pipeInput = PipedInputStream(PIPE_BUFFER_SIZE)
+            val pipeOutput = PipedOutputStream(pipeInput)
+            val closed = AtomicBoolean(false)
+            val failure = AtomicReference<IOException?>(null)
+            val thread =
+                Thread(
+                    {
+                        decodeFromCurrentFrame(decoder, input, currentFrame, skipFrames, pipeOutput, closed, failure)
+                    },
+                    "CoreAudioPlayer-flac-seek"
+                ).apply {
+                    isDaemon = true
+                }
+            thread.start()
+            handedOffToDecoderThread = true
+
+            val streamInput = DecoderPipeInputStream(pipeInput, thread, closed, failure)
+            val remainingFrames = totalSamples - targetFrame
+            return SeekableFlacPcmStream(AudioInputStream(streamInput, format, remainingFrames), targetFrame * format.frameSize.toLong())
+        } finally {
+            if (!handedOffToDecoderThread) {
+                runCatching { input.close() }
+            }
+        }
+    }
+
+    private fun decodeFromCurrentFrame(
+        decoder: FLACDecoder,
+        input: RandomFileInputStream,
+        currentFrame: Frame,
+        skipFrames: Long,
+        pipeOutput: PipedOutputStream,
+        closed: AtomicBoolean,
+        failure: AtomicReference<IOException?>
+    ) {
+        try {
+            val processor = PipePcmProcessor(pipeOutput, decoder.streamInfo.channels * (decoder.streamInfo.bitsPerSample / 8), skipFrames)
+            var pcmData = decoder.decodeFrame(currentFrame, null)
+            processor.processPCM(pcmData)
+
+            while (!decoder.isEOF) {
+                val frame = decoder.readNextFrame() ?: break
+                pcmData = decoder.decodeFrame(frame, pcmData)
+                processor.processPCM(pcmData)
+            }
+        } catch (e: IOException) {
+            if (!closed.get()) {
+                failure.compareAndSet(null, e)
+            }
+        } finally {
+            runCatching { pipeOutput.close() }
+            runCatching { input.close() }
+        }
+    }
+
+    private fun FLACDecoder.currentFrame(): Frame =
+        DECODER_FRAME_FIELD.get(this) as Frame
+
+    private fun pcmFormat(streamInfo: StreamInfo): AudioFormat? {
+        val bits = streamInfo.bitsPerSample
+        if (bits !in setOf(8, 16, 24)) return null
+        val channels = streamInfo.channels
+        val sampleRate = streamInfo.sampleRate
+        if (channels <= 0 || sampleRate <= 0) return null
+
+        val bytesPerSample = bits / 8
+        val encoding = if (bits == 8) AudioFormat.Encoding.PCM_UNSIGNED else AudioFormat.Encoding.PCM_SIGNED
+        return AudioFormat(encoding, sampleRate.toFloat(), bits, channels, channels * bytesPerSample, sampleRate.toFloat(), false)
+    }
+
+    private const val PIPE_BUFFER_SIZE = 64 * 1024
+    private val DECODER_FRAME_FIELD =
+        FLACDecoder::class.java.getDeclaredField("frame").apply {
+            isAccessible = true
+        }
+}
+
+/**
+ * PCM stream and absolute decoded byte offset for a random-access FLAC seek.
+ */
+internal data class SeekableFlacPcmStream(
+    val stream: AudioInputStream,
+    val startByteOffset: Long
+)
+
+/**
+ * Writes decoded FLAC PCM frames into a pipe while dropping the leading samples before the seek target.
+ */
+private class PipePcmProcessor(
+    private val output: PipedOutputStream,
+    private val bytesPerFrame: Int,
+    skipFrames: Long
+) : PCMProcessor {
+
+    private var bytesToDrop = skipFrames * bytesPerFrame.toLong()
+
+    override fun processStreamInfo(streamInfo: StreamInfo) = Unit
+
+    override fun processPCM(pcm: ByteData) {
+        var offset = 0
+        var length = pcm.len
+        if (bytesToDrop > 0L) {
+            val dropped = minOf(bytesToDrop, length.toLong()).toInt()
+            offset += dropped
+            length -= dropped
+            bytesToDrop -= dropped
+        }
+        if (length > 0) {
+            output.write(pcm.data, offset, length)
+        }
+    }
+}
+
+/**
+ * Input stream wrapper that closes the decoder pipe and rethrows asynchronous decoder failures to the reader.
+ */
+private class DecoderPipeInputStream(
+    private val input: PipedInputStream,
+    private val decoderThread: Thread,
+    private val closed: AtomicBoolean,
+    private val failure: AtomicReference<IOException?>
+) : InputStream() {
+
+    override fun read(): Int {
+        val value = input.read()
+        throwFailureIfEof(value)
+        return value
+    }
+
+    override fun read(buffer: ByteArray, offset: Int, length: Int): Int {
+        val bytesRead = input.read(buffer, offset, length)
+        throwFailureIfEof(bytesRead)
+        return bytesRead
+    }
+
+    override fun close() {
+        closed.set(true)
+        runCatching { input.close() }
+        decoderThread.interrupt()
+    }
+
+    private fun throwFailureIfEof(bytesRead: Int) {
+        if (bytesRead < 0) {
+            failure.get()?.let { throw it }
+        }
+    }
+}

--- a/music-commons-media/src/main/kotlin/net/transgressoft/commons/media/util/AudioDecoderUtil.kt
+++ b/music-commons-media/src/main/kotlin/net/transgressoft/commons/media/util/AudioDecoderUtil.kt
@@ -22,6 +22,7 @@ import java.io.File
 import java.io.IOException
 import java.nio.file.Path
 import java.util.ServiceLoader
+import javax.sound.sampled.AudioFileFormat
 import javax.sound.sampled.AudioFormat
 import javax.sound.sampled.AudioInputStream
 import javax.sound.sampled.AudioSystem
@@ -54,6 +55,35 @@ fun decodeToPcmStream(path: Path): AudioInputStream {
     }
 
     return decodeWithReaders(file, readers)
+}
+
+/**
+ * Reads audio file metadata using the same prioritized and exception-safe provider order as [decodeToPcmStream].
+ */
+fun readAudioFileFormat(path: Path): AudioFileFormat {
+    val file = path.toFile()
+    val readers = prioritizeAudioFileReaders(file, loadAudioFileReaders())
+    if (readers.isEmpty()) {
+        throw UnsupportedAudioPlaybackException("No AudioFileReader providers registered for '${file.name}'")
+    }
+
+    var firstFailure: Throwable? = null
+    for (reader in readers) {
+        try {
+            return reader.getAudioFileFormat(file)
+        } catch (_: UnsupportedAudioFileException) {
+            // Try the next provider.
+        } catch (e: IOException) {
+            if (firstFailure == null) firstFailure = e
+        } catch (e: RuntimeException) {
+            if (firstFailure == null) firstFailure = e
+        }
+    }
+
+    throw UnsupportedAudioPlaybackException(
+        "Cannot read audio format for '${file.name}': unsupported format (tried ${readers.size} providers)",
+        firstFailure
+    )
 }
 
 private fun decodeWithReaders(file: File, readers: List<AudioFileReader>): AudioInputStream {

--- a/music-commons-media/src/test/kotlin/net/transgressoft/commons/media/player/CoreAudioItemPlayerUnitTest.kt
+++ b/music-commons-media/src/test/kotlin/net/transgressoft/commons/media/player/CoreAudioItemPlayerUnitTest.kt
@@ -17,9 +17,12 @@
 
 package net.transgressoft.commons.media.player
 
+import net.transgressoft.commons.media.util.decodeToPcmStream
+import net.transgressoft.commons.music.audio.ArbitraryAudioFile
 import net.transgressoft.commons.music.audio.ReactiveAudioItem
 import net.transgressoft.commons.music.player.AudioItemPlayer.Status
 import net.transgressoft.commons.music.player.UnsupportedAudioPlaybackException
+import io.kotest.assertions.nondeterministic.eventually
 import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
@@ -28,6 +31,8 @@ import io.kotest.matchers.comparables.shouldBeLessThan
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
 import java.io.ByteArrayInputStream
 import java.io.File
 import java.io.IOException
@@ -42,6 +47,7 @@ import javax.sound.sampled.AudioFileFormat
 import javax.sound.sampled.AudioFormat
 import javax.sound.sampled.AudioInputStream
 import javax.sound.sampled.SourceDataLine
+import kotlin.time.Duration.Companion.seconds
 
 private val PCM_FORMAT = AudioFormat(44_100f, 16, 1, true, false)
 
@@ -81,6 +87,30 @@ internal class CoreAudioItemPlayerUnitTest : StringSpec({
     fun streamOf(vararg chunks: ByteArray): AudioInputStream {
         val bytes = chunks.flatMap { it.toList() }.toByteArray()
         return AudioInputStream(bytes.inputStream(), PCM_FORMAT, bytes.size.toLong() / PCM_FORMAT.frameSize)
+    }
+
+    fun discardBytes(stream: AudioInputStream, bytes: Long): Long {
+        val buffer = ByteArray(4096)
+        var remaining = bytes
+        var skipped = 0L
+        while (remaining > 0L) {
+            val bytesRead = stream.read(buffer, 0, minOf(buffer.size.toLong(), remaining).toInt())
+            if (bytesRead <= 0) break
+            skipped += bytesRead
+            remaining -= bytesRead
+        }
+        return skipped
+    }
+
+    fun readBytes(stream: AudioInputStream, size: Int): ByteArray {
+        val buffer = ByteArray(size)
+        var offset = 0
+        while (offset < size) {
+            val bytesRead = stream.read(buffer, offset, size - offset)
+            if (bytesRead <= 0) break
+            offset += bytesRead
+        }
+        return buffer.copyOf(offset)
     }
 
     "initial status is UNKNOWN" {
@@ -368,11 +398,30 @@ internal class CoreAudioItemPlayerUnitTest : StringSpec({
         }
     }
 
-    "openStreamSession refreshes totalDuration from the decoded PCM stream" {
+    "resolvePlayableDurationMillis supports MP3 audio inside M4A when metadata providers fail" {
+        val player = CoreAudioItemPlayer()
+        val resolvePlayableDurationMillis =
+            CoreAudioItemPlayer::class.java
+                .getDeclaredMethod("resolvePlayableDurationMillis", File::class.java, ReactiveAudioItem::class.java)
+                .apply {
+                    isAccessible = true
+                }
+        val file = ArbitraryAudioFile.getResourceAsFile("/testfiles/testeable_mp3.m4a")
+
+        try {
+            val duration = resolvePlayableDurationMillis.invoke(player, file, audioItem(file.toPath())) as Long
+
+            duration shouldBeGreaterThan 0L
+        } finally {
+            player.dispose()
+        }
+    }
+
+    "openStreamSession preserves totalDuration resolved before playback" {
         val player =
             CoreAudioItemPlayer(
                 pcmStreamFactory = {
-                    streamOf(ByteArray(88_200))
+                    streamOf(ByteArray(8_820))
                 },
                 lineFactory = { fakeLine() },
                 nanoTime = { 0L },
@@ -382,14 +431,14 @@ internal class CoreAudioItemPlayerUnitTest : StringSpec({
             CoreAudioItemPlayer::class.java.getDeclaredMethod("openStreamSession", File::class.java, Long::class.javaPrimitiveType).apply {
                 isAccessible = true
             }
+        val sourceDurationMillis = field("sourceDurationMillis")
 
         try {
+            sourceDurationMillis.setLong(player, 30_000L)
             val session = openStreamSession.invoke(player, File("unused.m4a"), 0L) as Any
             val stream = session.javaClass.getDeclaredMethod("getStream").apply { isAccessible = true }.invoke(session) as AudioInputStream
-            try {
-                player.totalDuration shouldBe Duration.ofSeconds(1)
-            } finally {
-                stream.close()
+            stream.use {
+                player.totalDuration shouldBe Duration.ofSeconds(30)
             }
         } finally {
             player.dispose()
@@ -448,6 +497,95 @@ internal class CoreAudioItemPlayerUnitTest : StringSpec({
         }
     }
 
+    "skipFully uses read-discard instead of provider skip" {
+        val player = CoreAudioItemPlayer()
+        val skipFully =
+            CoreAudioItemPlayer::class.java.getDeclaredMethod("skipFully", AudioInputStream::class.java, Long::class.javaPrimitiveType).apply {
+                isAccessible = true
+            }
+        val skipCount = AtomicLong()
+        val readCount = AtomicLong()
+        val stream =
+            object : AudioInputStream(ByteArrayInputStream(ByteArray(8_192)), PCM_FORMAT, 2_048) {
+                override fun skip(n: Long): Long {
+                    skipCount.incrementAndGet()
+                    return n
+                }
+
+                override fun read(b: ByteArray, off: Int, len: Int): Int {
+                    readCount.incrementAndGet()
+                    return super.read(b, off, len)
+                }
+            }
+
+        try {
+            skipFully.invoke(player, stream, 4_096L) shouldBe 4_096L
+            skipCount.get() shouldBe 0L
+            readCount.get() shouldBe 1L
+        } finally {
+            player.dispose()
+        }
+    }
+
+    "skipFully remains safe when stream skip is unsupported" {
+        val player = CoreAudioItemPlayer()
+        val skipFully =
+            CoreAudioItemPlayer::class.java.getDeclaredMethod("skipFully", AudioInputStream::class.java, Long::class.javaPrimitiveType).apply {
+                isAccessible = true
+            }
+        val skipCount = AtomicLong()
+        val readCount = AtomicLong()
+        val stream =
+            object : AudioInputStream(ByteArrayInputStream(ByteArray(8_192)), PCM_FORMAT, 2_048) {
+                override fun skip(n: Long): Long {
+                    skipCount.incrementAndGet()
+                    throw IOException("skip not supported")
+                }
+
+                override fun read(b: ByteArray, off: Int, len: Int): Int {
+                    readCount.incrementAndGet()
+                    return super.read(b, off, len)
+                }
+            }
+
+        try {
+            skipFully.invoke(player, stream, 4_096L) shouldBe 4_096L
+            skipCount.get() shouldBe 0L
+            readCount.get() shouldBe 1L
+        } finally {
+            player.dispose()
+        }
+    }
+
+    "SeekableFlacPcmStreams opens FLAC at the requested decoded position" {
+        val file = ArbitraryAudioFile.getResourceAsFile("/testfiles/testeable.flac")
+        val baseline = decodeToPcmStream(file.toPath())
+        try {
+            val frameSize = baseline.format.frameSize
+            val totalFrames = baseline.frameLength.takeIf { it > 0 } ?: error("baseline FLAC stream did not expose frame length")
+            val targetFrame = totalFrames / 2
+            val targetOffset = targetFrame * frameSize
+
+            discardBytes(baseline, targetOffset) shouldBe targetOffset
+            val expected = readBytes(baseline, 8192)
+            val seeked = SeekableFlacPcmStreams.open(file, targetOffset)
+
+            seeked?.startByteOffset shouldBe targetOffset
+            val seekedStream = seeked?.stream ?: error("seekable FLAC stream was not created")
+            seekedStream.frameLength shouldBeGreaterThan 0L
+            seekedStream.frameLength shouldBeLessThan totalFrames
+            seekedStream.use { stream ->
+                stream.format.sampleRate shouldBe baseline.format.sampleRate
+                readBytes(stream, expected.size).toList() shouldBe expected.toList()
+            }
+            val eofSeek = SeekableFlacPcmStreams.open(file, Long.MAX_VALUE / 2) ?: error("EOF FLAC seek stream was not created")
+            eofSeek.startByteOffset shouldBeGreaterThan targetOffset
+            eofSeek.stream.frameLength shouldBe 0L
+        } finally {
+            baseline.close()
+        }
+    }
+
     "volume scaling handles muted, 16-bit, and 8-bit buffers" {
         val player = CoreAudioItemPlayer()
         val applyVolume =
@@ -460,7 +598,9 @@ internal class CoreAudioItemPlayerUnitTest : StringSpec({
         val muted = byteArrayOf(1, 2, 3, 4)
         val sixteenBit = byteArrayOf(0x00, 0x40, 0x00, 0xC0.toByte())
         val eightBit = byteArrayOf(0x00, 0xFF.toByte())
+        val twentyFourBit = byteArrayOf(0x00, 0x02, 0x00, 0x00, 0xFE.toByte(), 0xFF.toByte())
         val eightBitFormat = AudioFormat(44_100f, 8, 1, false, false)
+        val twentyFourBitFormat = AudioFormat(AudioFormat.Encoding.PCM_SIGNED, 44_100f, 24, 1, 3, 44_100f, false)
 
         try {
             volume.setDouble(player, 0.0)
@@ -469,12 +609,71 @@ internal class CoreAudioItemPlayerUnitTest : StringSpec({
 
             volume.setDouble(player, 0.5)
             applyVolume.invoke(player, sixteenBit, sixteenBit.size, PCM_FORMAT)
-            sixteenBit.toList() shouldBe listOf<Byte>(0x00, 0x20, 0x00, 0xE0.toByte())
+            sixteenBit.toList() shouldBe listOf(0x00, 0x20, 0x00, 0xE0.toByte())
 
             applyVolume.invoke(player, eightBit, eightBit.size, eightBitFormat)
-            eightBit.toList() shouldBe listOf<Byte>(0x40, 0xBF.toByte())
+            eightBit.toList() shouldBe listOf(0x40, 0xBF.toByte())
+
+            applyVolume.invoke(player, twentyFourBit, twentyFourBit.size, twentyFourBitFormat)
+            twentyFourBit.toList() shouldBe listOf(0x00, 0x01, 0x00, 0x00, 0xFF.toByte(), 0xFF.toByte())
         } finally {
             player.dispose()
+        }
+    }
+
+    "seek publishes the requested position immediately while playback is active" {
+        val player = CoreAudioItemPlayer()
+        val state = field("state").get(player) as AtomicReference<*>
+        val lineRef = field("lineRef").get(player) as AtomicReference<*>
+        val pcmFormatRef = field("pcmFormat").get(player) as AtomicReference<*>
+        @Suppress("UNCHECKED_CAST")
+        (state as AtomicReference<Any>).set(enumValue("PLAYING"))
+        @Suppress("UNCHECKED_CAST")
+        (lineRef as AtomicReference<SourceDataLine?>).set(
+            mockk(relaxed = true) {
+                every { isOpen } returns true
+                every { microsecondPosition } returns 0L
+            }
+        )
+        @Suppress("UNCHECKED_CAST")
+        (pcmFormatRef as AtomicReference<AudioFormat?>).set(PCM_FORMAT)
+
+        try {
+            player.seek(Duration.ofMillis(750))
+
+            player.getCurrentTime() shouldBe Duration.ofMillis(750)
+        } finally {
+            player.dispose()
+        }
+    }
+
+    "play falls back to decoded PCM duration when file-format providers fail" {
+        val decodeCount = AtomicInteger()
+        val player =
+            CoreAudioItemPlayer(
+                pcmStreamFactory = {
+                    decodeCount.incrementAndGet()
+                    streamOf(ByteArray(8_820))
+                },
+                lineFactory = { fakeLine() },
+                nanoTime = { 0L },
+                stallThresholdNanos = Long.MAX_VALUE
+            )
+        mockkStatic("net.transgressoft.commons.media.util.AudioDecoderUtilKt")
+        every { net.transgressoft.commons.media.util.readAudioFileFormat(any()) } throws IOException("bad provider")
+        val file = Files.createTempFile("format-fallback", ".m4a")
+
+        try {
+            shouldNotThrowAny { player.play(audioItem(file)) }
+
+            eventually(5.seconds) {
+                player.totalDuration shouldBe Duration.ofMillis(100)
+                decodeCount.get() shouldBeGreaterThan 1
+            }
+        } finally {
+            player.dispose()
+            Files.deleteIfExists(file)
+            unmockkStatic("net.transgressoft.commons.media.util.AudioDecoderUtilKt")
         }
     }
 

--- a/music-commons-media/src/test/kotlin/net/transgressoft/commons/media/util/AudioDecoderUtilRegressionTest.kt
+++ b/music-commons-media/src/test/kotlin/net/transgressoft/commons/media/util/AudioDecoderUtilRegressionTest.kt
@@ -17,9 +17,11 @@ import java.io.IOException
 import java.io.InputStream
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
+import javax.sound.sampled.AudioFileFormat
 import javax.sound.sampled.AudioFormat
 import javax.sound.sampled.AudioInputStream
 import javax.sound.sampled.AudioSystem
+import javax.sound.sampled.UnsupportedAudioFileException
 import javax.sound.sampled.spi.AudioFileReader
 
 private val PCM_FORMAT = AudioFormat(44_100f, 16, 1, true, false)
@@ -39,6 +41,9 @@ internal class AudioDecoderUtilRegressionTest : StringSpec({
 
     fun pcmStreamOf(vararg bytes: Byte): AudioInputStream =
         AudioInputStream(ByteArrayInputStream(bytes), PCM_FORMAT, bytes.size.toLong() / PCM_FORMAT.frameSize.toLong())
+
+    fun audioFileFormat(): AudioFileFormat =
+        AudioFileFormat(AudioFileFormat.Type.WAVE, PCM_FORMAT, 44_100)
 
     fun crashingStream(): AudioInputStream =
         object : AudioInputStream(ByteArrayInputStream(ByteArray(0)), PCM_FORMAT, AudioSystem.NOT_SPECIFIED.toLong()) {
@@ -245,6 +250,57 @@ internal class AudioDecoderUtilRegressionTest : StringSpec({
             val error =
                 shouldThrow<UnsupportedAudioPlaybackException> {
                     decodeToPcmStream(temp)
+                }
+
+            error.message shouldContain "tried 2 providers"
+        } finally {
+            Files.deleteIfExists(temp)
+            unmockkStatic("net.transgressoft.commons.media.util.AudioDecoderUtilKt")
+        }
+    }
+
+    "readAudioFileFormat skips a crashing provider and uses the next SPI reader" {
+        val crashingReader =
+            mockk<AudioFileReader>(relaxed = true) {
+                every { getAudioFileFormat(any<File>()) } throws NullPointerException("bad metadata")
+            }
+        val successReader =
+            mockk<AudioFileReader>(relaxed = true) {
+                every { getAudioFileFormat(any<File>()) } returns audioFileFormat()
+            }
+
+        mockkStatic("net.transgressoft.commons.media.util.AudioDecoderUtilKt")
+        every { loadAudioFileReaders() } returns listOf(crashingReader, successReader)
+
+        val temp = Files.createTempFile("audio_", ".m4a")
+        try {
+            val format = readAudioFileFormat(temp)
+
+            format.type shouldBe AudioFileFormat.Type.WAVE
+        } finally {
+            Files.deleteIfExists(temp)
+            unmockkStatic("net.transgressoft.commons.media.util.AudioDecoderUtilKt")
+        }
+    }
+
+    "readAudioFileFormat reports unsupported playback when every provider rejects the file" {
+        val rejectingReader1 =
+            mockk<AudioFileReader>(relaxed = true) {
+                every { getAudioFileFormat(any<File>()) } throws UnsupportedAudioFileException("bad metadata")
+            }
+        val rejectingReader2 =
+            mockk<AudioFileReader>(relaxed = true) {
+                every { getAudioFileFormat(any<File>()) } throws UnsupportedAudioFileException("bad metadata")
+            }
+
+        mockkStatic("net.transgressoft.commons.media.util.AudioDecoderUtilKt")
+        every { loadAudioFileReaders() } returns listOf(rejectingReader1, rejectingReader2)
+
+        val temp = Files.createTempFile("audio_", ".m4a")
+        try {
+            val error =
+                shouldThrow<UnsupportedAudioPlaybackException> {
+                    readAudioFileFormat(temp)
                 }
 
             error.message shouldContain "tried 2 providers"


### PR DESCRIPTION
Closes #122

Summary:
- Fix FLAC seek alignment by using jflac random-access seeking and keeping decoded progress aligned with the source duration.
- Make compressed-format seek reopening decoder-aligned instead of trusting provider skip behavior.
- Add safe provider fallback for file-format probing and decoded-duration fallback when metadata providers fail.
- Cover the regressions with media-layer and FX-layer tests.

Verification:
- `gradle :music-commons-media:ktlintCheck --rerun-tasks`
- `gradle :music-commons-media:test --rerun-tasks`
- `gradle :music-commons-fx:test --rerun-tasks`