### PR TITLE
#170 Documentation overhaul: accuracy pass, restructure, and d2 diagrams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,149 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+The 0.7.0 line simplifies the album/genre projection API and completes the
+persistence-agnostic split. Breaking changes are listed below; **the JSON
+persistence format is unchanged**, so existing library files remain readable
+without any data migration.
+
+### Added
+- Album and Genre projections on the audio library. Albums are a single-key
+  projection keyed by canonical album identity; genres are a multi-key
+  projection, with untagged tracks surfaced in a dedicated `Genre.None` bucket
+  (#151, #164). Projection buckets are ordered by title (#166).
+- FX `FXAlbum.coverProperty` triggers a lazy cover-art load on first
+  observation, so an `ImageView` bound to it loads on demand (#154, #163).
+
+### Changed
+- **BREAKING:** Album API simplified. The `Album` value type became
+  `AlbumDetails`; `ReactiveAlbumCatalog`/`ReactiveGenreCatalog` became
+  `ReactiveAlbum`/`ReactiveGenreIndex` (FX: `ObservableAlbum`/
+  `ObservableGenreIndex`); the `AlbumSet`/`AlbumView` helpers were removed in
+  favor of `tracks: List<I>` on the bucket. Accessors and publishers were
+  renamed to match (`getAlbum`, `getGenreIndex`, `albumPublisher`,
+  `genreIndexPublisher`; FX `albumsProperty`, `genreIndexesProperty`). The
+  **Artist axis intentionally keeps** its `*Catalog` naming (#156).
+- **BREAKING:** FX `albumsProperty` and `genreIndexesProperty` changed from
+  `ReadOnlySetProperty` to `ReadOnlyListProperty` to expose ordered,
+  index-addressable buckets. `artistCatalogsProperty` remains a set (#156, #166).
+- Album buckets merge on canonical album identity, so per-track variance in
+  year, label, album artist, or compilation flag no longer fragments one
+  logical album (#162).
+- Upgraded to lirp 3.0.0; base modules are fully persistence-agnostic and ship
+  no JSON or SQL code (#150).
+
+### Fixed
+- JSON timestamp and play-count values are no longer lost on reload (#150).
+
+### Migration
+
+| Old symbol | New symbol |
+|------------|------------|
+| `Album` (value type) | `AlbumDetails` |
+| `ReactiveAlbumCatalog` | `ReactiveAlbum` |
+| `ReactiveGenreCatalog` | `ReactiveGenreIndex` |
+| `ObservableAlbumCatalog` | `ObservableAlbum` |
+| `ObservableGenreCatalog` | `ObservableGenreIndex` |
+| `AlbumSet` / `AlbumView` | removed — use `tracks: List<I>` |
+| `getAlbumCatalog(album)` | `getAlbum(album)` |
+| `getGenreCatalog(genre)` | `getGenreIndex(genre)` |
+| `albumCatalogPublisher` | `albumPublisher` |
+| `genreCatalogPublisher` | `genreIndexPublisher` |
+| `albumCatalogsProperty` (FX) | `albumsProperty` (now `ReadOnlyListProperty`) |
+| `genreCatalogsProperty` (FX) | `genreIndexesProperty` (now `ReadOnlyListProperty`) |
+
+`ReactiveAlbum.tracks` and `ReactiveGenreIndex.tracks` return an ordered,
+deduplicated `List<I>` — callers no longer sort or deduplicate. Album buckets
+are ordered by disc then track number; genre buckets by artist, album, then
+track number. When wiring FX change listeners against the property type,
+`ListChangeListener` replaces `SetChangeListener` for albums and genre indexes.
+
+## [0.6.0] — 2026-06-09
+
+### Added
+- Headless `CoreAudioItemPlayer` and the `music-commons-media` module: a
+  JavaFX-free playback engine over JavaSound SPI decoders, with ALAC and Opus
+  support and format-specific seeking.
+- M3U playlist import (`M3uImportService`) with nested-reference and
+  cycle detection.
+- Supply-chain hardening: aggregated CycloneDX SBOM, OSV-Scanner workflow, and
+  SHA-256 dependency verification.
+- Lazy cover-art loading — a full-library import no longer retains cover bytes
+  until they are read.
+
+### Changed
+- Persistence migrated to lirp's SQL repository via persistence-mapping modules.
+- JavaFX observable library updates are coalesced during large imports.
+- Repository-agnostic library refactor around `AudioItemMetadata`.
+
+### Fixed
+- Playback seek regressions, M4A decode fallback, and MP3 SPI provider ordering.
+
+## [0.5.2] — 2026-05-02
+
+### Fixed
+- Recursive audio-item changes propagate from descendant playlists to their
+  ancestors.
+
+## [0.5.1] — 2026-05-01
+
+### Fixed
+- Folder hierarchy and cover image are preserved when only leaf playlists are
+  selected for export.
+
+## [0.5.0] — 2026-04-27
+
+### Added
+- iTunes library XML import: parser, metadata policy, and library integration.
+- `PlayableWaveformPane` with progress fill, playhead, and click-to-seek;
+  normalized-amplitude caching in waveform serialization.
+- Cross-platform test fixtures and Windows path handling.
+
+### Changed
+- **BREAKING:** `AudioLibrary`/`PlaylistHierarchy` narrowed into `Reactive*`
+  interfaces; introduced the `MusicLibrary` facade.
+- `Genre` refactored from an enum to a sealed class.
+- Adopted lirp reactive delegates, projection maps, and collection events.
+
+### Fixed
+- Player `isPlayable()` NPE; `MediaException` wrapped in `play()`.
+- Cover image hydrated for JSON-loaded playlists.
+
+## [0.4.0] — 2026-03-27
+
+### Added
+- `ObservableArtistCatalog`; lifecycle management via `close()`.
+
+### Changed
+- Kotlin upgrade; adopted lirp 1.2.0; Gradle versions moved to a version catalog.
+- Renamed `createTagTag()` to `createTag()`.
+
+### Fixed
+- `addAudioItem()` behavior; `getRandomAudioItemsFromArtist` honoring the size
+  parameter.
+
+## [0.3.0] — 2025-11-23
+
+### Added
+- Artist-catalog subscription support.
+
+### Fixed
+- `ObservableAudioLibrary` defects.
+
+## [0.2.0] — 2025-11-15
+
+### Fixed
+- Artist-catalog initialization from a non-empty repository.
+- Removed a hardcoded dispatcher in `ScalableAudioWaveform`.
+
+## [0.1.0] — 2025-10-22
+
+### Added
+- Initial release: reactive audio library, artist-catalog registry, playlists,
+  waveform generation, JavaFX integration, and asynchronous batch import.

--- a/README.md
+++ b/README.md
@@ -1,680 +1,297 @@
+[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
+[![Kotlin](https://img.shields.io/badge/Kotlin-2.4.0-blue?logo=kotlin)](https://kotlinlang.org)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/octaviospain/music-commons)
+[![music-commons-api javadoc](https://javadoc.io/badge2/net.transgressoft/music-commons-api/javadoc.svg?label=music-commons-api%20javadoc)](https://javadoc.io/doc/net.transgressoft/music-commons-api)
+[![music-commons-core javadoc](https://javadoc.io/badge2/net.transgressoft/music-commons-core/javadoc.svg?label=music-commons-core%20javadoc)](https://javadoc.io/doc/net.transgressoft/music-commons-core)
+[![music-commons-fx javadoc](https://javadoc.io/badge2/net.transgressoft/music-commons-fx/javadoc.svg?label=music-commons-fx%20javadoc)](https://javadoc.io/doc/net.transgressoft/music-commons-fx)
+[![music-commons-media javadoc](https://javadoc.io/badge2/net.transgressoft/music-commons-media/javadoc.svg?label=music-commons-media%20javadoc)](https://javadoc.io/doc/net.transgressoft/music-commons-media)
+[![music-commons-persistence javadoc](https://javadoc.io/badge2/net.transgressoft/music-commons-persistence/javadoc.svg?label=music-commons-persistence%20javadoc)](https://javadoc.io/doc/net.transgressoft/music-commons-persistence)
+[![music-commons-persistence-fx javadoc](https://javadoc.io/badge2/net.transgressoft/music-commons-persistence-fx/javadoc.svg?label=music-commons-persistence-fx%20javadoc)](https://javadoc.io/doc/net.transgressoft/music-commons-persistence-fx)
 ![Maven Central Version](https://img.shields.io/maven-central/v/net.transgressoft/music-commons-core)
-![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/octaviospain/music-commons/.github%2Fworkflows%2Fmaster.yml?logo=github)
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=octaviospain_music-commons&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=octaviospain_music-commons)
 [![Bugs](https://sonarcloud.io/api/project_badges/measure?project=octaviospain_music-commons&metric=bugs)](https://sonarcloud.io/summary/new_code?id=octaviospain_music-commons)
 [![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=octaviospain_music-commons&metric=code_smells)](https://sonarcloud.io/summary/new_code?id=octaviospain_music-commons)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=octaviospain_music-commons&metric=coverage)](https://sonarcloud.io/summary/new_code?id=octaviospain_music-commons)
-[![Duplicated Lines (%)](https://sonarcloud.io/api/project_badges/measure?project=octaviospain_music-commons&metric=duplicated_lines_density)](https://sonarcloud.io/summary/new_code?id=octaviospain_music-commons)
+[![Lines of Code](https://sonarcloud.io/api/project_badges/measure?project=octaviospain_music-commons&metric=ncloc)](https://sonarcloud.io/summary/new_code?id=octaviospain_music-commons)
+[![Technical Debt](https://sonarcloud.io/api/project_badges/measure?project=octaviospain_music-commons&metric=sqale_index)](https://sonarcloud.io/summary/new_code?id=octaviospain_music-commons)
+[![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=octaviospain_music-commons&metric=vulnerabilities)](https://sonarcloud.io/summary/new_code?id=octaviospain_music-commons)
+![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/octaviospain/music-commons/.github%2Fworkflows%2Fmaster.yml?logo=github)
+
 # Music Commons
 
-A modular, reactive Kotlin library for managing audio libraries, playlists, and waveform visualizations. Originally extracted from the [Musicott](https://github.com/octaviospain/Musicott) desktop application. Published to Maven Central under `net.transgressoft`.
+A modular, reactive Kotlin library for managing audio libraries, playlists, and waveform
+visualizations. Domain state changes — metadata edits, imports, removals — propagate
+automatically to every dependent view (artist catalogs, album and genre projections, playlists,
+waveforms, and JavaFX bindings) with no manual wiring. Extracted from the
+[Musicott](https://github.com/octaviospain/Musicott) desktop application and published to Maven
+Central under `net.transgressoft`.
 
-See the [Wiki](https://github.com/octaviospain/music-commons/wiki) for detailed guides and architecture documentation.
+📖 **Full documentation lives in the [Wiki](https://github.com/octaviospain/music-commons/wiki)** —
+architecture, per-feature guides, and a [Glossary](https://github.com/octaviospain/music-commons/wiki/Glossary).
 
-## Overview
+## Contents
 
-music-commons was born from the need to separate the core audio management logic from the Musicott desktop application into a standalone, reusable library. The goal was to create a foundation that could power not just Musicott, but any project that needs to manage audio files and related operations—whether that's handling playlists, generating waveforms, managing metadata, or implementing import/export functionality. It provides reusable core components for audio file management: metadata handling, playlist organization, waveform generation, and playback control. The library offers a clean, layered architecture with reactive event-driven updates and optional JavaFX integration, enabling both headless services and desktop applications.
+- [Why this project](#why-this-project)
+- [Modules](#modules)
+- [Requirements](#requirements)
+- [Installation](#installation)
+- [Quickstart](#quickstart)
+- [Features](#features)
+- [Building](#building)
+- [Feature index](#feature-index)
+- [Contributing](#contributing)
+- [License and attributions](#license-and-attributions)
 
-### Built on lirp
+## Why this project
 
-Music Commons leverages [lirp](https://github.com/octaviospain/lirp), which provides the foundational reactive entity framework, repository pattern, automatic JSON serialization, and event-driven architecture that Music Commons builds upon.
+Musicott's audio-management logic was entangled with its desktop UI. Music Commons extracts that
+logic into a standalone, layered library that can power both headless services and JavaFX
+applications. It builds on [lirp](https://github.com/octaviospain/lirp) for the reactive entity
+framework, repository pattern, and event-driven architecture, and layers a music-specific domain
+model — audio metadata, artist/album/genre projections, playlists, waveforms, and playback — on
+top. See the [Architecture](https://github.com/octaviospain/music-commons/wiki/Architecture) and
+[Reactive Events](https://github.com/octaviospain/music-commons/wiki/Reactive-Events) wiki pages
+for the design.
 
-### Architecture
+## Modules
 
-The library is split into a reactive core and a set of opt-in persistence mapping modules. The
-reactive modules manage the domain entirely in memory through lirp's reactive/event model and
-ship no JSON or SQL persistence code. Persistence is a consumer choice, layered on top.
+The library splits into a reactive core and a set of opt-in persistence-mapping modules. The
+reactive modules manage the domain entirely in memory and ship **no** JSON or SQL persistence
+code; persistence is a consumer choice layered on top.
 
-**Reactive modules:**
+**Reactive modules**
 
-- **`music-commons-api`**: Interfaces and contracts defining the audio management domain model
-- **`music-commons-core`**: Reactive implementations with in-memory storage and event subscriptions
-- **`music-commons-fx`**: JavaFX integration layer with observable properties and UI components
-- **`music-commons-media`**: JavaFX-free audio playback engine and waveform generation
+| Module | Purpose |
+|--------|---------|
+| `music-commons-api` | Interfaces and contracts for the domain model |
+| `music-commons-core` | Reactive in-memory implementations and event subscriptions |
+| `music-commons-fx` | JavaFX integration — observable properties and UI components |
+| `music-commons-media` | JavaFX-free playback engine and waveform generation |
 
-**Persistence mapping modules (opt-in):**
+**Persistence-mapping modules (opt-in, mapping-only — no entities)**
 
-- **`music-commons-persistence`**: JSON serializers and SQL table definitions for the core entities
-- **`music-commons-persistence-fx`**: JSON serializers and SQL table definitions for the JavaFX entities
+| Module | Purpose |
+|--------|---------|
+| `music-commons-persistence` | JSON serializers + SQL table definitions for core entities |
+| `music-commons-persistence-fx` | JSON serializers + SQL table definitions for JavaFX entities |
 
-The persistence modules are mapping-only: they define no entities, only serializers,
-`SqlTableDef`s, and `ColumnConverter`s for the real reactive entities. A consumer enables
-persistence by injecting a concrete lirp `Repository` wired with these mappings, or skips them
-entirely and subscribes to library events to persist in their own model.
-
-Waveforms persist to JSON only. Their serializer (`AudioWaveformMapSerializer`, package
-`net.transgressoft.commons.media.persistence.waveform`) ships directly from `music-commons-media`
-alongside the `ScalableAudioWaveform` entity, so no separate waveform-persistence module is needed.
+A consumer enables persistence by injecting a concrete lirp `Repository` wired with these
+mappings, or skips them entirely and subscribes to library events to persist in their own model.
+Waveforms persist to JSON only; their serializer ships from `music-commons-media`. See
+[SQL Persistence](https://github.com/octaviospain/music-commons/wiki/SQL-Persistence).
 
 ## Requirements
 
-- **Java**: 21 or higher
-- **Kotlin**: 2.3.0
-- **JavaFX**: 21.0.7 or higher (only required for `music-commons-fx` module)
+- **Java** 21 or higher
+- **Kotlin** 2.4.0
+- **JavaFX** 21.0.11 or higher (only for the `music-commons-fx` module)
 
 ## Installation
 
 ```kotlin
-// Gradle (Kotlin DSL)
 dependencies {
     implementation("net.transgressoft:music-commons-api:$version")
     implementation("net.transgressoft:music-commons-core:$version")
-    implementation("net.transgressoft:music-commons-fx:$version")    // Optional, for JavaFX apps
-    implementation("net.transgressoft:music-commons-media:$version")  // Optional, for headless playback + waveforms
+    implementation("net.transgressoft:music-commons-fx:$version")     // Optional — JavaFX apps
+    implementation("net.transgressoft:music-commons-media:$version")  // Optional — headless playback + waveforms
 
     // Persistence is opt-in — add only the mapping module(s) you wire into a repository
-    implementation("net.transgressoft:music-commons-persistence:$version")        // core-tier serializers + SQL table defs
-    implementation("net.transgressoft:music-commons-persistence-fx:$version")     // JavaFX-tier serializers + SQL table defs
-    // The waveform JSON serializer ships from music-commons-media — no extra module needed
+    implementation("net.transgressoft:music-commons-persistence:$version")     // core-tier
+    implementation("net.transgressoft:music-commons-persistence-fx:$version")  // JavaFX-tier
 }
 ```
 
-The reactive modules depend on [lirp](https://github.com/octaviospain/lirp) 3.0.0 for the
-reactive/event model only (`lirp-api`, `lirp-core`). The version is declared once in
-`gradle/libs.versions.toml` and shared across all modules:
-
-```kotlin
-implementation("net.transgressoft:lirp-api:3.0.0")
-implementation("net.transgressoft:lirp-core:3.0.0")
-```
-
-SQL persistence additionally pulls in `lirp-sql` (transitively, through the persistence modules)
-plus a JDBC driver of your choice. The reactive modules never see `lirp-sql` on their classpath.
-
-## Key Features
-
-### Genre Handling
-
-`Genre` is a sealed class with ~370 predefined genre constants (data objects) and a `Custom` variant for arbitrary genre strings. Audio items carry multiple genres as a `Set<Genre>`, populated by parsing comma-separated tags from audio file metadata.
-
-The `parseGenre` and `joinGenres` helpers are **top-level functions** in `net.transgressoft.commons.music.audio`; import them directly:
-
-```kotlin
-import net.transgressoft.commons.music.audio.parseGenre
-import net.transgressoft.commons.music.audio.joinGenres
-
-val genres: Set<Genre> = parseGenre("Rock, Jazz")  // setOf(Rock, Jazz)
-val custom: Set<Genre> = parseGenre("Vaporwave")   // setOf(Genre.Custom("Vaporwave"))
-val tag: String = joinGenres(genres)               // "Jazz, Rock"
-```
-
-Unknown genre strings are preserved as `Genre.Custom(name)` instead of being discarded. Serialization uses a JSON array: `"genres": ["Rock", "Jazz"]`
-
-`Genre` also defines a projection-only `Genre.None` sentinel (a `data object` with an empty name) used by the genre index to bucket untagged tracks — see the genre index entry below. It is never parsed, persisted, or assigned to an item's `genres`; the empty name is reserved for it, so `Genre.Custom("")` is rejected.
-
-### Audio Library Management
-
-- **Multi-format support**: MP3, M4A (AAC and ALAC), WAV, FLAC, and OGG (Vorbis and Opus) with automatic metadata extraction
-- **Artist catalog indexing**: Automatic organization by artist and album with aggregated views. An item is indexed under every artist it involves (primary, album, and featured artists), so a collaboration appears in each contributor's catalog. The catalog is backed by a lirp multi-key registry projection — artist buckets update incrementally as items are added, modified, or removed, with no manual CRUD dispatch
-- **Album indexing**: Flat per-album bucket view backed by a lirp single-key value-transform registry projection. Buckets are keyed by a canonical album identity (normalized name + compilation-aware album artist, with year/label/compilation zeroed), so per-track variance in year, label, album artist, or compilation flag no longer fragments one logical album into multiple buckets — all such tracks merge into a single bucket. The bucket's exposed `AlbumDetails` is a derived representative (most-frequent non-empty value per field, with deterministic tie-breaks), distinct from the canonical key. Lookups (`getAlbum`, `getRandomAudioItemsFromAlbum`) canonicalize their argument, so any raw track's `AlbumDetails` resolves the correct bucket. Buckets update incrementally as items are added, moved to a different album, or removed — use `getAlbum(album)`, `containsAudioItemWithAlbum(albumName)`, `getRandomAudioItemsFromAlbum(album)`, and `albumPublisher` to query the index
-- **Genre index indexing**: Flat per-genre bucket view backed by a lirp multi-key registry projection. An item with multiple genres appears in every matching genre bucket simultaneously; an item with an empty genres set surfaces in the dedicated `Genre.None` bucket (the key extractor maps `genres.ifEmpty { setOf(Genre.None) }`) rather than being dropped. The no-genre bucket appears and disappears reactively as tracks gain or lose all genres. Buckets update incrementally as items are added, their genres change, or items are removed — use `getGenreIndex(genre)`, `containsAudioItemWithGenre(genreName)`, `getRandomAudioItemsFromGenre(genre)`, and `genreIndexPublisher` to query the index. The no-genre bucket is reachable via `getGenreIndex(Genre.None)` or a blank-name lookup (`getGenreIndex("")`, `containsAudioItemWithGenre("")`)
-- **Batch operations**: Asynchronous batch creation via `CompletableFuture` API
-- **Reactive updates**: CRUD operations publish events through Java Flow API
-- **Lazy cover-art loading**: `coverImageBytes` on `ReactiveAudioItem` is loaded on first access and cached — a full-library import retains no cover bytes until they are explicitly read. The getter and setter return and store the internal array reference directly; callers must treat the returned array as immutable and must not modify its contents. All mutations must go through the setter so reactive change notifications are published. For JavaFX consumers, observing or binding `ObservableAudioItem.coverImageProperty` also triggers the lazy load on first observation — an `ImageView` bound to `coverImageProperty` therefore loads its cover on demand when the cell first displays the track, without any explicit call to `coverImageBytes`.
-
-### Playlist Management
-
-- **Hierarchical organization**: Nested playlist structures with directories
-- **M3U export**: Export playlists preserving directory structure
-- **M3U import**: Import `.m3u` and `.m3u8` playlists, including nested playlist references and cycle detection
-- **Automatic synchronization**: Playlists update when audio items are modified or removed
-
-### Waveform Visualization
-
-- **Asynchronous generation**: Non-blocking waveform creation with configurable resolution
-- **Repository caching**: Waveforms are cached and reused across requests
-- **Normalized amplitude caching**: Serialized waveforms cache normalized amplitudes with their display width — same-width requests return instantly without audio file I/O, and height-only changes apply linear scaling from cache
-- **JavaFX component**: Custom `WaveformPane` canvas with automatic redraw on resize
-- **Playback-aware visualization**: `PlayableWaveformPane` adds two-color progress fill, playhead line, click-to-seek with drag-to-scrub, and a shimmer loading animation
-
-### Audio Playback
-
-- **Player abstraction**: `AudioItemPlayer` interface for custom playback engines
-- **JavaFX implementation**: `JavaFxPlayer` wrapping native MediaPlayer with status monitoring
-- **Play count tracking**: Automatic increment at 60% playback threshold
-
-### Persistence
-
-The reactive modules store everything in memory and never write to disk on their own. Persistence
-is enabled by injecting a concrete repository, and there are two ways to do it:
-
-**Library-managed persistence (lirp path)** — inject a lirp `Repository` wired with the mappings
-from the opt-in persistence modules. lirp persists and reloads the library's real entities:
-
-- **JSON file storage**: inject `JsonFileRepository(file, <MapSerializer>)` for debounced file I/O,
-  using the map serializers from `music-commons-persistence` / `music-commons-persistence-fx`, plus
-  `AudioWaveformMapSerializer` from `music-commons-media` for waveforms
-- **SQL storage**: inject `SqliteRepository.fileBacked(db, <SqlTableDef>)` (HikariCP + JetBrains
-  Exposed), using the table definitions from the persistence modules — add a JDBC driver
-  (e.g. `org.xerial:sqlite-jdbc`) to your build. Audio items and playlists have both JSON and SQL
-  options; waveforms are JSON-only
-- **Transparent persistence**: entity changes are persisted without manual save operations
-- **Async error observability**: wire a `LirpErrorHandler` on each repository to observe flush and
-  event-drain failures that would otherwise be log-only
-
-**Bring-your-own persistence** — construct the library with no repository arguments. Every
-aggregate defaults to an in-memory repository, and you subscribe to library and entity events to
-persist in your own model and format. No persistence module is required for this path.
-
-#### Observing Async Persistence Failures
-
-Repositories flush entity changes and drain event channels asynchronously. Failures in these
-paths are logged by the framework but are not surfaced to application code by default. To observe
-them — for example, to increment a metric or trigger an alert — pass a `LirpErrorHandler` via
-the `onError` parameter at repository construction time:
-
-```kotlin
-val audioRepo = JsonFileRepository(
-    file = File("audio-library.json"),
-    mapSerializer = AudioItemMapSerializer,
-    onError = LirpErrorHandler { throwable, ctx ->
-        // ctx.operation is FLUSH (persistence write failure) or EMIT (event-drain failure)
-        // ctx.repository is the repository name passed at construction time
-        // ctx.entityIds contains affected entity IDs (empty for flush-cycle failures)
-        logger.error("${ctx.repository}/${ctx.operation} failed", throwable)
-        metrics.increment("persistence.error", "repo" to ctx.repository)
-    }
-)
-
-val library = CoreMusicLibrary.builder()
-    .audioRepository(audioRepo)
-    .build()
-```
-
-The handler is **notify-only**: the framework logs the failure first, then invokes the handler.
-The handler cannot retry or alter control flow — the library keeps running regardless of what
-the handler does. Handler exceptions are swallowed.
-
-The `LirpErrorContext` passed to the handler carries only entity identity information
-(`operation`, `entityIds`, `repository`). Entity field values are never included, avoiding
-sensitive data in error paths.
-
-### JavaFX Integration
-
-- **Observable properties**: Direct binding to JavaFX TableView, ListView, and other controls
-- **Thread safety**: JavaFX-facing library and catalog projections coalesce burst updates onto the JavaFX Application Thread. The FX artist, album, and genre catalogs use lirp 3.0.0's two-phase projection approach (`registryFxMultiKeyProjection` for artist/genre, `registryFxProjection` for album) — background data transformation followed by FX-thread `fxFactory` construction — keeping large imports responsive while converging to the correct observable state
-- **Enriched catalog fields**: `ObservableArtistCatalog` exposes `artistName` alongside the full `Artist` value object. `ObservableAlbum` delegates `albumName`, `albumArtist`, `isCompilation`, `year`, and `label` directly onto the bucket so binding code does not need to navigate into the `AlbumDetails` object. `ReactiveAlbum` also exposes `coverImageBytes: ByteArray?` (lazily loaded from the first item in the bucket that carries cover data). `ObservableAlbum` adds `coverProperty: ReadOnlyObjectProperty<Optional<Image>>` — a softly cached JavaFX image property resolved on the FX Application Thread, safe to bind directly to an `ImageView`
-- **Custom controls**: `WaveformPane` for static waveforms, `PlayableWaveformPane` for playback-aware visualization with seek
-
-### Typed Path Validation Exceptions
-
-Audio-item construction and iTunes import now throw typed exceptions for invalid paths:
-
-- `InvalidAudioFilePathException` -- any of: file does not exist, path is not a regular
-  file, file is not readable. Subclass of `AudioItemManipulationException`, so existing
-  catch blocks continue to work.
-- `WindowsPathException` (subclass of `InvalidAudioFilePathException`) -- thrown only when
-  the JVM runs on Windows. Carries a `WindowsViolation` reason: `ForbiddenChar`,
-  `ReservedName`, `TrailingDotOrSpace`, or `ExceedsMaxPath`.
-
-On a real Windows JVM, `Paths.get("bad|name.mp3")` throws `java.nio.file.InvalidPathException`
-at parse time, before the validator even runs. `WindowsPathException` surfaces for inputs that
-parse successfully but fail validation: reserved names, trailing dot/space, MAX_PATH overflow,
-or paths assembled from already-parsed segments.
-
-```kotlin
-try {
-    // Reserved name -- parses fine on Windows, but the validator rejects it.
-    library.audioItemFromFile(Paths.get("C:\\music\\NUL.mp3"))
-} catch (e: WindowsPathException) {
-    println("Windows-specific: ${e.violation}")
-} catch (e: InvalidAudioFilePathException) {
-    println("Invalid path: ${e.message}")
-}
-```
-
-### iTunes Library Import
-
-The `music-commons-core` module includes an iTunes library XML import engine for migrating
-tracks and playlists from Apple Music / iTunes. `ItunesImportService` accepts any `MusicLibrary<*, *>`
-implementation, so it works with both `CoreMusicLibrary` (headless) and `FXMusicLibrary` (JavaFX).
-
-**Two-step import flow:**
-
-1. **Parse** the iTunes `library.xml` file:
-   ```kotlin
-   val itunesLibrary = ItunesLibraryParser.parse(Paths.get("/path/to/library.xml"))
-   // Inspect itunesLibrary.playlists to let the user select which to import
-   ```
-
-2. **Import** selected playlists with a configurable policy:
-   ```kotlin
-   val service = ItunesImportService(musicLibrary)
-   val future = service.importAsync(
-       selectedPlaylists = chosen,
-       itunesLibrary = itunesLibrary,
-       policy = ItunesImportPolicy(useFileMetadata = false, holdPlayCount = true),
-       onProgress = { progress -> println("${progress.itemsProcessed}/${progress.totalItems}") }
-   )
-   val result = future.get()
-   result.imported                // List<ReactiveAudioItem<*>> -- successful imports
-   result.unresolved              // List<UnresolvedTrack> -- could not resolve
-   result.rejectedPlaylistNames   // List<RejectedPlaylistName> -- Windows-incompatible names
-   ```
-
-#### Structured Import Results
-
-`ItunesImportService.importAsync()` returns a structured `ImportResult` with three typed buckets
-so consumers can handle every failure mode individually:
-
-```kotlin
-val result = itunesImport.importAsync(...).await()
-result.imported                // List<ReactiveAudioItem<*>> -- successful imports
-result.unresolved              // List<UnresolvedTrack> -- could not resolve (FileNotFound,
-                               //   UnsupportedType, ImportError)
-result.rejectedPlaylistNames   // List<RejectedPlaylistName> -- playlist name incompatible
-                               //   with Windows filesystems (only rejected when JVM is
-                               //   running on Windows)
-```
-
-Filenames in iTunes XML are also normalized to Unicode NFC form after URI decoding, which
-fixes the common case of a macOS-origin library failing to resolve tracks on Linux or
-Windows due to NFD-encoded accented characters.
-
-**Import policy options:**
-
-| Option | Default | Description |
-|--------|---------|-------------|
-| `useFileMetadata` | `true` | When `true`, metadata comes from audio file tags. When `false`, user-facing fields come from iTunes data. |
-| `holdPlayCount` | `true` | Transfers play counts from iTunes to imported items. |
-| `writeMetadata` | `true` | Writes iTunes metadata to audio file tags after import. |
-| `acceptedFileTypes` | All | Filters tracks by audio file type (MP3, M4A, WAV, FLAC). |
-
-Tracks whose files don't exist on disk are always recorded in `ImportResult.unresolved`
-with reason `UnresolvedReason.FileNotFound`; consumers decide how to surface them.
-
-## Module Details
-
-### music-commons-api
-
-Defines contracts and interfaces for the audio management domain.
-
-**Key Interfaces:**
-- `MusicLibrary<I, P>` -- Unified facade interface implemented by both `CoreMusicLibrary` and `FXMusicLibrary`, enabling library-agnostic consumers like `ItunesImportService`
-- `ReactiveAudioItem<I>` -- Audio file representation with metadata
-- `ReactiveAudioLibrary<I, AC, RA, GI>` -- Generic CRUD repository with reactive event publishing and `createAudioItem(factory)` for ID-encapsulated construction; type parameters bind the artist-catalog (`AC`), album (`RA`), and genre-index (`GI`) types
-- `ReactiveAlbum<RA, I>` -- Per-album bucket with `tracks: List<I>` (ordered by disc then track number), `album: AlbumDetails`, and lazy `coverImageBytes`
-- `ReactiveGenreIndex<GI, I>` -- Per-genre bucket with `tracks: List<I>` (ordered by artist then album then track), `genre: Genre`
-- `AlbumDetails` -- Album value type (replaces the former `Album`); carries `name`, `artist`, `year`, `isCompilation`, and `label`
-- `ReactiveAudioPlaylist<I, P>` / `ReactivePlaylistHierarchy<I, P>` -- Generic playlist management with M3U export and ID-based `createPlaylist` overload
-- `AudioWaveform` / `AudioWaveformRepository` -- Waveform data and generation
-- `AudioItemPlayer` -- Playback controls with status monitoring, including `STALLED` for sustained streaming starvation
-
-### music-commons-core
-
-Reactive, in-memory implementations built on [lirp](https://github.com/octaviospain/lirp) 3.0.0's
-reactive/event model. Ships no JSON or SQL persistence code — persistence is supplied by the opt-in
-`music-commons-persistence` module.
-
-- `CoreMusicLibrary` -- Unified facade for headless audio management implementing `MusicLibrary<AudioItem, MutableAudioPlaylist>` (builder-based entry point)
-- `AudioLibrary` -- Narrowed `ReactiveAudioLibrary` for `AudioItem`, `ArtistCatalog`, `Album`, and `GenreIndex` types
-- `PlaylistHierarchy` -- Narrowed `ReactivePlaylistHierarchy` for `AudioItem` and `MutableAudioPlaylist` types
-- Internal implementations: `DefaultAudioLibrary`, `DefaultPlaylistHierarchy`, `DefaultAudioWaveformRepository`
-- **Artist catalog** -- multi-key registry projection (`registryMultiKeyProjection`); each item is bucketed under every artist it involves; buckets update incrementally as audio items change. Query via `artistCatalogs()`, `getArtistCatalog(artist)`, `containsAudioItemWithArtist(name)`, `getRandomAudioItemsFromArtist(artist)`, `artistCatalogPublisher`
-- **Album index** -- single-key value-transform registry projection (`registryProjection`); each item lands in exactly one album bucket keyed by its canonical album identity (normalized name + compilation-aware album artist), with the bucket's exposed `AlbumDetails` derived as the most-frequent representative across the grouped tracks. Album buckets are ordered by album name (case-insensitive, trimmed) → album artist → year, with blank or unknown-name albums sorted last. Query via `getAlbum(album)`, `containsAudioItemWithAlbum(name)`, `getRandomAudioItemsFromAlbum(album)`, `albumPublisher`; iterate ordered buckets via `forEach` on the projection; navigate from an item via `item.albumIn(library)`; in JavaFX consumers, `albumsProperty` exposes the ordered buckets as a `ReadOnlyListProperty<ObservableAlbum>` that is index-addressable
-- **Genre index** -- multi-key registry projection (`registryMultiKeyProjection`); an item with multiple genres appears in each matching genre bucket; an item with an empty genres set surfaces in the dedicated `Genre.None` bucket (`genres.ifEmpty { setOf(Genre.None) }`) instead of being dropped. Genre buckets are ordered by `Genre` natural order (ordinal), with `Genre.None` always first. Query via `getGenreIndex(genre)`, `containsAudioItemWithGenre(name)`, `getRandomAudioItemsFromGenre(genre)`, `genreIndexPublisher`; the no-genre bucket is reachable via `getGenreIndex(Genre.None)` or a blank-name lookup; in JavaFX consumers, `genreIndexesProperty` exposes the ordered buckets as a `ReadOnlyListProperty<ObservableGenreIndex>`
-- Event subscribers for reactive synchronization between components
-
-### music-commons-fx
-
-Bridges core module with JavaFX's property binding system.
-
-- `FXMusicLibrary` -- Unified facade for JavaFX audio management implementing `MusicLibrary<ObservableAudioItem, ObservablePlaylist>` with observable properties (builder-based entry point)
-- `ObservableAudioLibrary` -- Narrowed `ReactiveAudioLibrary` with JavaFX observable properties for UI binding; exposes `audioItemsProperty`, `emptyLibraryProperty`, `artistCatalogsProperty` (`ReadOnlySetProperty`), `albumsProperty` (`ReadOnlyListProperty`, ordered by album name → artist → year), and `genreIndexesProperty` (`ReadOnlyListProperty`, ordered by `Genre` natural order with `Genre.None` first); the list properties are index-addressable and still support set-style derivations (e.g. `albumsProperty.map { it.album }.toSet()`, `albumsProperty.sizeProperty()`)
-- `ObservablePlaylistHierarchy` -- Narrowed `ReactivePlaylistHierarchy` with a JavaFX observable playlists collection
-- `FXAudioItemPlayer` -- JavaFX wrapper around the bounded-streaming `CoreAudioItemPlayer`, exposing volume, status, and current-time as observable properties
-- `WaveformPane` -- Custom Canvas component for static waveform visualization
-- `PlayableWaveformPane` -- Region component with progress fill, playhead, seek, and shimmer loading
-- `SeekEvent` -- Custom JavaFX event fired on click-to-seek and drag-to-scrub interactions
-
-### music-commons-media
-
-JavaFX-free audio playback engine based on `javax.sound.sampled` SPI decoders, plus reactive
-waveform generation. Also ships the JSON serializer for waveforms (waveforms are JSON-only),
-co-located with the `ScalableAudioWaveform` entity.
-
-- `CoreAudioItemPlayer` -- Headless audio player supporting MP3, FLAC, OGG, AAC/M4A, and WAV via SPI decoders. Bounded PCM streaming pipeline with `SourceDataLine` output and format-specific seek (see [Seek precision](#seek-precision))
-- `ScalableAudioWaveform` -- Reactive waveform entity with on-demand amplitude generation and cached scaling
-- `AudioWaveformMapSerializer` -- map serializer for `JsonFileRepository`, preserving cached width and amplitudes (package `net.transgressoft.commons.media.persistence.waveform`)
-- `StallDetector` -- Detects and recovers from PCM read stalls in the pump loop
-- `DurationProber` -- Resolves playable duration including full-decode fallback for AAC/M4A containers
-- `PcmVolume` -- In-place linear gain application supporting 8/16/24/32-bit PCM
-- `FlacPcmStreamSeeker`, `Mp3PcmStreamSeeker`, `OggPcmStreamSeeker` -- Format-specific seek implementations
-
-### music-commons-persistence
-
-Opt-in JSON and SQL mapping for the core-tier entities. Mapping-only — defines no entity classes.
-
-- `AudioItemMapSerializer` / `AudioPlaylistMapSerializer` -- kotlinx-serialization map serializers for `JsonFileRepository`
-- `audioItemSerializersModule` -- contextual `SerializersModule` for the domain value types (artist, album, label, genre, metadata), so the domain stays annotation-free
-- `MutableAudioItemSqlTableDef` / `AudioPlaylistSqlTableDef` -- SQL table definitions for `SqliteRepository`
-- `CountryConverter`, `GenreConverter` -- column converters for SQL persistence (duration and path columns reuse lirp's built-in converters)
-
-### music-commons-persistence-fx
-
-Opt-in JSON and SQL mapping for the JavaFX-tier entities. Mapping-only — reuses the core-tier
-contextual serializers and column converters.
-
-- `ObservableAudioItemMapSerializer` / `ObservablePlaylistMapSerializer` -- map serializers for `JsonFileRepository`
-- `FXAudioItemSqlTableDef` / `ObservablePlaylistSqlTableDef` -- SQL table definitions for `SqliteRepository`
-
-## Usage Examples
-
-### Core module (headless)
-
-Use `CoreMusicLibrary.builder()` as the single entry point for headless audio management:
+The reactive modules depend on [lirp](https://github.com/octaviospain/lirp) `lirp-api`/`lirp-core`
+for the reactive/event model only. SQL persistence additionally pulls in `lirp-sql` (transitively,
+through the persistence modules) plus a JDBC driver of your choice; the reactive modules never see
+`lirp-sql` on their classpath.
+
+## Quickstart
+
+`CoreMusicLibrary.builder()` is the single entry point for headless use. With no repository
+arguments the library is fully in-memory — subscribe to events to persist in your own model.
 
 ```kotlin
 import net.transgressoft.commons.music.CoreMusicLibrary
-import net.transgressoft.commons.music.m3u.M3uImportService
-import net.transgressoft.commons.persistence.music.audio.AudioItemMapSerializer
-import net.transgressoft.commons.persistence.music.audio.MutableAudioItemSqlTableDef
-import net.transgressoft.commons.persistence.music.playlist.AudioPlaylistMapSerializer
-import net.transgressoft.commons.media.persistence.waveform.AudioWaveformMapSerializer
-import net.transgressoft.lirp.persistence.json.JsonFileRepository
-import net.transgressoft.lirp.persistence.sql.SqliteRepository
+import java.nio.file.Path
 
-// Bring-your-own persistence: no repository arguments -> in-memory storage.
-// Subscribe to library/entity events to persist in your own model and format.
 val library = CoreMusicLibrary.builder().build()
 
-// Library-managed JSON persistence -- inject JsonFileRepository instances wired with the
-// serializers from music-commons-persistence (audio items, playlists) and music-commons-media (waveforms)
-val library = CoreMusicLibrary.builder()
-    .audioRepository(JsonFileRepository(File("audio-library.json"), AudioItemMapSerializer))
-    .playlistRepository(JsonFileRepository(File("playlists.json"), AudioPlaylistMapSerializer))
-    .waveformRepository(JsonFileRepository(File("waveforms.json"), AudioWaveformMapSerializer))
-    .build()
+// Add an audio file — metadata is extracted automatically
+val song = library.audioItemFromFile(Path.of("/music/song.mp3"))
 
-// Library-managed SQL persistence -- add a JDBC driver (e.g. org.xerial:sqlite-jdbc) to your build;
-// MutableAudioItemSqlTableDef (from music-commons-persistence) is a ready SqlTableDef<AudioItem>
-// that reconstructs the real entity through lirp's construction SPI -- no factory needed
-val library = CoreMusicLibrary.builder()
-    .audioRepository(SqliteRepository.fileBacked(Path.of("audio-library.db"), MutableAudioItemSqlTableDef))
-    .build()
+// Projections update reactively — no manual dispatch
+library.getArtistCatalog(song.artist)          // artist bucket
+library.audioLibrary().getAlbum(song.album)    // album bucket (canonical identity)
 
-// Add audio files
-val audioItem = library.audioItemFromFile(Path.of("/path/to/song.mp3"))
+// Playlists
+val favorites = library.createPlaylist("Favorites")
+library.playlistHierarchy().addAudioItemsToPlaylist(listOf(song), "Favorites")
+favorites.exportToM3uFile(Path.of("favorites.m3u"))
 
-// Batch import (returns CompletableFuture, default batch size: 500)
-val audioItems = library.audioLibrary().createFromFileBatchAsync(listOfPaths).get()
+// Waveform (async)
+val waveform = library.getOrCreateWaveformAsync(song, 800, 300).get()
 
-// Create and manage playlists
-val playlist = library.createPlaylist("Favorites")
-library.playlistHierarchy().addAudioItemsToPlaylist(listOf(audioItem), "Favorites")
-
-// Generate waveforms
-val waveform = library
-    .getOrCreateWaveformAsync(audioItem, 800.toShort(), 300.toShort())
-    .get()
-
-// Export playlist to M3U
-playlist.exportToM3uFile(Path.of("favorites.m3u"))
-
-// Import playlist from M3U (M3uImportService is AutoCloseable — close to release its coroutine scope)
-val importedPlaylist = M3uImportService(library).use { importer ->
-    importer.import(Path.of("/path/to/favorites.m3u"))
-}
-
-// Lifecycle
 library.close()
 ```
 
-### JavaFX Integration
-
-Use `FXMusicLibrary.builder()` for JavaFX applications with observable property bindings:
+To persist through the library, inject a repository built from the persistence-mapping modules —
+JSON via `JsonFileRepository(file, <MapSerializer>)` or SQL via
+`SqliteRepository.fileBacked(path, <SqlTableDef>)`:
 
 ```kotlin
-import net.transgressoft.commons.fx.music.FXMusicLibrary
-import net.transgressoft.commons.persistence.fx.music.audio.FXAudioItemSqlTableDef
-import net.transgressoft.commons.persistence.fx.music.audio.ObservableAudioItemMapSerializer
-import net.transgressoft.commons.persistence.fx.music.playlist.ObservablePlaylistMapSerializer
-import net.transgressoft.commons.media.persistence.waveform.AudioWaveformMapSerializer
-import net.transgressoft.lirp.persistence.json.JsonFileRepository
-import net.transgressoft.lirp.persistence.sql.SqliteRepository
-
-val fxLibrary = FXMusicLibrary.builder()
-    .audioRepository(JsonFileRepository(File("audio-library.json"), ObservableAudioItemMapSerializer))
-    .playlistRepository(JsonFileRepository(File("playlists.json"), ObservablePlaylistMapSerializer, loadOnInit = false))
-    .waveformRepository(JsonFileRepository(File("waveforms.json"), AudioWaveformMapSerializer))
+val library = CoreMusicLibrary.builder()
+    .audioRepository(JsonFileRepository(File("audio-library.json"), AudioItemMapSerializer))
+    .playlistRepository(JsonFileRepository(File("playlists.json"), AudioPlaylistMapSerializer))
     .build()
-
-// Library-managed SQL persistence -- add a JDBC driver (e.g. org.xerial:sqlite-jdbc) to your build;
-// FXAudioItemSqlTableDef (from music-commons-persistence-fx) is a ready SqlTableDef<ObservableAudioItem>
-val fxLibrary = FXMusicLibrary.builder()
-    .audioRepository(SqliteRepository.fileBacked(Path.of("audio-library.db"), FXAudioItemSqlTableDef))
-    .build()
-
-// Bind directly to JavaFX UI components
-tableView.itemsProperty().bind(fxLibrary.audioItemsProperty)
-
-// Derive counts from the ordered album/genre list properties
-val albumCount = fxLibrary.albumsProperty.sizeProperty()
-albumCountLabel.textProperty().bind(albumCount.asString())
-val genreCount = fxLibrary.genreIndexesProperty.sizeProperty()
-genreCountLabel.textProperty().bind(genreCount.asString())
-
-// albumsProperty and genreIndexesProperty are ReadOnlyListProperty — ordered and index-addressable
-// Buckets are ordered: albums by name → artist → year (blank/unknown last); genres by Genre natural order (Genre.None first)
-val firstAlbum = fxLibrary.albumsProperty[0]       // index access on the ordered list
-val firstGenre = fxLibrary.genreIndexesProperty[0] // Genre.None bucket when untagged tracks exist
-
-// Flat sets (e.g. for filtering or display): derived on demand from the list, not live-bound properties
-val allAlbums = fxLibrary.albumsProperty.map { it.album }.toSet()
-val allGenres = fxLibrary.genreIndexesProperty.map { it.genre }.toSet()
-
-// Album and genre index lists are observable for list/grid binding
-fxLibrary.albumsProperty.addListener { _, _, _ -> /* refresh album browser */ }
-fxLibrary.genreIndexesProperty.addListener { _, _, _ -> /* refresh genre browser */ }
-
-// Large create bursts are coalesced before the FX-facing projections refresh,
-// so bound controls converge after import bursts instead of repainting per item.
-
-// Reactive playlist updates
-fxLibrary.playlistsProperty.addListener { _, _, _ -> /* refresh UI */ }
-
-// Create playlists
-val playlist = fxLibrary.createPlaylist("Favorites")
-
-// Add audio items
-fxLibrary.audioItemFromFile(Path.of("/path/to/song.mp3"))
-
-// Lifecycle
-fxLibrary.close()
 ```
 
-### Audio Playback
+For JavaFX, `FXMusicLibrary.builder()` exposes the same domain as observable properties bindable
+directly to `TableView`/`ListView` and friends. See the
+[Audio Library](https://github.com/octaviospain/music-commons/wiki/Audio-Library) wiki page.
+
+## Features
+
+Each feature has a dedicated wiki page with the full API and examples — this section is a summary.
+
+### Reactive audio library
+
+Audio items are indexed into three live projections that update incrementally as items are added,
+changed, or removed:
+
+- **Artist catalog** — multi-key: an item is bucketed under every artist it involves (primary,
+  album, and featured), so collaborations appear in each contributor's catalog.
+- **Album projection** — single-key: buckets are keyed by a canonical album identity (normalized
+  name + compilation-aware album artist), so per-track variance in year, label, or compilation
+  flag no longer fragments one logical album. Buckets are ordered by title.
+- **Genre index** — multi-key: multi-genre items appear in every matching bucket; untagged items
+  surface in a dedicated `Genre.None` bucket rather than being dropped.
+
+`Genre` is a sealed class with ~370 predefined constants plus a `Custom` variant that preserves
+unknown tags. Cover art is loaded lazily on first access. See
+[Audio Library](https://github.com/octaviospain/music-commons/wiki/Audio-Library).
+
+### Playlists
+
+Hierarchical playlist directories with M3U import/export (nested references and cycle detection),
+kept synchronized automatically when items change or are removed. See
+[Playlists](https://github.com/octaviospain/music-commons/wiki/Playlists).
+
+### Waveforms
+
+Asynchronous, cached waveform generation with normalized-amplitude caching (same-width requests
+return without audio I/O). JavaFX renders via `WaveformPane`, or `PlayableWaveformPane` for
+progress fill, playhead, and click/drag-to-seek. See
+[Waveforms](https://github.com/octaviospain/music-commons/wiki/Waveforms).
+
+### Audio playback
+
+`AudioItemPlayer` abstracts playback; `music-commons-media` provides a headless
+`CoreAudioItemPlayer` over JavaSound SPI decoders (MP3, FLAC, OGG Vorbis/Opus, AAC/ALAC-M4A, WAV)
+with format-specific seek precision, and `music-commons-fx` wraps it as `FXAudioItemPlayer` with
+observable `volumeProperty`/`statusProperty`/`currentTimeProperty`. Play count auto-increments at
+a 60% playback threshold.
 
 ```kotlin
-import net.transgressoft.commons.fx.music.player.JavaFxPlayer
+import net.transgressoft.commons.fx.music.player.FXAudioItemPlayer
+import javafx.util.Duration
 
-val player = JavaFxPlayer()
-
-// Play, pause, resume, stop
-player.play(audioItem)
-player.pause()
-player.resume()
-player.stop()
-
-// Monitor status and position
-player.statusProperty.addListener { _, _, newStatus -> println("Status: $newStatus") }
-player.currentTimeProperty.addListener { _, _, time -> println("Time: $time") }
-
-// Control volume and seek
+val player = FXAudioItemPlayer()
+player.play(song)
 player.setVolume(0.8)
-player.seek(30000.0) // seek to 30 seconds
-
+player.seek(Duration.seconds(30.0))
+player.statusProperty.addListener { _, _, status -> println("Status: $status") }
 player.dispose()
 ```
 
-#### Seek precision
+See [Audio Playback](https://github.com/octaviospain/music-commons/wiki/Audio-Playback).
 
-The `CoreAudioItemPlayer` (and `FXAudioItemPlayer`) resolve seek positions differently for each codec:
+### JavaFX integration
 
-| Format | Seek mechanism | Typical precision |
-|--------|---------------|-------------------|
-| **FLAC** | Byte-stream bisection to the nearest FLAC frame | ≤ 1 frame (~4096 samples ≈ 85 ms at 48 kHz) |
-| **MP3** | Xing/Info TOC lookup when present; frame-scan fallback for CBR | ≤ 1 MP3 frame (~26 ms at 48 kHz) |
-| **OGG Vorbis** | Ogg page bisection validates the target; PCM decoded forward to the exact offset | Sample-accurate, but seek cost grows linearly with position |
-| **WAV / AIFF** | Byte-aligned to the nearest PCM frame | Effectively sample-accurate (4 bytes for 16-bit stereo) |
-| **AAC / M4A** | Full-decode skip from the start (no TOC in the container) | Exact byte offset, but seek cost grows linearly with position |
+`FXMusicLibrary` exposes the domain as bindable observable properties — `audioItemsProperty`,
+`artistCatalogsProperty` (set), and the ordered `albumsProperty`/`genreIndexesProperty`
+(`ReadOnlyListProperty`, index-addressable). Burst updates during large imports are coalesced onto
+the JavaFX Application Thread so bound controls converge after the import instead of repainting per
+item.
 
-All formats clamp seek positions to `[0, totalDuration]`. The seek target is consumed by the pump
-thread on its next iteration, so there is a small delay between calling `seek()` and the position
-change becoming audible.
+### Persistence and error observability
 
-### Waveform Visualization (JavaFX)
+Persistence is transparent once a repository is injected — entity changes are written without
+manual save calls. Repositories flush and drain events asynchronously; wire a `LirpErrorHandler`
+via the `onError` constructor parameter to observe flush/event-drain failures that are otherwise
+log-only. The handler is notify-only and carries entity identity (not field values). See
+[SQL Persistence](https://github.com/octaviospain/music-commons/wiki/SQL-Persistence).
 
-```kotlin
-import net.transgressoft.commons.fx.music.waveform.WaveformPane
-import javafx.scene.paint.Color
+### Typed path validation
 
-// Static waveform (no playback controls)
-val waveformPane = WaveformPane()
-waveformPane.drawWaveformAsync(waveform, Color.CYAN, Color.BLACK)
-stackPane.children.add(waveformPane)
-```
+Audio-item construction and iTunes import throw typed exceptions for invalid paths —
+`InvalidAudioFilePathException` (missing/unreadable/non-regular file) and, on Windows,
+`WindowsPathException` carrying a `WindowsViolation` reason. See
+[Typed Exceptions](https://github.com/octaviospain/music-commons/wiki/Typed-Exceptions) and
+[Cross-Platform Paths](https://github.com/octaviospain/music-commons/wiki/Cross-Platform-Paths).
 
-#### Playback-Aware Waveform
+### iTunes import
 
-`PlayableWaveformPane` adds progress visualization, seek interaction, and a shimmer loading animation:
+`ItunesImportService` migrates tracks and playlists from an Apple Music / iTunes `library.xml`,
+returning a structured `ImportResult` (`imported`, `unresolved`, `rejectedPlaylistNames`).
+Filenames are normalized to Unicode NFC so macOS-origin libraries resolve on Linux and Windows.
+See [iTunes Import](https://github.com/octaviospain/music-commons/wiki/iTunes-Import).
 
-```kotlin
-import net.transgressoft.commons.fx.music.waveform.PlayableWaveformPane
-import net.transgressoft.commons.fx.music.waveform.SeekEvent
-
-val playablePane = PlayableWaveformPane()
-playablePane.loadWaveform(waveform)
-
-// Bind progress to player (0.0-1.0)
-player.currentTimeProperty.addListener { _, _, newTime ->
-    val total = player.totalDuration.toMillis()
-    if (total > 0) playablePane.progressProperty.set(newTime.toMillis() / total)
-}
-
-// Handle seek events (fires on mouse release)
-playablePane.addEventHandler(SeekEvent.SEEK) { event ->
-    player.seek(event.seekRatio * player.totalDuration.toMillis())
-}
-```
-
-## Building the Project
+## Building
 
 ```bash
-# Build all modules
-gradle build
-
-# Run tests
-gradle test
-
-# Generate aggregated coverage report
-gradle testCodeCoverageReport
-
-# Check code formatting
-gradle ktlintCheck
-
-# Generate documentation
-gradle dokkaHtml
+gradle build                    # Build all modules (compile + test + coverage)
+gradle test                     # Run tests
+gradle testCodeCoverageReport   # Aggregated coverage report
+gradle ktlintCheck              # Code style
+gradle dokkaGenerate            # HTML documentation
 ```
 
-## Migration Notes
+Each GitHub Release ships an aggregated CycloneDX SBOM scoped to the runtime classpaths of the
+published modules, and the build enforces SHA-256 dependency verification. Contributors bumping a
+dependency must regenerate the verification metadata — see
+[CONTRIBUTING.md](CONTRIBUTING.md) for the workflow and the supply-chain (Renovate, OSV-Scanner)
+details.
 
-### Album API Breaking Changes
+## Feature index
 
-The album and genre bucket types were renamed and simplified. If you are upgrading from an earlier version, update your source code according to the table below. **The JSON persistence format is unchanged** — existing library files remain readable without any data migration.
+Capabilities documented in the wiki rather than in this README:
 
-#### Renamed Types
-
-| Old name | New name | Notes |
-|----------|----------|-------|
-| `Album` (value type) | `AlbumDetails` | The `album` property on `ReactiveAudioItem` still exists; only its type changed |
-| `ReactiveAlbumCatalog` | `ReactiveAlbum` | Album bucket interface |
-| `ReactiveGenreCatalog` | `ReactiveGenreIndex` | Genre bucket interface |
-| `ObservableAlbumCatalog` | `ObservableAlbum` | FX album bucket interface |
-| `ObservableGenreCatalog` | `ObservableGenreIndex` | FX genre bucket interface |
-| `AlbumSet` | removed | Was a helper; replaced by `tracks: List<I>` on the bucket |
-| `AlbumView` | removed | Was a helper; replaced by `tracks: List<I>` on the bucket |
-
-#### Renamed Accessors and Publishers
-
-| Old accessor / publisher | New accessor / publisher |
-|--------------------------|--------------------------|
-| `getAlbumCatalog(album)` | `getAlbum(album)` |
-| `getGenreCatalog(genre)` | `getGenreIndex(genre)` |
-| `albumCatalogPublisher` | `albumPublisher` |
-| `genreCatalogPublisher` | `genreIndexPublisher` |
-| `albumCatalogsProperty` (FX) | `albumsProperty` |
-| `genreCatalogsProperty` (FX) | `genreIndexesProperty` |
-
-> The **Artist axis intentionally keeps** its `*Catalog` naming (`ReactiveArtistCatalog`,
-> `getArtistCatalog`, `artistCatalogPublisher`, `ObservableArtistCatalog`, etc.). Only the
-> Album and Genre axes were renamed.
-
-#### Bucket Members: `Set` → `List`
-
-`ReactiveAlbum.tracks` and `ReactiveGenreIndex.tracks` return `List<I>` instead of the former `Set`-based container. The list is ordered and deduplicated by lirp before it reaches the bucket — callers no longer need to sort or deduplicate the members.
-
-- Album buckets: ordered by disc number, then track number
-- Genre index buckets: ordered by artist name, then album name, then track number
-
-#### Ordered Album and Genre Buckets (FX: `ReadOnlySetProperty` → `ReadOnlyListProperty`)
-
-Album and genre buckets are now ordered. In the FX module this required changing the property types:
-
-| Property | Old type | New type | Order |
-|----------|----------|----------|-------|
-| `albumsProperty` | `ReadOnlySetProperty<ObservableAlbum>` | `ReadOnlyListProperty<ObservableAlbum>` | album name (case-insensitive) → album artist → year; blank/unknown-name albums last |
-| `genreIndexesProperty` | `ReadOnlySetProperty<ObservableGenreIndex>` | `ReadOnlyListProperty<ObservableGenreIndex>` | `Genre` natural order (ordinal); `Genre.None` first |
-| `artistCatalogsProperty` | `ReadOnlySetProperty<ObservableArtistCatalog>` | `ReadOnlySetProperty<ObservableArtistCatalog>` | unchanged — artist catalogs remain a set |
-
-The list properties are index-addressable (`albumsProperty[0]`, `genreIndexesProperty[0]`). Existing code that iterates or maps the properties continues to work as-is on a `List`. `toSet()` derivations are still valid. The **JSON persistence format is unchanged** — no data migration is required.
-
-**Migration:** change any declared type from `ReadOnlySetProperty<ObservableAlbum>` / `ReadOnlySetProperty<ObservableGenreIndex>` to `ReadOnlyListProperty<ObservableAlbum>` / `ReadOnlyListProperty<ObservableGenreIndex>`. `ListChangeListener` replaces `SetChangeListener` if you were wiring change listeners directly against the property type.
-
-#### Full-Value Album Identity
-
-`AlbumDetails` uses full structural equality (all fields). The former `Album` type used name-keyed equality within an artist, meaning two albums with the same name but different artists or years were considered equal. Under the new identity, each distinct combination of `(name, artist, year, isCompilation, label)` is a separate bucket.
-
-#### Navigation Helper
-
-A convenience extension function `item.albumIn(library)` is available to navigate from an audio item to its album bucket:
-
-```kotlin
-import net.transgressoft.commons.music.audio.albumIn
-
-val album: Optional<out ReactiveAlbum<*, AudioItem>> = item.albumIn(library)
-```
-
-## Supply Chain
-
-Each GitHub Release includes a CycloneDX SBOM artifact (`music-commons-sbom-cyclonedx`) — an aggregated `bom.json` describing the runtime classpaths of all six modules (`api`, `core`, `fx`, `media`, `test`, `fx-test`). Per-PR builds run GitHub Dependency Review and fail on HIGH+ severity CVEs. A weekly OSV-Scanner job uploads SARIF results to the repository Security tab.
-
-The build also enforces SHA-256 dependency verification via `gradle/verification-metadata.xml`: every resolved artifact is checked against its locked checksum on every Gradle invocation, defeating compromised-mirror and typosquat attacks. See [CONTRIBUTING.md](CONTRIBUTING.md) for the regeneration workflow contributors must run when bumping a dependency.
-
-Dependency hygiene is automated via [Renovate](https://docs.renovatebot.com/) (`renovate.json` at the repo root). Renovate opens weekly grouped pull requests — `gradle-libraries` (library bumps in `gradle/libs.versions.toml` and `build.gradle`), `kotlin` (Kotlin plugin + stdlib + KSP in lockstep), `github-actions` (workflow action SHAs, preserving the SHA-pin policy via the `helpers:pinGitHubActionDigests` preset), and `gradle-wrapper`. CVE-driven security PRs (`vulnerabilityAlerts`) bypass the weekly window and open at any time. Auto-merge is **disabled**: every Renovate PR is manually reviewed and merged.
-
-Renovate coexists with the global Transgressoft init script (`~/.gradle/init.d/transgressoft-updates.gradle`) without conflict — Renovate updates **declarations** in `gradle/libs.versions.toml` and `build.gradle`, while the init script operates at **dependency-resolution time** to align Transgressoft-published artifacts. The two act on different layers and never compete.
-
-**Owner action (post-merge, one-time):** for `renovate.json` to take effect, the [Renovate GitHub App](https://github.com/apps/renovate) must be installed on `octaviospain/music-commons`. Until installed, the configuration file is inert and no PRs will be opened. After installation, Renovate publishes a "Renovate: dependency dashboard" issue and begins its weekly cadence.
+| Feature | Wiki page |
+|---------|-----------|
+| Layered architecture and module dependencies | [Architecture](https://github.com/octaviospain/music-commons/wiki/Architecture) |
+| Reactive event flow and subscribers | [Reactive Events](https://github.com/octaviospain/music-commons/wiki/Reactive-Events) |
+| Album/genre projection ordering and lookups | [Audio Library](https://github.com/octaviospain/music-commons/wiki/Audio-Library) |
+| JSON and SQL persistence wiring | [SQL Persistence](https://github.com/octaviospain/music-commons/wiki/SQL-Persistence) |
+| Seek precision per codec | [Audio Playback](https://github.com/octaviospain/music-commons/wiki/Audio-Playback) |
+| Windows path rules and validation | [Windows Validation](https://github.com/octaviospain/music-commons/wiki/Windows-Validation) |
+| Cross-platform path handling | [Cross-Platform Paths](https://github.com/octaviospain/music-commons/wiki/Cross-Platform-Paths) |
+| Domain terminology | [Glossary](https://github.com/octaviospain/music-commons/wiki/Glossary) |
+| Version history and migration notes | [CHANGELOG.md](CHANGELOG.md) |
 
 ## Contributing
 
-Contributions are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for details.
+Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) for the development setup, test
+commands, branching/PR conventions, and code style.
 
-## License and Attributions
+## License and attributions
 
-Copyright (c) 2025-2026 Octavio Calleya Garcia.
+Copyright © 2025-2026 Octavio Calleya Garcia.
 
-Music Commons is free software under GNU GPL version 3 license, available [here](https://www.gnu.org/licenses/gpl-3.0.en.html#license-text).
+Music Commons is free software under the
+[GNU GPL version 3](https://www.gnu.org/licenses/gpl-3.0.en.html#license-text).
 
-This project builds upon several excellent open-source libraries:
+It builds on several open-source libraries, including:
 
-- **[JAudioTagger](https://github.com/ericfarng/jaudiotagger)**: Audio metadata reading and writing library
-- **JavaSound SPI providers** ([mp3spi](https://github.com/umjammer/mp3spi), [javasound-flac](https://github.com/Tianscar/javasound-flac), [javasound-vorbis](https://github.com/Tianscar/javasound-vorbis), [javasound-aac](https://github.com/Tianscar/javasound-aac), [JAAD](https://github.com/Almax/jaad), [javasound-alac](https://github.com/Tianscar/javasound-alac), [jse-spi-opus](https://github.com/jseproject/jse-spi)): pure-Java audio decoders for MP3, FLAC, OGG Vorbis, AAC/M4A, ALAC/M4A, and Opus/OGG; metadata and decoding use prioritized provider fallback, native FLAC seeks use the decoder's random-access path, generic compressed seeks discard decoded PCM to stay decoder-aligned, and playback volume scales signed PCM sample widths up to 32-bit. Opus-in-M4A is not supported (no pure-Java Maven Central SPI for Opus in ISO-BMFF/M4A containers).
-- **[Kotlin Coroutines](https://github.com/Kotlin/kotlinx.coroutines)**: Library support for Kotlin coroutines
-- **[kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization)**: Kotlin multiplatform serialization
-- **[lirp](https://github.com/octaviospain/lirp)**: Reactive entity framework and persistence infrastructure
-- **[Kotest](https://kotest.io/)**: Kotlin testing framework
-- **[MockK](https://mockk.io/)**: Mocking library for Kotlin
-- **[TestFX](https://github.com/TestFX/TestFX)**: JavaFX testing framework
+- **[lirp](https://github.com/octaviospain/lirp)** — reactive entity framework and persistence infrastructure
+- **[JAudioTagger](https://www.jthink.net/jaudiotagger/)** — audio metadata reading and writing
+- **JavaSound SPI providers** ([mp3spi](https://github.com/umjammer/mp3spi),
+  [javasound-flac](https://github.com/Tianscar/javasound-flac),
+  [javasound-vorbis](https://github.com/Tianscar/javasound-vorbis),
+  [javasound-aac](https://github.com/Tianscar/javasound-aac),
+  [javasound-alac](https://github.com/Tianscar/javasound-alac),
+  [jse-spi-opus](https://github.com/jseproject/jse-spi)) — pure-Java decoders for MP3, FLAC,
+  OGG Vorbis, AAC/ALAC-M4A, and Opus/OGG
+- **[Kotlin Coroutines](https://github.com/Kotlin/kotlinx.coroutines)** and
+  **[kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization)**
+- **[Kotest](https://kotest.io/)**, **[MockK](https://mockk.io/)**, and
+  **[TestFX](https://github.com/TestFX/TestFX)** for testing

--- a/d2/README.md
+++ b/d2/README.md
@@ -1,0 +1,44 @@
+# Diagram sources (`d2/`)
+
+This directory is the single source of truth for the project's diagrams. Each `.d2` file renders to
+an SVG that is committed into the **wiki** repository under `images/` and referenced from wiki
+pages as `![Description](images/<name>.svg)`.
+
+## Layout
+
+| Source | Rendered SVG (wiki) | Used by wiki page |
+|--------|---------------------|-------------------|
+| `architecture-modules.d2` | `images/architecture-modules.svg` | Architecture (Module Structure) |
+| `dependency-flow.d2` | `images/dependency-flow.svg` | Architecture (Dependency Flow) |
+| `type-hierarchy.d2` | `images/type-hierarchy.svg` | Architecture (Interface-First Design) |
+| `registry-projection-flow.d2` | `images/registry-projection-flow.svg` | Reactive Events |
+| `event-flow.d2` | `images/event-flow.svg` | Reactive Events |
+| `player-state.d2` | `images/player-state.svg` | Audio Playback |
+| `persistence-wiring.d2` | `images/persistence-wiring.svg` | SQL Persistence |
+| `exception-hierarchy.d2` | `images/exception-hierarchy.svg` | Typed Exceptions |
+
+## Rendering
+
+Requires [d2](https://d2lang.com) on the `PATH` (`d2 --version`). Render a single diagram into the
+wiki's `images/` directory (the wiki is a sibling checkout):
+
+```bash
+d2 d2/architecture-modules.d2 ../music-commons.wiki/images/architecture-modules.svg
+```
+
+Render all of them:
+
+```bash
+mkdir -p ../music-commons.wiki/images
+for f in d2/*.d2; do
+    d2 "$f" "../music-commons.wiki/images/$(basename "${f%.d2}").svg"
+done
+```
+
+## Adding a diagram
+
+1. Add a `<name>.d2` source file here.
+2. Add a row to the table above.
+3. Render it to `../music-commons.wiki/images/<name>.svg`.
+4. Reference it from the relevant wiki page with `![Description](images/<name>.svg)`.
+5. Commit the source here and the SVG in the wiki repo (they are separate git repositories).

--- a/d2/architecture-modules.d2
+++ b/d2/architecture-modules.d2
@@ -1,0 +1,26 @@
+# Module overview for Music Commons — the eight modules grouped by tier.
+# Render: d2 d2/architecture-modules.d2 ../music-commons.wiki/images/architecture-modules.svg
+
+title: |md
+  # Music Commons — modules
+| {near: top-center}
+
+reactive: Reactive modules {
+  style.fill: "#eef6ff"
+  api: "music-commons-api\ninterfaces & contracts (no impl, no SQL)"
+  core: "music-commons-core\nreactive in-memory implementations"
+  fx: "music-commons-fx\nJavaFX integration (observable properties, UI)"
+  media: "music-commons-media\nJavaFX-free playback + reactive waveforms"
+}
+
+persistence: Persistence-mapping modules (opt-in, mapping-only) {
+  style.fill: "#f3fff0"
+  p: "music-commons-persistence\nJSON serializers + SQL TableDefs for core"
+  pfx: "music-commons-persistence-fx\nJSON serializers + SQL TableDefs for FX"
+}
+
+test: Test-support modules {
+  style.fill: "#faf0ff"
+  t: "music-commons-test\nfactories + Kotest Arb generators"
+  tfx: "music-commons-fx-test\nJavaFX (TestFX / Monocle) test utilities"
+}

--- a/d2/dependency-flow.d2
+++ b/d2/dependency-flow.d2
@@ -1,0 +1,30 @@
+# Compile-dependency flow between modules. Arrow A -> B means "A depends on B".
+# Render: d2 d2/dependency-flow.d2 ../music-commons.wiki/images/dependency-flow.svg
+
+direction: right
+
+title: |md
+  # Module dependency flow
+| {near: top-center}
+
+api: music-commons-api {style.fill: "#eef6ff"}
+core: music-commons-core {style.fill: "#eef6ff"}
+fx: music-commons-fx {style.fill: "#eef6ff"}
+media: music-commons-media {style.fill: "#eef6ff"}
+persistence: music-commons-persistence {style.fill: "#f3fff0"}
+persistence_fx: music-commons-persistence-fx {style.fill: "#f3fff0"}
+lirp_sql: lirp-sql {style.fill: "#fff7e6"}
+
+core -> api: depends on
+fx -> core
+media -> core
+persistence -> core
+persistence_fx -> fx
+persistence_fx -> persistence
+persistence -> lirp_sql
+persistence_fx -> lirp_sql
+
+note: |md
+  The four reactive modules (api, core, fx, media) keep **lirp-sql** off their
+  compile classpaths — SQL mapping lives only in the persistence modules.
+| {near: bottom-center; style.font-size: 13}

--- a/d2/event-flow.d2
+++ b/d2/event-flow.d2
@@ -1,0 +1,23 @@
+# Reactive event propagation for PLAYED and DELETE events.
+# Render: d2 d2/event-flow.d2 ../music-commons.wiki/images/event-flow.svg
+
+direction: down
+
+title: |md
+  # Event flow — play-count and deletion cascades
+| {near: top-center}
+
+player: AudioItemPlayer {shape: rectangle; style.fill: "#fff7e6"}
+playedSub: PlayedEventSubscriber {shape: rectangle}
+library: "AudioLibrary\n(increments play count,\npublishes CrudEvent)" {shape: rectangle; style.fill: "#eef6ff"}
+itemSubPlaylist: "AudioItemEventSubscriber\n(playlist wiring)" {shape: rectangle}
+itemSubWaveform: "AudioItemEventSubscriber\n(waveform wiring)" {shape: rectangle}
+hierarchy: "PlaylistHierarchy\n(removes deleted items)" {shape: rectangle; style.fill: "#f3fff0"}
+waveforms: "AudioWaveformRepository\n(removes cached waveforms)" {shape: rectangle; style.fill: "#f3fff0"}
+
+player -> playedSub: PLAYED event
+playedSub -> library
+library -> itemSubPlaylist: DELETE
+library -> itemSubWaveform: DELETE
+itemSubPlaylist -> hierarchy
+itemSubWaveform -> waveforms

--- a/d2/exception-hierarchy.d2
+++ b/d2/exception-hierarchy.d2
@@ -1,0 +1,24 @@
+# Typed path-validation exception hierarchy. Arrow = "subclass of".
+# Render: d2 d2/exception-hierarchy.d2 ../music-commons.wiki/images/exception-hierarchy.svg
+
+direction: down
+
+title: |md
+  # Path-validation exception hierarchy
+| {near: top-center}
+
+base: "AudioItemManipulationException\n(open)" {style.fill: "#eef6ff"}
+invalid: "InvalidAudioFilePathException\n(open)" {style.fill: "#eef6ff"}
+windows: WindowsPathException {style.fill: "#fff7e6"}
+
+violation: "WindowsViolation (sealed)" {
+  style.fill: "#f3fff0"
+  ForbiddenChar
+  ReservedName
+  TrailingDotOrSpace
+  ExceedsMaxPath
+}
+
+invalid -> base: subclass of
+windows -> invalid: subclass of
+windows -> violation: carries

--- a/d2/persistence-wiring.d2
+++ b/d2/persistence-wiring.d2
@@ -1,0 +1,39 @@
+# How a consumer wires optional persistence into a library through the mapping modules.
+# Render: d2 d2/persistence-wiring.d2 ../music-commons.wiki/images/persistence-wiring.svg
+
+direction: right
+
+title: |md
+  # Persistence wiring (opt-in)
+| {near: top-center}
+
+consumer: Consumer code {shape: oval; style.fill: "#eef6ff"}
+builder: "CoreMusicLibrary.builder()\nFXMusicLibrary.builder()" {shape: rectangle}
+
+choice: Repository choice {
+  style.fill: "#f3fff0"
+  inmem: "(none)\nin-memory default" {shape: rectangle}
+  json: "JsonFileRepository(file, MapSerializer)" {shape: rectangle}
+  sql: "SqliteRepository.fileBacked(path, SqlTableDef)" {shape: rectangle}
+}
+
+mapping: Persistence-mapping modules {
+  style.fill: "#fff7e6"
+  ser: "MapSerializers\n(AudioItemMapSerializer, ...)" {shape: rectangle}
+  tabledef: "SqlTableDefs\n(MutableAudioItemSqlTableDef, ...)" {shape: rectangle}
+  conv: "ColumnConverters\n(GenreConverter, CountryConverter)" {shape: rectangle}
+}
+
+entities: "Real reactive entities\n(AudioItem, playlists, waveforms)" {shape: rectangle}
+
+consumer -> builder: build()
+builder -> choice.inmem
+builder -> choice.json
+builder -> choice.sql
+choice.inmem -> entities: constructs only
+choice.json -> entities: persists + reloads
+choice.sql -> entities: persists + reloads
+choice.json -> mapping.ser: uses
+choice.sql -> mapping.tabledef: uses
+mapping.tabledef -> mapping.conv: column mapping
+mapping -> entities: maps / reconstructs (construction SPI)

--- a/d2/player-state.d2
+++ b/d2/player-state.d2
@@ -1,0 +1,33 @@
+# AudioItemPlayer.Status lifecycle (music-commons-api / music-commons-media).
+# Render: d2 d2/player-state.d2 ../music-commons.wiki/images/player-state.svg
+
+title: |md
+  # AudioItemPlayer status lifecycle
+| {near: top-center}
+
+UNKNOWN: UNKNOWN\n(initial, no item loaded) {shape: circle}
+READY: READY\n(item loaded, idle)
+PLAYING: PLAYING\n(decoding to output line)
+PAUSED: PAUSED\n(position preserved)
+STOPPED: STOPPED\n(position reset to 0)
+STALLED: STALLED\n(decoder starved)
+HALTED: HALTED\n(halted abnormally; recoverable via play())
+DISPOSED: DISPOSED\n(resources released, terminal) {shape: circle; style.fill: "#ffeef0"}
+
+UNKNOWN -> READY: load item
+READY -> PLAYING: play()
+PLAYING -> PAUSED: pause()
+PAUSED -> PLAYING: resume()
+PLAYING -> STOPPED: stop()
+STOPPED -> PLAYING: play()
+PLAYING -> READY: playback finished
+PLAYING -> STALLED: buffer underrun
+STALLED -> PLAYING: recovers
+STALLED -> HALTED: sustained starvation
+PLAYING -> HALTED: abnormal exit
+HALTED -> PLAYING: play()
+
+READY -> DISPOSED: dispose()
+PLAYING -> DISPOSED: dispose()
+PAUSED -> DISPOSED: dispose()
+STOPPED -> DISPOSED: dispose()

--- a/d2/registry-projection-flow.d2
+++ b/d2/registry-projection-flow.d2
@@ -1,0 +1,25 @@
+# How an audio-item CRUD change propagates to a projection bucket and out as a catalog event.
+# Render: d2 d2/registry-projection-flow.d2 ../music-commons.wiki/images/registry-projection-flow.svg
+
+direction: right
+
+title: |md
+  # Registry projection flow (item change to bucket event)
+| {near: top-center}
+
+crud: "Audio item\ncreated / updated / removed" {shape: oval; style.fill: "#eef6ff"}
+extractor: "Key extractor\n(single-key: album identity\nmulti-key: artists, genres)" {shape: rectangle}
+registry: "lirp registry projection\n(re-buckets incrementally)" {shape: rectangle; style.fill: "#f3fff0"}
+bucket: "Bucket change\n(add / update / remove member)" {shape: rectangle}
+event: "CrudEvent published\non catalog / album / genre publisher" {shape: rectangle; style.fill: "#fff7e6"}
+
+fx: "FX two-phase projection" {
+  style.fill: "#ffeef0"
+  transform: "background dataTransform" {shape: rectangle}
+  factory: "FX-thread fxFactory\n(Platform.runLater, coalesced)" {shape: rectangle}
+  prop: "Observable property refreshes\n(albumsProperty, genreIndexesProperty, ...)" {shape: rectangle}
+  transform -> factory -> prop
+}
+
+crud -> extractor -> registry -> bucket -> event
+event -> fx.transform: FX consumers subscribe

--- a/d2/type-hierarchy.d2
+++ b/d2/type-hierarchy.d2
@@ -1,0 +1,56 @@
+# Interface-first layering: api contracts, core (headless), fx (JavaFX).
+# Dashed arrow = "implements / narrows". Render:
+# d2 d2/type-hierarchy.d2 ../music-commons.wiki/images/type-hierarchy.svg
+
+direction: down
+
+title: |md
+  # Interface-first type layering
+| {near: top-center}
+
+classes: {
+  impl: {style: {stroke-dash: 3}}
+}
+
+api: music-commons-api (contracts) {
+  style.fill: "#eef6ff"
+  MusicLibrary
+  ReactiveAudioLibrary
+  ReactiveAudioItem
+  AudioPlaylist
+  ReactiveAudioPlaylist
+  projections: "ReactiveArtistCatalog\nReactiveAlbum / ReactiveGenreIndex"
+
+  ReactiveAudioPlaylist -> AudioPlaylist: extends {class: impl}
+}
+
+core: music-commons-core (headless) {
+  style.fill: "#f3fff0"
+  CoreMusicLibrary
+  AudioLibrary
+  AudioItem
+  MutableAudioPlaylist
+}
+
+fx: music-commons-fx (JavaFX) {
+  style.fill: "#fff7e6"
+  FXMusicLibrary
+  ObservableAudioLibrary
+  ObservableAudioItem
+  ObservablePlaylist
+  fxprojections: "ObservableArtistCatalog\nObservableAlbum / ObservableGenreIndex"
+}
+
+core.CoreMusicLibrary -> api.MusicLibrary: implements {class: impl}
+fx.FXMusicLibrary -> api.MusicLibrary: implements {class: impl}
+
+core.AudioLibrary -> api.ReactiveAudioLibrary: narrows {class: impl}
+fx.ObservableAudioLibrary -> api.ReactiveAudioLibrary: narrows + observable {class: impl}
+
+core.AudioItem -> api.ReactiveAudioItem: implements {class: impl}
+fx.ObservableAudioItem -> api.ReactiveAudioItem: implements + JavaFX props {class: impl}
+
+core.MutableAudioPlaylist -> api.ReactiveAudioPlaylist: implements {class: impl}
+fx.ObservablePlaylist -> api.ReactiveAudioPlaylist: implements + observable {class: impl}
+
+fx.fxprojections -> api.projections: observable views {class: impl}

--- a/music-commons-api/README.md
+++ b/music-commons-api/README.md
@@ -11,11 +11,12 @@ This module provides a reactive, repository-based API for managing music librari
 ### `audio`
 Core music library abstractions for managing audio items and their metadata.
 
+- **`MusicLibrary`** - Unified facade contract implemented by both the headless and JavaFX libraries, enabling library-agnostic consumers
 - **`ReactiveAudioItem`** - Audio file representation with comprehensive metadata (artist, album, genre, etc.)
-- **`AudioLibrary`** - Repository for CRUD operations on audio items with reactive event publishing
-- **`Artist`**, **`Album`**, **`Label`**, **`Genre`** - Metadata domain models
-- **`ArtistCatalog`**, **`Albumset`** - Aggregated views of an artist album and its audio items
-- **`AudioFileType`** - Supported formats: MP3, M4A, WAV, FLAC
+- **`ReactiveAudioLibrary`** - Repository for CRUD operations on audio items with reactive event publishing
+- **`Artist`**, **`AlbumDetails`**, **`Label`**, **`Genre`** - Metadata domain models
+- **`ReactiveArtistCatalog`**, **`ReactiveAlbum`**, **`ReactiveGenreIndex`** - Live per-artist, per-album, and per-genre projections of the library
+- **`AudioFileType`** - Supported formats: MP3, M4A (AAC and ALAC), WAV, FLAC, and OGG (Vorbis and Opus)
 
 ### `player`
 Audio playback control interfaces.
@@ -47,8 +48,8 @@ Audio waveform visualization.
 ## Usage Pattern
 
 ```kotlin
-// Create audio library instance (implementation-specific)
-val library: AudioLibrary<MyAudioItem> = ...
+// Obtain a library through a concrete facade (CoreMusicLibrary / FXMusicLibrary)
+val library: ReactiveAudioLibrary<MyAudioItem, *, *, *> = ...
 
 // Subscribe to library changes
 library.subscribe(object : Flow.Subscriber<CrudEvent<Int, MyAudioItem>> {
@@ -60,18 +61,18 @@ library.subscribe(object : Flow.Subscriber<CrudEvent<Int, MyAudioItem>> {
 // Load audio files asynchronously (default batch size: 500)
 val audioItems = library.createFromFileBatchAsync(paths).get()
 
-// Query artist catalog
-val artistView = library.getArtistCatalog(artist)
+// Query the artist catalog projection
+val artistCatalog = library.getArtistCatalog(artist)
 
-// Create and manage playlists
-val hierarchy: PlaylistHierarchy<MyAudioItem, MyPlaylist> = ...
-val playlist = hierarchy.createPlaylist("My Favorites", audioItems)
+// Create and manage playlists (createPlaylist takes audio-item IDs)
+val hierarchy: ReactivePlaylistHierarchy<MyAudioItem, MyPlaylist> = ...
+val playlist = hierarchy.createPlaylist("My Favorites", audioItems.map { it.id })
 playlist.exportToM3uFile(outputPath)
 
 // Play audio
 val player: AudioItemPlayer = ...
 player.play(audioItem)
-player.volumeProperty.set(0.8)
+player.setVolume(0.8)
 ```
 
 ## License

--- a/music-commons-api/src/main/kotlin/net/transgressoft/commons/music/audio/AudioMetadataIO.kt
+++ b/music-commons-api/src/main/kotlin/net/transgressoft/commons/music/audio/AudioMetadataIO.kt
@@ -16,7 +16,7 @@ interface AudioMetadataIO {
      * Reads tag and header metadata from the audio file at [path] and returns a populated
      * [AudioItemMetadata].
      *
-     * Implementations fall back to safe defaults (empty title, [UnknownArtist], [UnknownAlbum],
+     * Implementations fall back to safe defaults (empty title, [Artist.UNKNOWN], [AlbumDetails.UNKNOWN],
      * empty genre set) when the file's tag block is unreadable or absent. Cover image bytes are
      * not included on this path — call [loadCover] when needed.
      *

--- a/music-commons-api/src/main/kotlin/net/transgressoft/commons/music/audio/Genre.kt
+++ b/music-commons-api/src/main/kotlin/net/transgressoft/commons/music/audio/Genre.kt
@@ -45,6 +45,13 @@ sealed class Genre(open val name: String) : Comparable<Genre> {
      */
     data object None : Genre("")
 
+    /**
+     * A genre whose name was not found in the predefined whitelist of known genres.
+     *
+     * Preserves the original tag string verbatim rather than discarding or mapping it to a fallback,
+     * ensuring round-trip fidelity for niche or user-defined genre values. The name must not be blank
+     * (reserved for [None]) and must not contain commas (which would be ambiguous as a delimiter).
+     */
     data class Custom(override val name: String) : Genre(name) {
         init {
             // A blank name is reserved for the [None] sentinel: an empty name is compareTo-equal to None

--- a/music-commons-api/src/main/kotlin/net/transgressoft/commons/music/audio/GenreDefinitions.kt
+++ b/music-commons-api/src/main/kotlin/net/transgressoft/commons/music/audio/GenreDefinitions.kt
@@ -17,6 +17,14 @@
 
 package net.transgressoft.commons.music.audio
 
+/**
+ * Predefined standard genre constants sourced from the
+ * [whatlastgenre whitelist](https://github.com/YetAnotherNerd/whatlastgenre).
+ *
+ * Each singleton is a [Genre] subtype keyed by its display name. Use these constants when
+ * constructing or comparing genre values to avoid raw string allocation and to benefit from
+ * identity-level equality checks. Genres not present here should use [Genre.Custom].
+ */
 data object Abstract : Genre("Abstract")
 
 data object AbstractHipHop : Genre("Abstract Hip Hop")

--- a/music-commons-api/src/main/kotlin/net/transgressoft/commons/music/audio/ReactiveAudioItem.kt
+++ b/music-commons-api/src/main/kotlin/net/transgressoft/commons/music/audio/ReactiveAudioItem.kt
@@ -37,22 +37,58 @@ import kotlinx.serialization.json.put
  */
 interface ReactiveAudioItem<I: ReactiveAudioItem<I>>: ReactiveEntity<Int, I>, Comparable<I> {
 
+    /** Absolute path to the audio file on disk. */
     val path: Path
+
+    /** File name including extension, derived from [path]. */
     val fileName: String
+
+    /** File extension without the leading dot (e.g. `"mp3"`, `"flac"`). */
     val extension: String
+
+    /** Track title as stored in the file's tag. */
     var title: String
+
+    /** Playback duration of the audio file. */
     val duration: Duration
+
+    /** Bit rate of the audio stream in kbps. */
     val bitRate: Int
+
+    /** Primary credited artist for this track. */
     var artist: Artist
+
+    /**
+     * All artists involved in this track, including the primary [artist] and any featured or
+     * contributing artists encoded in the tag.
+     */
     val artistsInvolved: Set<Artist>
+
+    /** Album to which this track belongs, including album-level metadata. */
     var album: AlbumDetails
+
+    /** Set of genres associated with this track. An empty set means untagged. */
     var genres: Set<Genre>
+
+    /** Free-text comment stored in the tag, or `null` if absent. */
     var comments: String?
+
+    /** Track number within its disc, or `null` if not tagged. */
     var trackNumber: Short?
+
+    /** Disc number within the album, or `null` if not tagged. */
     var discNumber: Short?
+
+    /** Beats per minute, or `null` if not tagged. */
     var bpm: Float?
+
+    /** Encoder tool or settings string from the tag, or `null` if absent. */
     val encoder: String?
+
+    /** Audio encoding format identifier (e.g. codec name), or `null` if absent. */
     val encoding: String?
+
+    /** File size in bytes. */
     val length: Long
 
     /**
@@ -64,7 +100,11 @@ interface ReactiveAudioItem<I: ReactiveAudioItem<I>>: ReactiveEntity<Int, I>, Co
      * must go through the setter so reactive change notifications are published.
      */
     var coverImageBytes: ByteArray?
+
+    /** Timestamp when the track entry was first created in the library. */
     val dateOfCreation: LocalDateTime
+
+    /** Number of times this track has been played. */
     val playCount: Short
 
     /**
@@ -90,11 +130,21 @@ interface ReactiveAudioItem<I: ReactiveAudioItem<I>>: ReactiveEntity<Int, I>, Co
      */
     fun mutate(action: I.() -> Unit)
 
+    /**
+     * Returns a JSON string with this item's numeric ID as the key and its full metadata object as the value.
+     *
+     * @return JSON object string suitable for embedding in a larger JSON map
+     */
     fun asJsonKeyValue() =
         buildJsonObject {
             put("$id", toJsonObject())
         }.toString()
 
+    /**
+     * Returns a JSON string containing only this item's metadata object, without a surrounding key.
+     *
+     * @return JSON object string of this item's full metadata
+     */
     fun asJsonValue() = toJsonObject().toString()
 }
 

--- a/music-commons-api/src/main/kotlin/net/transgressoft/commons/music/player/event/AudioItemPlayerEvent.kt
+++ b/music-commons-api/src/main/kotlin/net/transgressoft/commons/music/player/event/AudioItemPlayerEvent.kt
@@ -27,6 +27,7 @@ import net.transgressoft.lirp.event.LirpEvent
  */
 sealed class AudioItemPlayerEvent : LirpEvent<AudioItemPlayerEvent.Type> {
 
+    /** The audio item that triggered this event. */
     abstract val audioItem: ReactiveAudioItem<*>
 
     /**

--- a/music-commons-api/src/main/kotlin/net/transgressoft/commons/music/playlist/AudioPlaylist.kt
+++ b/music-commons-api/src/main/kotlin/net/transgressoft/commons/music/playlist/AudioPlaylist.kt
@@ -34,6 +34,10 @@ import kotlin.io.path.exists
  */
 interface AudioPlaylist<I : ReactiveAudioItem<I>> : IdentifiableEntity<Int>, Comparable<AudioPlaylist<I>> {
 
+    /**
+     * Stable, human-readable identity string used for sorting and equality checks. Prefixed
+     * with `"D-"` for directory playlists so directories sort predictably alongside leaf playlists.
+     */
     override val uniqueId: String
         get() {
             return buildString {
@@ -44,12 +48,18 @@ interface AudioPlaylist<I : ReactiveAudioItem<I>> : IdentifiableEntity<Int>, Com
             }
         }
 
+    /** Whether this playlist acts as a directory that contains nested playlists. */
     val isDirectory: Boolean
 
+    /** Display name of this playlist, unique within its parent directory. */
     val name: String
 
+    /** Ordered list of audio items directly held by this playlist. */
     val audioItems: List<I>
 
+    /**
+     * Flattened list of all audio items in this playlist and all nested [playlists], in depth-first order.
+     */
     val audioItemsRecursive: List<I>
         get() =
             buildList {
@@ -57,10 +67,21 @@ interface AudioPlaylist<I : ReactiveAudioItem<I>> : IdentifiableEntity<Int>, Com
                 addAll(playlists.stream().flatMap { it.audioItemsRecursive.stream() }.toList())
             }
 
+    /** Nested playlists directly contained within this playlist directory. Empty for leaf playlists. */
     val playlists: Set<AudioPlaylist<I>>
 
+    /**
+     * Returns `true` if all audio items in this playlist satisfy [predicate].
+     *
+     * @param predicate the condition to test against each item
+     */
     fun audioItemsAllMatch(predicate: Predicate<I>) = audioItems.stream().allMatch { predicate.test(it) }
 
+    /**
+     * Returns `true` if at least one audio item in this playlist satisfies [predicate].
+     *
+     * @param predicate the condition to test against each item
+     */
     fun audioItemsAnyMatch(predicate: Predicate<I>) = audioItems.stream().anyMatch { predicate.test(it) }
 
     /**
@@ -114,6 +135,12 @@ interface AudioPlaylist<I : ReactiveAudioItem<I>> : IdentifiableEntity<Int>, Com
         }
     }
 
+    /**
+     * Returns a JSON snippet with this playlist's numeric ID as the key and its metadata as the value,
+     * including the audio item IDs and nested playlist IDs.
+     *
+     * @return JSON key-value string suitable for embedding in a larger JSON map
+     */
     fun asJsonKeyValue(): String {
         val audioItemsString =
             buildString {

--- a/music-commons-api/src/main/kotlin/net/transgressoft/commons/music/playlist/ReactiveAudioPlaylist.kt
+++ b/music-commons-api/src/main/kotlin/net/transgressoft/commons/music/playlist/ReactiveAudioPlaylist.kt
@@ -27,10 +27,17 @@ import net.transgressoft.lirp.entity.ReactiveEntity
  */
 interface ReactiveAudioPlaylist<I : ReactiveAudioItem<I>, P : ReactiveAudioPlaylist<I, P>> : AudioPlaylist<I>, ReactiveEntity<Int, P> {
 
+    /** Mutable display name of this playlist. Changing this value publishes a reactive mutation event. */
     override var name: String
 
+    /** Mutable directory flag. Changing this value publishes a reactive mutation event. */
     override var isDirectory: Boolean
 
+    /**
+     * Adds [audioItem] to this playlist. Convenience delegate for [addAudioItems].
+     *
+     * @return `true` if the playlist changed as a result of this call
+     */
     fun addAudioItem(audioItem: I): Boolean = addAudioItems(listOf(audioItem))
 
     /**
@@ -41,34 +48,88 @@ interface ReactiveAudioPlaylist<I : ReactiveAudioItem<I>, P : ReactiveAudioPlayl
      */
     fun addAudioItems(audioItems: Collection<I>): Boolean
 
+    /**
+     * Removes [audioItem] from this playlist. Convenience delegate for [removeAudioItems].
+     *
+     * @return `true` if the playlist changed as a result of this call
+     */
     fun removeAudioItem(audioItem: I): Boolean = removeAudioItems(listOf(audioItem))
 
+    /**
+     * Removes the audio item with [audioItemId] from this playlist. Convenience delegate for [removeAudioItems].
+     *
+     * @return `true` if the playlist changed as a result of this call
+     */
     fun removeAudioItem(audioItemId: Int): Boolean = removeAudioItems(listOf(audioItemId))
 
+    /**
+     * Removes all occurrences of each item in [audioItems] from this playlist.
+     *
+     * @return `true` if the playlist changed as a result of this call
+     */
     fun removeAudioItems(audioItems: Collection<I>): Boolean
 
     // @JvmName required on generic interface methods to avoid JVM signature clashes with Java callers
+
+    /**
+     * Removes audio items whose IDs are in [audioItemIds] from this playlist.
+     *
+     * @return `true` if the playlist changed as a result of this call
+     */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("removeAudioItemIds")
     fun removeAudioItems(audioItemIds: Collection<Int>): Boolean
 
+    /**
+     * Adds [playlist] as a nested child of this directory playlist. Convenience delegate for [addPlaylists].
+     *
+     * @return `true` if the set of nested playlists changed as a result of this call
+     */
     fun addPlaylist(playlist: P): Boolean = addPlaylists(listOf(playlist))
 
+    /**
+     * Adds all playlists in [playlists] as nested children of this directory playlist.
+     *
+     * @return `true` if the set of nested playlists changed as a result of this call
+     */
     fun addPlaylists(playlists: Collection<P>): Boolean
 
+    /**
+     * Removes the nested playlist with [playlistId] from this directory playlist. Convenience delegate for [removePlaylists].
+     *
+     * @return `true` if the set of nested playlists changed as a result of this call
+     */
     fun removePlaylist(playlistId: Int): Boolean = removePlaylists(listOf(playlistId))
 
+    /**
+     * Removes [playlist] from this directory playlist. Convenience delegate for [removePlaylists].
+     *
+     * @return `true` if the set of nested playlists changed as a result of this call
+     */
     fun removePlaylist(playlist: P): Boolean = removePlaylists(listOf(playlist))
 
+    /**
+     * Removes all playlists in [playlists] from this directory playlist.
+     *
+     * @return `true` if the set of nested playlists changed as a result of this call
+     */
     fun removePlaylists(playlists: Collection<P>): Boolean
 
+    /**
+     * Removes nested playlists whose IDs are in [playlistIds] from this directory playlist.
+     *
+     * @return `true` if the set of nested playlists changed as a result of this call
+     */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("removePlaylistIds")
     fun removePlaylists(playlistIds: Collection<Int>): Boolean
 
+    /** Removes all audio items from this playlist, leaving it empty. */
     fun clearAudioItems()
 
+    /** Removes all nested playlists from this directory playlist. */
     fun clearPlaylists()
 
+    /** The set of nested playlists directly contained within this playlist directory. */
     override val playlists: Set<P>
 }

--- a/music-commons-api/src/main/kotlin/net/transgressoft/commons/music/playlist/ReactivePlaylistHierarchy.kt
+++ b/music-commons-api/src/main/kotlin/net/transgressoft/commons/music/playlist/ReactivePlaylistHierarchy.kt
@@ -37,9 +37,24 @@ interface ReactivePlaylistHierarchy<I: ReactiveAudioItem<I>, P: ReactiveAudioPla
     LirpEventSubscriber<I, CrudEvent.Type, CrudEvent<Int, I>>,
     Flow.Publisher<CrudEvent<Int, P>> {
 
+    /**
+     * Creates and registers a new empty playlist with [name].
+     *
+     * @param name unique name for the new playlist
+     * @return the newly created playlist
+     * @throws IllegalArgumentException if a playlist with [name] already exists
+     */
     @Throws(IllegalArgumentException::class)
     fun createPlaylist(name: String): P
 
+    /**
+     * Creates and registers a new playlist with [name] pre-populated with [audioItems].
+     *
+     * @param name unique name for the new playlist
+     * @param audioItems typed audio items to include in the playlist
+     * @return the newly created playlist
+     * @throws IllegalArgumentException if a playlist with [name] already exists
+     */
     @Throws(IllegalArgumentException::class)
     fun createPlaylist(
         name: String,
@@ -66,50 +81,121 @@ interface ReactivePlaylistHierarchy<I: ReactiveAudioItem<I>, P: ReactiveAudioPla
         audioItemIds: List<Int>
     ): P
 
+    /**
+     * Creates and registers a new empty playlist directory with [name].
+     *
+     * @param name unique name for the new directory
+     * @return the newly created playlist directory
+     * @throws IllegalArgumentException if a playlist with [name] already exists
+     */
     @Throws(IllegalArgumentException::class)
     fun createPlaylistDirectory(name: String): P
 
+    /**
+     * Creates and registers a new playlist directory with [name] pre-populated with [audioItems].
+     *
+     * @param name unique name for the new directory
+     * @param audioItems typed audio items to include in the directory playlist
+     * @return the newly created playlist directory
+     * @throws IllegalArgumentException if a playlist with [name] already exists
+     */
     @Throws(IllegalArgumentException::class)
     fun createPlaylistDirectory(
         name: String,
         audioItems: List<I>
     ): P
 
+    /**
+     * Finds a playlist by its exact [name].
+     *
+     * @param name the name to search for
+     * @return an [Optional] containing the matching playlist, or empty if not found
+     */
     fun findByName(name: String): Optional<out P>
 
+    /**
+     * Finds the direct parent directory playlist that contains [playlist].
+     *
+     * @param playlist the playlist whose parent is to be located
+     * @return an [Optional] containing the parent directory, or empty if [playlist] is a root-level entry
+     */
     fun findParentPlaylist(playlist: ReactiveAudioPlaylist<I, P>): Optional<out P>
 
+    /**
+     * Moves the playlist named [playlistNameToMove] into the directory playlist named [destinationPlaylistName].
+     *
+     * @param playlistNameToMove name of the playlist to relocate
+     * @param destinationPlaylistName name of the target directory playlist
+     */
     fun movePlaylist(
         playlistNameToMove: String,
         destinationPlaylistName: String
     )
 
+    /**
+     * Adds [audioItem] to the playlist named [playlistName]. Convenience delegate for [addAudioItemsToPlaylist].
+     *
+     * @return `true` if the target playlist changed as a result of this call
+     */
     fun addAudioItemToPlaylist(
         audioItem: I,
         playlistName: String
     ): Boolean = addAudioItemsToPlaylist(listOf(audioItem), playlistName)
 
+    /**
+     * Adds all items in [audioItems] to the playlist named [playlistName].
+     *
+     * @param audioItems items to add
+     * @param playlistName name of the target playlist
+     * @return `true` if the target playlist changed as a result of this call
+     */
     fun addAudioItemsToPlaylist(
         audioItems: Collection<I>,
         playlistName: String
     ): Boolean
 
+    /**
+     * Removes [audioItem] from the playlist named [playlistName]. Convenience delegate for [removeAudioItemsFromPlaylist].
+     *
+     * @return `true` if the target playlist changed as a result of this call
+     */
     fun removeAudioItemFromPlaylist(
         audioItem: I,
         playlistName: String
     ): Boolean = removeAudioItemsFromPlaylist(listOf(audioItem), playlistName)
 
+    /**
+     * Removes the audio item with [audioItemId] from the playlist named [playlistName].
+     * Convenience delegate for [removeAudioItemsFromPlaylist].
+     *
+     * @return `true` if the target playlist changed as a result of this call
+     */
     fun removeAudioItemFromPlaylist(
         audioItemId: Int,
         playlistName: String
     ): Boolean = removeAudioItemsFromPlaylist(listOf(audioItemId), playlistName)
 
+    /**
+     * Removes all items in [audioItems] from the playlist named [playlistName].
+     *
+     * @param audioItems items to remove
+     * @param playlistName name of the target playlist
+     * @return `true` if the target playlist changed as a result of this call
+     */
     fun removeAudioItemsFromPlaylist(
         audioItems: Collection<I>,
         playlistName: String
     ): Boolean
 
     // @JvmName required on generic interface methods to avoid JVM signature clashes with Java callers
+
+    /**
+     * Removes audio items whose IDs are in [audioItemIds] from the playlist named [playlistName].
+     *
+     * @param audioItemIds IDs of items to remove
+     * @param playlistName name of the target playlist
+     * @return `true` if the target playlist changed as a result of this call
+     */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("removeAudioItemIdsFromPlaylist")
     fun removeAudioItemsFromPlaylist(
@@ -117,21 +203,47 @@ interface ReactivePlaylistHierarchy<I: ReactiveAudioItem<I>, P: ReactiveAudioPla
         playlistName: String
     ): Boolean
 
+    /**
+     * Adds [playlistToAdd] into the directory playlist named [directoryName].
+     * Convenience delegate for [addPlaylistsToDirectory].
+     *
+     * @return `true` if the directory changed as a result of this call
+     */
     fun addPlaylistToDirectory(
         playlistToAdd: P,
         directoryName: String
     ): Boolean = addPlaylistsToDirectory(setOf(playlistToAdd), directoryName)
 
+    /**
+     * Adds the playlist named [playlistNameToAdd] into the directory playlist named [directoryName].
+     * Convenience delegate for [addPlaylistsToDirectory].
+     *
+     * @return `true` if the directory changed as a result of this call
+     */
     fun addPlaylistToDirectory(
         playlistNameToAdd: String,
         directoryName: String
     ): Boolean = addPlaylistsToDirectory(setOf(playlistNameToAdd), directoryName)
 
+    /**
+     * Adds all playlists in [playlistsToAdd] into the directory playlist named [directoryName].
+     *
+     * @param playlistsToAdd playlists to nest inside the directory
+     * @param directoryName name of the target directory playlist
+     * @return `true` if the directory changed as a result of this call
+     */
     fun addPlaylistsToDirectory(
         playlistsToAdd: Set<P>,
         directoryName: String
     ): Boolean
 
+    /**
+     * Adds playlists identified by name in [playlistNamesToAdd] into the directory playlist named [directoryName].
+     *
+     * @param playlistNamesToAdd names of playlists to nest inside the directory
+     * @param directoryName name of the target directory playlist
+     * @return `true` if the directory changed as a result of this call
+     */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("addPlaylistNamesToDirectory")
     fun addPlaylistsToDirectory(
@@ -139,21 +251,47 @@ interface ReactivePlaylistHierarchy<I: ReactiveAudioItem<I>, P: ReactiveAudioPla
         directoryName: String
     ): Boolean
 
+    /**
+     * Removes [playlistToRemove] from the directory playlist named [directoryName].
+     * Convenience delegate for [removePlaylistsFromDirectory].
+     *
+     * @return `true` if the directory changed as a result of this call
+     */
     fun removePlaylistFromDirectory(
         playlistToRemove: P,
         directoryName: String
     ): Boolean = removePlaylistsFromDirectory(setOf(playlistToRemove), directoryName)
 
+    /**
+     * Removes the playlist named [playlistNameToRemove] from the directory playlist named [directoryName].
+     * Convenience delegate for [removePlaylistsFromDirectory].
+     *
+     * @return `true` if the directory changed as a result of this call
+     */
     fun removePlaylistFromDirectory(
         playlistNameToRemove: String,
         directoryName: String
     ): Boolean = removePlaylistsFromDirectory(setOf(playlistNameToRemove), directoryName)
 
+    /**
+     * Removes all playlists in [playlistsToRemove] from the directory playlist named [directoryName].
+     *
+     * @param playlistsToRemove playlists to detach from the directory
+     * @param directoryName name of the target directory playlist
+     * @return `true` if the directory changed as a result of this call
+     */
     fun removePlaylistsFromDirectory(
         playlistsToRemove: Set<P>,
         directoryName: String
     ): Boolean
 
+    /**
+     * Removes playlists identified by name in [playlistsNamesToRemove] from the directory playlist named [directoryName].
+     *
+     * @param playlistsNamesToRemove names of playlists to detach from the directory
+     * @param directoryName name of the target directory playlist
+     * @return `true` if the directory changed as a result of this call
+     */
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("removePlaylistNamesFromDirectory")
     fun removePlaylistsFromDirectory(
@@ -161,7 +299,13 @@ interface ReactivePlaylistHierarchy<I: ReactiveAudioItem<I>, P: ReactiveAudioPla
         directoryName: String
     ): Boolean
 
+    /**
+     * Returns the total number of leaf playlists (non-directory) registered in this hierarchy.
+     */
     fun numberOfPlaylists(): Int
 
+    /**
+     * Returns the total number of directory playlists registered in this hierarchy.
+     */
     fun numberOfPlaylistDirectories(): Int
 }

--- a/music-commons-api/src/main/kotlin/net/transgressoft/commons/music/waveform/AudioWaveform.kt
+++ b/music-commons-api/src/main/kotlin/net/transgressoft/commons/music/waveform/AudioWaveform.kt
@@ -29,6 +29,7 @@ import kotlinx.coroutines.Dispatchers
  */
 interface AudioWaveform : ReactiveEntity<Int, AudioWaveform> {
 
+    /** Absolute path to the audio file from which this waveform was derived. */
     val audioFilePath: Path
 
     /**
@@ -46,7 +47,14 @@ interface AudioWaveform : ReactiveEntity<Int, AudioWaveform> {
     suspend fun amplitudes(width: Int, height: Int, dispatcher: CoroutineDispatcher = Dispatchers.IO): FloatArray
 
     /**
-     * Creates a visual image of the waveform with the specified colors and dimensions.
+     * Renders the waveform as an image file with the specified colors and dimensions.
+     *
+     * @param outputFile destination file to write the image to
+     * @param waveformColor color used to draw the amplitude bars
+     * @param backgroundColor color used to fill the image background
+     * @param width image width in pixels
+     * @param height image height in pixels
+     * @param dispatcher the coroutine dispatcher on which rendering runs; defaults to [Dispatchers.IO]
      */
     suspend fun createImage(
         outputFile: File,

--- a/music-commons-api/src/main/kotlin/net/transgressoft/commons/music/waveform/AudioWaveformRepository.kt
+++ b/music-commons-api/src/main/kotlin/net/transgressoft/commons/music/waveform/AudioWaveformRepository.kt
@@ -36,7 +36,14 @@ interface AudioWaveformRepository<W : AudioWaveform, I : ReactiveAudioItem<I>>
 : Repository<Int, W>, LirpEventSubscriber<I, CrudEvent.Type, CrudEvent<Int, I>> {
 
     /**
-     * Retrieves an existing waveform or creates a new one asynchronously for the given audio item.
+     * Retrieves an existing waveform or creates a new one asynchronously for the given audio item,
+     * using the provided coroutine [dispatcher] for amplitude computation.
+     *
+     * @param audioItem the audio item whose waveform is requested
+     * @param width desired waveform width in pixels
+     * @param height desired waveform height in pixels
+     * @param dispatcher coroutine dispatcher for the computation
+     * @return a [CompletableFuture] that completes with the waveform once ready
      */
     fun getOrCreateWaveformAsync(
         audioItem: I,
@@ -45,6 +52,16 @@ interface AudioWaveformRepository<W : AudioWaveform, I : ReactiveAudioItem<I>>
         dispatcher: CoroutineDispatcher
     ): CompletableFuture<W>
 
+    /**
+     * Retrieves an existing waveform or creates a new one asynchronously for the given audio item,
+     * using the provided Java [executor] as the coroutine dispatcher.
+     *
+     * @param audioItem the audio item whose waveform is requested
+     * @param width desired waveform width in pixels
+     * @param height desired waveform height in pixels
+     * @param executor Java executor to back the coroutine dispatcher
+     * @return a [CompletableFuture] that completes with the waveform once ready
+     */
     fun getOrCreateWaveformAsync(
         audioItem: I,
         width: Short,
@@ -52,12 +69,28 @@ interface AudioWaveformRepository<W : AudioWaveform, I : ReactiveAudioItem<I>>
         executor: Executor
     ): CompletableFuture<W> = getOrCreateWaveformAsync(audioItem, width, height, executor.asCoroutineDispatcher())
 
+    /**
+     * Retrieves an existing waveform or creates a new one asynchronously for the given audio item,
+     * using [Dispatchers.Default] as the coroutine dispatcher.
+     *
+     * @param audioItem the audio item whose waveform is requested
+     * @param width desired waveform width in pixels
+     * @param height desired waveform height in pixels
+     * @return a [CompletableFuture] that completes with the waveform once ready
+     */
     fun getOrCreateWaveformAsync(
         audioItem: I,
         width: Short,
         height: Short
     ): CompletableFuture<W> = getOrCreateWaveformAsync(audioItem, width, height, Dispatchers.Default)
 
+    /**
+     * Removes waveforms associated with audio items whose IDs are in [audioItemIds].
+     *
+     * Silently ignores IDs for which no waveform exists.
+     *
+     * @param audioItemIds set of audio item IDs whose waveforms should be removed
+     */
     fun removeByAudioItemIds(audioItemIds: Set<Int>) {
         audioItemIds.forEach { findById(it).ifPresent { waveform -> remove(waveform) } }
     }

--- a/music-commons-api/src/main/kotlin/net/transgressoft/commons/util/InvalidAudioFilePathException.kt
+++ b/music-commons-api/src/main/kotlin/net/transgressoft/commons/util/InvalidAudioFilePathException.kt
@@ -24,10 +24,9 @@ package net.transgressoft.commons.util
  * file not found, path is not a regular file, or file is not readable.
  *
  * Lives in `music-commons-api` and extends [Exception] directly rather than the core-resident
- * `AudioItemManipulationException`. The Phase 40 refactor decoupled path-validation errors from
- * file-IO errors so the api module owns the entire entity-construction contract without depending
- * on core. Consumers catching path-validation failures should catch this type or its subclass
- * `WindowsPathException`.
+ * `AudioItemManipulationException`. Path-validation errors are decoupled from file-IO errors so the
+ * api module owns the entire entity-construction contract without depending on core. Consumers catching
+ * path-validation failures should catch this type or its subclass `WindowsPathException`.
  */
 open class InvalidAudioFilePathException(message: String, cause: Throwable?) : Exception(message, cause) {
     constructor(message: String) : this(message, null)

--- a/music-commons-core/README.md
+++ b/music-commons-core/README.md
@@ -14,32 +14,35 @@ This module contains the concrete implementations of the interfaces defined in `
 
 ### Creating an Audio Library
 
+`CoreMusicLibrary.builder()` is the entry point; the `Default*` implementations are `internal` and
+are not instantiated directly. With no repository arguments the library is fully in-memory.
+
 ```kotlin
-// Set up a JSON-backed repository
-val repository = JsonFileRepository(file, AudioItemMapSerializer)
-val audioLibrary = DefaultAudioLibrary(repository)
+// In-memory, or inject a JSON/SQL repository from music-commons-persistence
+val library = CoreMusicLibrary.builder()
+    .audioRepository(JsonFileRepository(file, AudioItemMapSerializer))
+    .build()
 
 // Create audio items from files
-val audioItem = audioLibrary.createFromFile(audioFilePath)
+val audioItem = library.audioItemFromFile(audioFilePath)
 
 // Query by artist and album
-audioLibrary.findAlbumAudioItems(artist, albumName)
+library.findAlbumAudioItems(artist, albumName)
 
 // Batch creation with async support (default batch size: 500)
-audioLibrary.createFromFileBatchAsync(filePaths, executor)
-
-// With custom batch size
-audioLibrary.createFromFileBatchAsync(filePaths, executor, batchSize = 200)
+library.audioLibrary().createFromFileBatchAsync(filePaths).get()
 ```
 
 ### Managing Playlists
 
 ```kotlin
-val playlistRepository = JsonFileRepository(file, AudioPlaylistMapSerializer)
-val playlistHierarchy = DefaultPlaylistHierarchy(playlistRepository)
+val library = CoreMusicLibrary.builder()
+    .playlistRepository(JsonFileRepository(file, AudioPlaylistMapSerializer))
+    .build()
+val playlistHierarchy = library.playlistHierarchy()
 
-// Create playlists and directories
-val playlist = playlistHierarchy.createPlaylist("My Playlist", audioItems)
+// Create playlists and directories (createPlaylist takes audio-item IDs)
+val playlist = playlistHierarchy.createPlaylist("My Playlist", audioItems.map { it.id })
 val directory = playlistHierarchy.createPlaylistDirectory("Rock")
 
 // Build hierarchies
@@ -53,7 +56,7 @@ playlistHierarchy.findByName("Rock")
 ### Generating Waveforms
 
 ```kotlin
-val waveformRepository = DefaultAudioWaveformRepository()
+val waveformRepository = library.waveformRepository()
 
 // Generate waveform asynchronously
 val waveform = waveformRepository
@@ -109,11 +112,12 @@ All components support JSON serialization through kotlinx.serialization, with au
 
 ## Dependencies
 
-- **kotlinx.serialization** - JSON serialization support
 - **JAudioTagger** - Audio file metadata reading/writing
-- **transgressoft-commons** - Base repository and reactive event infrastructure
+- **lirp** - Reactive entity framework, repository pattern, and event-driven infrastructure
 
-Audio decoding and waveform PCM generation live in the separate `music-commons-media` module (JavaSound SPI).
+This module ships no JSON or SQL persistence code — persistence is supplied by the opt-in
+`music-commons-persistence` module. Audio decoding and waveform PCM generation live in the
+separate `music-commons-media` module (JavaSound SPI).
 
 ## Testing
 

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/AudioLibraryBase.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/AudioLibraryBase.kt
@@ -57,7 +57,7 @@ import java.util.concurrent.atomic.AtomicInteger
  *
  * @param I The type of audio items stored in this library
  * @param AC The concrete artist catalog type
- * @param ALC The concrete album catalog type
+ * @param ALC The type of reactive album exposed by this library
  * @param GC The concrete genre catalog type
  */
 abstract class AudioLibraryBase<I, AC, ALC, GC>(

--- a/music-commons-fx/README.md
+++ b/music-commons-fx/README.md
@@ -17,16 +17,20 @@ This module bridges the reactive music-commons-core with JavaFX's property bindi
 
 ### Observable Audio Library
 
+`FXMusicLibrary.builder()` is the entry point; `ObservableAudioLibrary`/`ObservablePlaylistHierarchy`
+are interfaces exposed by the facade, not directly constructed.
+
 ```kotlin
-val repository = JsonFileRepository(file, ObservableAudioItemMapSerializer)
-val audioLibrary = ObservableAudioLibrary(repository)
+val library = FXMusicLibrary.builder()
+    .audioRepository(JsonFileRepository(file, ObservableAudioItemMapSerializer))
+    .build()
 
 // Bind to UI components
-tableView.itemsProperty().bind(audioLibrary.audioItemsProperty)
-emptyLabel.visibleProperty().bind(audioLibrary.emptyLibraryProperty)
+tableView.itemsProperty().bind(library.audioItemsProperty)
+emptyLabel.visibleProperty().bind(library.emptyLibraryProperty)
 
 // Create audio items
-val audioItem = audioLibrary.createFromFile(audioFilePath)
+val audioItem = library.audioItemFromFile(audioFilePath)
 
 // Property changes automatically update the UI
 audioItem.titleProperty.set("New Title")    // TableView updates automatically
@@ -36,8 +40,10 @@ audioItem.title = "Another Title"           // Also triggers JavaFX property upd
 ### Observable Playlists
 
 ```kotlin
-val playlistRepository = JsonFileRepository(file, ObservablePlaylistMapSerializer)
-val playlistHierarchy = ObservablePlaylistHierarchy(playlistRepository, audioLibrary)
+val library = FXMusicLibrary.builder()
+    .playlistRepository(JsonFileRepository(file, ObservablePlaylistMapSerializer))
+    .build()
+val playlistHierarchy = library.playlistHierarchy()
 
 // Bind playlist collection to UI
 listView.itemsProperty().bind(playlistHierarchy.playlistsProperty)
@@ -61,7 +67,7 @@ playlistTableView.itemsProperty().bind(playlist.audioItemsProperty)
 ### Audio Playback
 
 ```kotlin
-val player = JavaFxPlayer()
+val player = FXAudioItemPlayer()
 
 // Bind player properties to UI
 playButton.disableProperty().bind(
@@ -79,7 +85,7 @@ timeSlider.valueProperty().bind(
 player.play(audioItem)  // Automatically increments play count at 60% threshold
 
 // Subscribe to playback events
-audioLibrary.playerSubscriber.addOnNextEventAction(PLAYED) { event ->
+library.playerSubscriber.addOnNextEventAction(PLAYED) { event ->
     println("Played: ${event.entities.values.first().title}")
 }
 ```
@@ -171,9 +177,9 @@ Observable components use the same serialization as core components:
 val json = Json.encodeToString(audioLibrary.findAll())
 
 // Deserialize and restore JavaFX bindings
-val restoredLibrary = ObservableAudioLibrary(
-    JsonFileRepository(file, ObservableAudioItemMapSerializer)
-)
+val restoredLibrary = FXMusicLibrary.builder()
+    .audioRepository(JsonFileRepository(file, ObservableAudioItemMapSerializer))
+    .build()
 ```
 
 ## Dependencies
@@ -192,13 +198,13 @@ beforeSpec {
 }
 
 "Observable properties update correctly" {
-    val audioItem = audioLibrary.createFromFile(path)
+    val audioItem = library.audioItemFromFile(path)
 
     audioItem.titleProperty.set("Test Title")
     audioItem.title shouldBe "Test Title"
 
     // Verify reactive updates
-    audioLibrary.audioItemsProperty.contains(audioItem) shouldBe true
+    library.audioItemsProperty.contains(audioItem) shouldBe true
 }
 ```
 

--- a/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/audio/ObservableAudioItem.kt
+++ b/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/audio/ObservableAudioItem.kt
@@ -42,29 +42,47 @@ import java.util.Optional
  */
 interface ObservableAudioItem : ReactiveAudioItem<ObservableAudioItem> {
 
+    /** Observable property exposing the track title. */
     val titleProperty: StringProperty
 
+    /** Observable property exposing the primary [Artist] of the track. */
     val artistProperty: ObjectProperty<Artist>
 
+    /** Observable property exposing the [AlbumDetails] the track belongs to. */
     val albumProperty: ObjectProperty<AlbumDetails>
 
+    /** Observable property exposing the set of [Genre]s assigned to the track. */
     val genresProperty: ObjectProperty<Set<Genre>>
 
+    /** Observable property exposing the track's free-text comments field. */
     val commentsProperty: StringProperty
 
+    /** Observable property exposing the track number within its disc. */
     val trackNumberProperty: IntegerProperty
 
+    /** Observable property exposing the disc number within its release. */
     val discNumberProperty: IntegerProperty
 
+    /** Observable property exposing the beats-per-minute value of the track. */
     val bpmProperty: FloatProperty
 
+    /**
+     * Observable property exposing the cover image wrapped in an [Optional].
+     *
+     * Attaching a listener or reading the value for the first time triggers a lazy load of the
+     * cover image from the underlying audio file metadata when the item is wired to a library.
+     */
     val coverImageProperty: ReadOnlyObjectProperty<Optional<Image>>
 
+    /** Observable property exposing the full set of [Artist]s involved in the track, derived from title, artist, and album-artist fields. */
     val artistsInvolvedProperty: ReadOnlySetProperty<Artist>
 
+    /** Observable property exposing the date and time the track metadata was last modified. */
     val lastDateModifiedProperty: ReadOnlyObjectProperty<LocalDateTime>
 
+    /** Observable property exposing the date and time the track was first added to the library. */
     val dateOfCreationProperty: ReadOnlyProperty<LocalDateTime>
 
+    /** Observable property exposing the number of times the track has been played. */
     val playCountProperty: ReadOnlyIntegerProperty
 }

--- a/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/player/FXAudioItemPlayer.kt
+++ b/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/player/FXAudioItemPlayer.kt
@@ -37,12 +37,15 @@ class FXAudioItemPlayer(
     private val corePlayer: CoreAudioItemPlayer = CoreAudioItemPlayer()
 ) : AudioItemPlayer by corePlayer {
 
+    /** Observable property for the playback volume, in the range [0.0, 1.0]. [setVolume] schedules the update on the JavaFX Application Thread. */
     val volumeProperty: DoubleProperty
         field = SimpleDoubleProperty(this, "volume", 1.0)
 
+    /** Observable property reflecting the current [AudioItemPlayer.Status] of the underlying player, updated on the JavaFX Application Thread. */
     val statusProperty: ReadOnlyObjectProperty<AudioItemPlayer.Status>
         field = SimpleObjectProperty(this, "status", AudioItemPlayer.Status.UNKNOWN)
 
+    /** Observable property reflecting the current playback position, updated on each animation frame while the player is active. */
     val currentTimeProperty: ReadOnlyObjectProperty<FxDuration>
         field = SimpleObjectProperty(this, "currentTime", FxDuration.ZERO)
 

--- a/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/waveform/PlayableWaveformPane.kt
+++ b/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/waveform/PlayableWaveformPane.kt
@@ -58,12 +58,16 @@ class PlayableWaveformPane : Region() {
 
     private val canvas = Canvas()
 
+    /** Observable property holding the current playback position as a fraction in [0.0, 1.0]. Bind to a player's time ratio to drive the waveform split. */
     val progressProperty = SimpleDoubleProperty(this, "progress", 0.0)
 
+    /** Observable property for the color used to draw bars after the current playback position. */
     val waveformColorProperty = SimpleObjectProperty(this, "waveformColor", Color.WHITE)
 
+    /** Observable property for the color used to draw bars before the current playback position, indicating the portion already played. */
     val playedColorProperty = SimpleObjectProperty(this, "playedColor", Color.GREEN)
 
+    /** Observable property for the canvas background fill color. */
     val backgroundColorProperty: ObjectProperty<Color> = SimpleObjectProperty(this, "backgroundColor", Color.BLACK)
 
     private val job: Job = Job()

--- a/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/waveform/WaveformPane.kt
+++ b/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/waveform/WaveformPane.kt
@@ -67,6 +67,17 @@ class WaveformPane : Canvas() {
         }
     }
 
+    /**
+     * Renders the given [waveform] onto this canvas asynchronously.
+     *
+     * Any in-progress rendering task is cancelled before the new one begins. The amplitude data
+     * is computed off the JavaFX Application Thread and the canvas is painted once results arrive.
+     * Resizing the canvas automatically re-triggers this method with the current waveform.
+     *
+     * @param waveform the waveform whose amplitude data will be rendered
+     * @param waveformColor the color used to draw the waveform bars; defaults to the current setting
+     * @param backgroundColor the color used to fill the canvas background; defaults to the current setting
+     */
     fun drawWaveformAsync(waveform: AudioWaveform, waveformColor: Color = this.waveformColor, backgroundColor: Color = this.backgroundColor) {
         this.waveform = waveform
         this.waveformColor = waveformColor
@@ -111,6 +122,11 @@ class WaveformPane : Canvas() {
         }
     }
 
+    /**
+     * Cancels the coroutine scope, stopping any in-progress waveform rendering.
+     *
+     * Must be called when the component is no longer needed to release coroutine resources.
+     */
     fun dispose() {
         job.cancel()
     }

--- a/music-commons-media/README.md
+++ b/music-commons-media/README.md
@@ -1,0 +1,70 @@
+# Music Commons Media
+
+JavaFX-free audio playback engine and reactive waveform generation, built on the
+`javax.sound.sampled` SPI. This module has no JavaFX dependency, so it can be used from headless
+services and, through `music-commons-fx`, from desktop applications.
+
+## Overview
+
+Two independent capabilities live here:
+
+- **Playback** — `CoreAudioItemPlayer` streams decoded PCM in bounded chunks to a
+  `SourceDataLine`, driven by a small set of focused collaborators.
+- **Waveforms** — `ScalableAudioWaveform` is a reactive waveform entity with on-demand amplitude
+  generation and cached scaling; its JSON serializer ships alongside it (waveforms are JSON-only,
+  so no separate persistence module is needed).
+
+## Key Components
+
+### `player`
+
+- **`CoreAudioItemPlayer`** — headless player supporting MP3, FLAC, OGG (Vorbis and Opus),
+  AAC/M4A, ALAC/M4A, and WAV via prioritized JavaSound SPI decoders. Constructable directly
+  (`CoreAudioItemPlayer()`); it publishes `AudioItemPlayerEvent`s and exposes an
+  `AudioItemPlayer.Status` lifecycle (including `STALLED` for streaming starvation).
+- Internal collaborators keep the player a thin coordinator: `PlaybackPump` (pump loop and gain
+  application), `StallDetector` (starvation detection and recovery), `DurationProber` (duration
+  resolution with full-decode fallback for AAC/M4A), `PcmVolume` (in-place linear gain for
+  8/16/24/32-bit PCM), and the per-format `PcmStreamSeeker` implementations (`FlacPcmStreamSeeker`,
+  `Mp3PcmStreamSeeker`, `OggPcmStreamSeeker`).
+
+### `waveform`
+
+- **`ScalableAudioWaveform`** — reactive `AudioWaveform` implementation. Generates normalized
+  amplitudes on demand and caches them with their display width, so same-width requests return
+  without re-reading the audio file and height-only changes apply linear scaling from cache.
+
+### `persistence.waveform`
+
+- **`AudioWaveformMapSerializer`** — kotlinx-serialization map serializer for a lirp
+  `JsonFileRepository`, preserving the cached width and amplitudes.
+
+## Usage
+
+```kotlin
+import net.transgressoft.commons.media.player.CoreAudioItemPlayer
+import java.time.Duration
+
+val player = CoreAudioItemPlayer()
+player.play(audioItem)
+player.setVolume(0.8)
+player.seek(Duration.ofSeconds(30))
+player.stop()
+player.dispose()
+```
+
+Per-codec seek precision and the full playback lifecycle are described on the
+[Audio Playback](https://github.com/octaviospain/music-commons/wiki/Audio-Playback) wiki page.
+
+## Dependencies
+
+- **music-commons-api** — the `AudioItemPlayer`, `AudioWaveform`, and `ReactiveAudioItem` contracts
+- **kotlinx-coroutines-core** — asynchronous waveform generation
+- **JavaSound SPI providers** — pure-Java decoders for MP3, FLAC, OGG Vorbis/Opus, AAC/M4A, and ALAC
+
+## License
+
+Copyright © 2025-2026 Octavio Calleya Garcia.
+
+This program is free software under the terms of the GNU General Public License version 3 or
+(at your option) any later version.

--- a/music-commons-persistence-fx/README.md
+++ b/music-commons-persistence-fx/README.md
@@ -1,0 +1,63 @@
+# Music Commons Persistence FX
+
+Opt-in JSON and SQL persistence mapping for the **JavaFX-tier** entities. Like
+`music-commons-persistence`, this module is mapping-only — it defines no entity classes and reuses
+the core-tier contextual serializers and column converters.
+
+## Overview
+
+`music-commons-fx` keeps its observable entities in memory and ships no persistence code. This
+module supplies the serializers and SQL table definitions needed to persist `ObservableAudioItem`
+and `ObservablePlaylist` through the `audioRepository(...)` and `playlistRepository(...)` hooks on
+`FXMusicLibrary.builder()`.
+
+## Key Components
+
+### JSON serialization
+
+- **`ObservableAudioItemMapSerializer`** / **`ObservablePlaylistMapSerializer`** — map serializers
+  for a lirp `JsonFileRepository`, reusing `audioItemSerializersModule` from
+  `music-commons-persistence` for the shared domain value types.
+
+### SQL persistence
+
+- **`FXAudioItemSqlTableDef`** / **`ObservablePlaylistSqlTableDef`** — table definitions for a lirp
+  `SqliteRepository`, reconstructing the observable entities through lirp's construction SPI.
+
+## Usage
+
+```kotlin
+import net.transgressoft.commons.fx.music.FXMusicLibrary
+import net.transgressoft.commons.persistence.fx.music.audio.FXAudioItemSqlTableDef
+import net.transgressoft.commons.persistence.fx.music.audio.ObservableAudioItemMapSerializer
+import net.transgressoft.lirp.persistence.json.JsonFileRepository
+import net.transgressoft.lirp.persistence.sql.SqliteRepository
+
+// JSON file storage
+val jsonLibrary = FXMusicLibrary.builder()
+    .audioRepository(JsonFileRepository(File("audio-library.json"), ObservableAudioItemMapSerializer))
+    .build()
+
+// SQL storage — add a JDBC driver (e.g. org.xerial:sqlite-jdbc) to your build
+val sqlLibrary = FXMusicLibrary.builder()
+    .audioRepository(SqliteRepository.fileBacked(Path.of("audio-library.db"), FXAudioItemSqlTableDef))
+    .build()
+```
+
+See the [SQL Persistence](https://github.com/octaviospain/music-commons/wiki/SQL-Persistence) wiki
+page for details.
+
+## Dependencies
+
+- **music-commons-fx** — the observable entities being mapped
+- **music-commons-persistence** — reused core-tier contextual serializers and column converters
+- **lirp-api**, **lirp-sql-api** — repository and SQL table-definition contracts (exposed in this
+  module's public API)
+- **lirp-sql**, **javafx-controls**
+
+## License
+
+Copyright © 2025-2026 Octavio Calleya Garcia.
+
+This program is free software under the terms of the GNU General Public License version 3 or
+(at your option) any later version.

--- a/music-commons-persistence/README.md
+++ b/music-commons-persistence/README.md
@@ -1,0 +1,70 @@
+# Music Commons Persistence
+
+Opt-in JSON and SQL persistence mapping for the **core-tier** entities. This module is
+mapping-only: it defines no entity classes, only serializers, SQL table definitions, and column
+converters for the real reactive entities in `music-commons-core`.
+
+## Overview
+
+The reactive modules (`api`, `core`, `fx`, `media`) keep all state in memory and ship no
+persistence code. A consumer enables persistence by injecting a concrete lirp `Repository` wired
+with the mappings from this module — or skips it entirely and subscribes to library events to
+persist in their own model. Audio items and playlists can be persisted to JSON or SQL; waveforms
+are JSON-only and their serializer ships from `music-commons-media`.
+
+## Key Components
+
+### JSON serialization
+
+- **`AudioItemMapSerializer`** / **`AudioPlaylistMapSerializer`** — kotlinx-serialization map
+  serializers for a lirp `JsonFileRepository`.
+- **`audioItemSerializersModule`** — a contextual `SerializersModule` for the domain value types
+  (artist, album, label, genre, country, metadata, and the `Path`/`Duration`/`LocalDateTime`
+  scalars), so the domain model itself stays annotation-free.
+
+### SQL persistence
+
+- **`MutableAudioItemSqlTableDef`** / **`AudioPlaylistSqlTableDef`** — table definitions for a lirp
+  `SqliteRepository`. They reconstruct the real entities through lirp's construction SPI, so no
+  hand-written factory is required.
+- **`CountryConverter`**, **`GenreConverter`** — column converters for SQL persistence (duration
+  and path columns reuse lirp's built-in converters).
+
+## Usage
+
+Inject a repository built from these mappings through `CoreMusicLibrary.builder()`:
+
+```kotlin
+import net.transgressoft.commons.music.CoreMusicLibrary
+import net.transgressoft.commons.persistence.music.audio.AudioItemMapSerializer
+import net.transgressoft.commons.persistence.music.audio.MutableAudioItemSqlTableDef
+import net.transgressoft.lirp.persistence.json.JsonFileRepository
+import net.transgressoft.lirp.persistence.sql.SqliteRepository
+
+// JSON file storage
+val jsonLibrary = CoreMusicLibrary.builder()
+    .audioRepository(JsonFileRepository(File("audio-library.json"), AudioItemMapSerializer))
+    .build()
+
+// SQL storage — add a JDBC driver (e.g. org.xerial:sqlite-jdbc) to your build
+val sqlLibrary = CoreMusicLibrary.builder()
+    .audioRepository(SqliteRepository.fileBacked(Path.of("audio-library.db"), MutableAudioItemSqlTableDef))
+    .build()
+```
+
+See the [SQL Persistence](https://github.com/octaviospain/music-commons/wiki/SQL-Persistence) wiki
+page for the full wiring, including error observability via `LirpErrorHandler`.
+
+## Dependencies
+
+- **music-commons-core** — the entities being mapped
+- **lirp-api**, **lirp-sql-api** — repository and SQL table-definition contracts (exposed in this
+  module's public API)
+- **lirp-sql** — SQL repository implementation
+
+## License
+
+Copyright © 2025-2026 Octavio Calleya Garcia.
+
+This program is free software under the terms of the GNU General Public License version 3 or
+(at your option) any later version.


### PR DESCRIPTION
Closes #170

Brings the documentation back in line with the current codebase (album/genre projection rename, persistence-agnostic split, lirp, JDK 21 / Kotlin 2.4.0 / JavaFX 21.0.11), makes the README approachable, and replaces every hand-drawn ASCII diagram with rendered d2 sources.

## Source doc-comments
- Added missing KDoc across the public API surface (`ReactiveAudioItem`, `AudioPlaylist`, `ReactiveAudioPlaylist`, `ReactivePlaylistHierarchy`, waveform contracts, `ObservableAudioItem`, `FXAudioItemPlayer`, waveform panes).
- Fixed broken KDoc links in `AudioMetadataIO` and stale wording in `AudioLibraryBase`.

## READMEs
- Root README restructured (~680 → ~260 lines): table of contents, clear quickstart, per-feature wiki links, feature-index table; corrected requirements and the `FXAudioItemPlayer` playback example; fixed the JAudioTagger link.
- Corrected the `api`, `core`, and `fx` module READMEs (facade builders, `ReactiveAudioLibrary`/`AlbumDetails` naming, lirp dependency).
- Added READMEs for `music-commons-media`, `music-commons-persistence`, and `music-commons-persistence-fx`.

## Changelog
- Added `CHANGELOG.md` (Keep a Changelog) covering 0.1.0 → 0.6.0 plus an Unreleased section for the in-progress breaking changes.

## Diagrams
- Added a `d2/` directory as the single source of truth for diagrams, with a render guide. The wiki now references rendered SVGs instead of ASCII: module overview, dependency flow, interface-first type hierarchy, registry projection flow, event flow, player state, persistence wiring, and exception hierarchy.

## Notes
- The wiki changes (inaccuracy fixes, new Glossary, diagram wiring) are pushed directly to the wiki repository.
- `CLAUDE.md` was also refreshed but is gitignored, so it is not part of this PR.

## Testing
Documentation-only change. `gradle compileKotlin` and `gradle ktlintCheck` pass; all d2 sources render. No production logic changed, so coverage is unaffected.