### PR TITLE
Framework-workaround hardening and media decoder coverage, security & seek precision

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,3 +295,7 @@ It builds on several open-source libraries, including:
   **[kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization)**
 - **[Kotest](https://kotest.io/)**, **[MockK](https://mockk.io/)**, and
   **[TestFX](https://github.com/TestFX/TestFX)** for testing
+
+The licenses for all bundled JavaSound SPI decoders, including a compatibility analysis for the
+`tritonus-share` LGPL-2.1 / GPL-3.0 interaction, are documented in
+[THIRD-PARTY-LICENSES.md](THIRD-PARTY-LICENSES.md).

--- a/THIRD-PARTY-LICENSES.md
+++ b/THIRD-PARTY-LICENSES.md
@@ -1,0 +1,58 @@
+# Third-Party Licenses
+
+Music Commons is distributed under the [GNU General Public License v3.0](LICENSE) (GPL-3.0).
+
+The `music-commons-media` module bundles the following third-party SPI (Service Provider Interface)
+decoders at runtime. These libraries are loaded by JavaSound's `AudioSystem` service-loader
+mechanism to provide audio decoding for MP3, FLAC, OGG Vorbis, AAC/M4A, ALAC, Opus, and
+WAV resampling. All of them are compatible with GPL-3.0 as described below.
+
+## Bundled SPI Decoders
+
+| Dependency | Version | License | GPL-3.0 Compatible | Notes |
+|---|---|---|---|---|
+| `com.googlecode.soundlibs:mp3spi` | 1.9.5.4 | LGPL-2.1 | Yes | Weak-copyleft; FSF confirms LGPL-2.1 is compatible with GPL-3.0 |
+| `com.googlecode.soundlibs:tritonus-share` | 0.3.7.4 | LGPL-2.1 | Yes | See compatibility analysis below |
+| `com.tianscar.javasound:javasound-flac` | 1.4.1 | LGPL-2.1 AND Apache-2.0 | Yes | Both licenses are GPL-3.0 compatible |
+| `com.tianscar.javasound:javasound-vorbis` | 2.1.0 | LGPL-2.0 AND Xiph.Org BSD | Yes | Both permissive/weak-copyleft; GPL-3.0 compatible |
+| `com.tianscar.javasound:javasound-aac` | 0.9.8 | Apache-2.0 | Yes | FSF confirms Apache-2.0 is compatible with GPL-3.0 |
+| `com.tianscar.javasound:javasound-alac` | 0.2.3 | BSD-3-Clause | Yes | Permissive license; fully compatible |
+| `com.tianscar.javasound:javasound-resloader` | 0.1.3 | Apache-2.0 | Yes | Stream reload utility used internally by the Tianscar SPI providers |
+| `de.sfuhrm:jaad` | 0.8.7 | Public Domain | Yes | No restrictions; compatible with any license |
+| `io.github.jseproject:jse-spi-opus` | 1.1.0 | Xiph.Org Variant of BSD | Yes | Permissive BSD variant; GPL-3.0 compatible |
+
+## tritonus-share LGPL-2.1 / GPL-3.0 Compatibility Analysis
+
+`tritonus-share` (version 0.3.7.4, `com.googlecode.soundlibs:tritonus-share`) is licensed under
+the GNU Lesser General Public License version 2.1 (LGPL-2.1). Music Commons is licensed under
+GPL-3.0. The LGPL-2.1 / GPL-3.0 interaction is compatible for the following reasons:
+
+1. **Weak copyleft permits linking**: LGPL-2.1 is a "weak copyleft" license explicitly designed to
+   permit linking with programs under other licenses, including GPL-3.0, without imposing the LGPL
+   terms on the combined work. The combined program becomes GPL-3.0 as a whole.
+
+2. **"Or any later version" clause**: The standard LGPL-2.1 license text includes the clause
+   "either version 2.1 of the License, or (at your option) any later version". This clause allows
+   the library to be treated as LGPL-3.0 (which is built on top of GPL-3.0) when that is more
+   permissive for the combination.
+
+3. **FSF explicit guidance**: The Free Software Foundation explicitly states that LGPL-2.1 is
+   compatible with GPL-3.0. See the [GPL FAQ](https://www.gnu.org/licenses/gpl-faq.html) entry
+   "Can I use GPL-incompatible libraries in my GPL'd programs if I use the Library GPL?".
+
+**Conclusion**: `tritonus-share` (LGPL-2.1) is compatible with the project's GPL-3.0 license and
+may be combined with it. Compatibility does not extinguish the LGPL's own obligations, which
+continue to apply to the `tritonus-share` library itself: its copyright and license notices must
+be preserved, its corresponding source (or a written offer for it) must remain available, and
+recipients must be able to relink or replace it with a modified version. music-commons satisfies
+these by depending on the unmodified, publicly published Maven Central artifact and linking it
+dynamically at runtime — it is not modified or statically embedded — so the source-availability
+and relinking rights are preserved upstream. No LGPL obligation is triggered that GPL-3.0 does not
+already accommodate.
+
+## Other Dependencies
+
+The library also depends on [lirp](https://github.com/octaviospain/lirp),
+[JAudioTagger](https://www.jthink.net/jaudiotagger/), [Kotlin](https://kotlinlang.org/),
+[Kotlin Coroutines](https://github.com/Kotlin/kotlinx.coroutines), and other libraries.
+Their licenses are recorded in the respective project repositories and are compatible with GPL-3.0.

--- a/music-commons-api/src/main/kotlin/net/transgressoft/commons/music/player/AudioItemPlayer.kt
+++ b/music-commons-api/src/main/kotlin/net/transgressoft/commons/music/player/AudioItemPlayer.kt
@@ -152,9 +152,13 @@ interface AudioItemPlayer : Flow.Publisher<AudioItemPlayerEvent> {
      *   AAC/M4A.
      * - **WAV / AIFF**: byte-aligned to the nearest PCM frame. Precision is limited only by
      *   the frame size (4 bytes for 16-bit stereo); effectively sample-accurate.
-     * - **AAC/M4A**: frame-accurate. The implementation decodes to PCM from the beginning of
-     *   the stream and discards bytes up to the target offset, so seeking near the end of a
-     *   long track is proportionally slower than seeking near the start.
+     * - **AAC/M4A (known limitation)**: the implementation decodes PCM from the beginning of the
+     *   stream and discards bytes until the target offset is reached. Unlike MP3 (Xing/Info TOC or
+     *   frame-scan) and OGG (granulepos bisection), the M4A container has no ADTS-frame index that
+     *   enables random-access byte-level seeking in the decoder. Seek cost therefore scales linearly
+     *   with the target position; seeking near the end of a long track is proportionally slower than
+     *   seeking near the start. Implementing efficient ADTS-frame-based seeking is out of scope for
+     *   this release.
      *
      * @param position the target playback position; negative values are clamped to
      *   [Duration.ZERO], and positions beyond `totalDuration` are clamped to it once the total

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/playlist/MutablePlaylist_LirpRefAccessor.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/playlist/MutablePlaylist_LirpRefAccessor.kt
@@ -29,10 +29,15 @@ import net.transgressoft.lirp.persistence.RefEntry
 /**
  * Manually-written aggregate reference accessor for [MutablePlaylist].
  *
- * This class replaces the KSP-generated `_LirpRefAccessor` that would normally be produced
- * by the `@Aggregate` annotation processor. A manual implementation is required because the
- * KSP processor generates a `public` accessor that cannot reference `internal` entities,
- * causing a visibility error at compile time.
+ * This class is hand-authored because `music-commons-core` deliberately omits the lirp-ksp
+ * processor to remain persistence-agnostic. lirp-ksp emits a `_LirpRefAccessor` only for entities
+ * annotated with `@PersistenceMapping` plus `@ToManyAggregates` on their aggregate delegates;
+ * annotating this entity to trigger generation would also pull table-definition, raw-initializer,
+ * and property-accessor codegen into the reactive core for every mapped entity in the module. The
+ * accessor is therefore written by hand to keep persistence codegen out of this module — not
+ * because lirp-ksp cannot generate it. Given the annotations, lirp-ksp produces an
+ * equivalent `internal`-visibility accessor with the same `audioItems`/`playlists` collection
+ * entries, so this is an architectural choice rather than a framework limitation.
  *
  * The class name follows the lirp convention `{EntityJvmName}_LirpRefAccessor` so that
  * [net.transgressoft.lirp.persistence.RegistryBase.discoverRefs] locates it via

--- a/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/playlist/DefaultPlaylistHierarchyTest.kt
+++ b/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/playlist/DefaultPlaylistHierarchyTest.kt
@@ -4,6 +4,7 @@ import net.transgressoft.commons.music.audio.AudioItem
 import net.transgressoft.commons.music.audio.DefaultAudioLibrary
 import net.transgressoft.commons.music.audio.audioItem
 import net.transgressoft.commons.music.testing.reactiveScope
+import net.transgressoft.commons.music.testing.registryIsolation
 import net.transgressoft.commons.persistence.music.playlist.AudioPlaylistMapSerializer
 import net.transgressoft.commons.util.OsDetector
 import net.transgressoft.commons.util.WindowsPathException
@@ -31,6 +32,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 @ExperimentalCoroutinesApi
 internal class DefaultPlaylistHierarchyTest : StringSpec({
 
+    registryIsolation()
     // failOnUncaughtExceptions = false: this spec exercises Arb.audioItem mocks that
     // don't stub the full ReactiveEntity subscribe() surface, so background subscribers
     // fail with MockKException after the spec has already verified its assertions.

--- a/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/playlist/MutablePlaylistTest.kt
+++ b/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/playlist/MutablePlaylistTest.kt
@@ -3,6 +3,7 @@ package net.transgressoft.commons.music.playlist
 import net.transgressoft.commons.music.audio.AudioItem
 import net.transgressoft.commons.music.audio.artist
 import net.transgressoft.commons.music.audio.audioItem
+import net.transgressoft.commons.music.testing.registryIsolation
 import net.transgressoft.commons.persistence.music.playlist.AudioPlaylistMapSerializer
 import net.transgressoft.lirp.persistence.RegistryBase
 import net.transgressoft.lirp.persistence.VolatileRepository
@@ -29,6 +30,8 @@ private lateinit var playlistHierarchy: PlaylistHierarchy
 private lateinit var audioItemRepository: VolatileRepository<Int, AudioItem>
 
 internal class MutablePlaylistTest : StringSpec({
+
+    registryIsolation()
 
     lateinit var jsonFileRepository: JsonRepository<Int, MutableAudioPlaylist>
 

--- a/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/playlist/PlaylistHierarchyBaseTest.kt
+++ b/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/playlist/PlaylistHierarchyBaseTest.kt
@@ -6,6 +6,7 @@ import net.transgressoft.commons.music.audio.virtualFiles
 import net.transgressoft.commons.music.shouldNotReferenceItemId
 import net.transgressoft.commons.music.shouldReferenceItemId
 import net.transgressoft.commons.music.testing.reactiveScope
+import net.transgressoft.commons.music.testing.registryIsolation
 import net.transgressoft.lirp.persistence.RegistryBase.Companion.deregisterRepository
 import net.transgressoft.lirp.persistence.RegistryBase.Companion.registerRepository
 import net.transgressoft.lirp.persistence.VolatileRepository
@@ -22,6 +23,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 @ExperimentalCoroutinesApi
 internal class PlaylistHierarchyBaseTest : StringSpec({
 
+    registryIsolation()
     val reactive = reactiveScope()
     val files = virtualFiles()
     lateinit var playlistHierarchy: TestPlaylistHierarchy

--- a/music-commons-fx/build.gradle
+++ b/music-commons-fx/build.gradle
@@ -79,6 +79,7 @@ dependencies {
     implementation libs.javafx.controls.get()
 
     testImplementation project(path: ':music-commons-fx-test')
+    testImplementation(testFixtures(project(':music-commons-media')))
     testImplementation(platform(libs.junit.bom.get()))
     testImplementation(libs.junit.jupiter.get())
     testImplementation libs.jimfs.get()

--- a/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/playlist/FXPlaylist_LirpRefAccessor.kt
+++ b/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/playlist/FXPlaylist_LirpRefAccessor.kt
@@ -29,9 +29,15 @@ import net.transgressoft.lirp.persistence.RefEntry
 /**
  * Manually-written aggregate reference accessor for the top-level [FXPlaylist] class.
  *
- * This class replaces the KSP-generated `_LirpRefAccessor` that would normally be produced
- * by the `@Aggregate` annotation processor. A manual implementation is required because
- * [FXPlaylist] is an `internal` class that KSP cannot process.
+ * This class is hand-authored because `music-commons-fx` deliberately omits the lirp-ksp
+ * processor to remain persistence-agnostic. lirp-ksp emits a `_LirpRefAccessor` only for entities
+ * annotated with `@PersistenceMapping` plus `@ToManyAggregates` on their aggregate delegates;
+ * annotating this entity to trigger generation would also pull table-definition, raw-initializer,
+ * and property-accessor codegen into the reactive FX layer for every mapped entity in the module.
+ * The accessor is therefore written by hand to keep persistence codegen out of this module — not
+ * because lirp-ksp cannot generate it. Given the annotations, lirp-ksp produces an
+ * equivalent `internal`-visibility accessor with the same `audioItems`/`playlists` collection
+ * entries, so this is an architectural choice rather than a framework limitation.
  *
  * The class name follows the lirp convention `{EntityJvmName}_LirpRefAccessor`, where the JVM
  * name of the top-level class is `net.transgressoft.commons.fx.music.playlist.FXPlaylist`, so

--- a/music-commons-fx/src/test/kotlin/net/transgressoft/commons/fx/music/player/FXAudioItemPlayerFormatIntegrationTest.kt
+++ b/music-commons-fx/src/test/kotlin/net/transgressoft/commons/fx/music/player/FXAudioItemPlayerFormatIntegrationTest.kt
@@ -15,15 +15,16 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.     *
  ******************************************************************************/
 
-package net.transgressoft.commons.media.player
+package net.transgressoft.commons.fx.music.player
 
-import net.transgressoft.commons.media.util.decodeToPcmStream
+import net.transgressoft.commons.media.player.FakeAudioLine
+import net.transgressoft.commons.media.player.testPlayer
 import net.transgressoft.commons.music.audio.ArbitraryAudioFile
 import net.transgressoft.commons.music.audio.audioItem
 import net.transgressoft.commons.music.player.AudioItemPlayer.Status
 import io.kotest.assertions.nondeterministic.eventually
 import io.kotest.core.annotation.DisplayName
-import io.kotest.core.annotation.Tags
+import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.datatest.withData
 import io.kotest.matchers.longs.shouldBeGreaterThan
@@ -31,25 +32,41 @@ import io.kotest.matchers.longs.shouldBeLessThan
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.next
+import org.testfx.api.FxToolkit
 import kotlin.time.Duration.Companion.seconds
 
 /**
- * Per-format end-to-end integration tests for [CoreAudioItemPlayer] using [FakeAudioLine] to
- * exercise the real SPI decode pipeline without audio hardware.
+ * Per-format end-to-end integration tests for [FXAudioItemPlayer] driven by a real
+ * [net.transgressoft.commons.media.player.CoreAudioItemPlayer] with [FakeAudioLine]
+ * substituting the hardware output sink.
  *
- * Each test row drives the real [decodeToPcmStream] factory so actual codec-specific decoding
- * happens; only the hardware output sink is replaced by [FakeAudioLine]. The test matrix covers
- * the 6 formats for which [net.transgressoft.commons.music.player.AudioItemPlayer.isPlayable]
+ * Each test row exercises the full FX playback pipeline — real SPI decoding, real
+ * [net.transgressoft.commons.media.player.CoreAudioItemPlayer] state machine, and JavaFX
+ * observable property synchronisation — without requiring audio hardware or a real
+ * [javax.sound.sampled.SourceDataLine]. [FakeAudioLine] advances its virtual clock
+ * proportionally to bytes written, allowing deterministic status-transition and duration assertions.
+ *
+ * The matrix covers the 6 formats for which [net.transgressoft.commons.music.player.AudioItemPlayer.isPlayable]
  * returns `true`: MP3 VBR, MP3 CBR, FLAC, AAC/M4A, WAV, and Vorbis/OGG.
- *
- * ALAC (`testeable_alac.m4a`) and Opus (`testeable_opus.ogg`) are excluded from the playback
- * matrix because [net.transgressoft.commons.music.player.AudioItemPlayer.isPlayable] returns
- * `false` for them — calling `play()` on an ALAC or Opus item throws
- * [net.transgressoft.commons.music.player.UnsupportedAudioPlaybackException]. Their SPI-decode
- * coverage lives in [SpiProviderVerificationTest] at the `AudioSystem.getAudioInputStream()` level.
+ * ALAC (`testeable_alac.m4a`) and Opus (`testeable_opus.ogg`) are excluded because
+ * [net.transgressoft.commons.music.player.AudioItemPlayer.isPlayable] returns `false` for them;
+ * their SPI-decode coverage is verified at the [javax.sound.sampled.AudioSystem] level in
+ * `SpiProviderVerificationTest`.
  */
-@DisplayName("CoreAudioItemPlayer per-format integration")
-internal class CoreAudioItemPlayerFormatIntegrationTest : FunSpec({
+@DisplayName("FXAudioItemPlayer per-format integration")
+internal class FXAudioItemPlayerFormatIntegrationTest : FunSpec({
+    isolationMode = IsolationMode.SingleInstance
+
+    // REQUIRED: FXAudioItemPlayer.syncStatus() calls Platform.runLater().
+    // Without this, play()/pause()/stop() throw IllegalStateException: Toolkit not initialized.
+    // FxKotestProjectConfig wires the Monocle headless backend globally — only registerPrimaryStage() is needed here.
+    beforeSpec {
+        FxToolkit.registerPrimaryStage()
+    }
+
+    afterSpec {
+        FxToolkit.cleanupStages()
+    }
 
     /**
      * Describes a single playable format row in the test matrix.
@@ -66,7 +83,7 @@ internal class CoreAudioItemPlayerFormatIntegrationTest : FunSpec({
         val toleranceMs: Long
     )
 
-    context("CoreAudioItemPlayer plays each bundled format end-to-end with FakeAudioLine") {
+    context("FXAudioItemPlayer plays each bundled format end-to-end with FakeAudioLine") {
         withData(
             nameFn = { it.label },
             // WAV — PCM byte-aligned, near-exact duration probe
@@ -81,8 +98,10 @@ internal class CoreAudioItemPlayerFormatIntegrationTest : FunSpec({
             FormatCase("Vorbis-OGG", "testeable_vorbis.ogg", expectedMs = 24_705L, toleranceMs = 100L),
             // AAC/M4A — DurationProber probes asynchronously for M4A; wider tolerance
             FormatCase("AAC/M4A", "testeable_aac.m4a", expectedMs = 41_559L, toleranceMs = 500L)
+            // ALAC (testeable_alac.m4a) and Opus (testeable_opus.ogg) are not in this matrix:
+            // AudioItemPlayer.isPlayable() returns false for both formats — play() would throw UnsupportedAudioPlaybackException.
         ) { (_, resourcePath, expectedMs, toleranceMs) ->
-            val player = testPlayer(::decodeToPcmStream) { FakeAudioLine() }
+            val player = testFxPlayer()
             val file = ArbitraryAudioFile.getResourceAsFile("/testfiles/$resourcePath")
             val audioItem = Arb.audioItem { path = file.toPath() }.next()
             player.setVolume(0.0)
@@ -112,30 +131,12 @@ internal class CoreAudioItemPlayerFormatIntegrationTest : FunSpec({
 })
 
 /**
- * PCM-to-line smoke test for [CoreAudioItemPlayer] that opens a real [javax.sound.sampled.SourceDataLine].
+ * Builds an [FXAudioItemPlayer] wrapping a real [net.transgressoft.commons.media.player.CoreAudioItemPlayer]
+ * with [FakeAudioLine] substituting the hardware output sink.
  *
- * Excluded from default CI via `-PexcludeAudioHardware=true`; run on a machine with
- * audio output to verify the full JavaSound SPI pipeline end-to-end.
+ * Delegates to [testPlayer] from the media testFixtures, which uses the real
+ * [net.transgressoft.commons.media.util.decodeToPcmStream] factory so actual codec-specific SPI
+ * decoding occurs. [FakeAudioLine] drains written bytes immediately and advances a virtual
+ * clock deterministically, enabling status-transition and duration assertions without audio hardware.
  */
-@Tags("audio-hardware")
-internal class CoreAudioItemPlayerFormatSmokeTest : FunSpec({
-
-    test("PCM-to-line smoke: MP3 CBR plays through real SourceDataLine") {
-        val player = CoreAudioItemPlayer()
-        val file = ArbitraryAudioFile.getResourceAsFile("/testfiles/testeable_cbr.mp3")
-        val audioItem = Arb.audioItem { path = file.toPath() }.next()
-        player.setVolume(0.0)
-
-        try {
-            player.play(audioItem)
-            player.status() shouldBe Status.PLAYING
-
-            // Generous timeout because audio output is real-time and CI runners add latency
-            eventually(15.seconds) {
-                player.status() shouldBe Status.READY
-            }
-        } finally {
-            player.dispose()
-        }
-    }
-})
+private fun testFxPlayer(): FXAudioItemPlayer = FXAudioItemPlayer(testPlayer(lineFactory = { FakeAudioLine() }))

--- a/music-commons-media/build.gradle
+++ b/music-commons-media/build.gradle
@@ -1,4 +1,16 @@
+plugins {
+    id 'java-test-fixtures'
+}
+
 description = 'Transgressoft Music Commons - Media (JavaSound)'
+
+kotlin {
+    target {
+        compilations.named('testFixtures') {
+            associateWith(compilations.named('main').get())
+        }
+    }
+}
 
 dependencies {
     api project(path: ':music-commons-api')

--- a/music-commons-media/src/main/kotlin/net/transgressoft/commons/media/waveform/ScalableAudioWaveform.kt
+++ b/music-commons-media/src/main/kotlin/net/transgressoft/commons/media/waveform/ScalableAudioWaveform.kt
@@ -51,12 +51,27 @@ import kotlinx.serialization.Transient
  *
  * The waveform data can be scaled to different widths and heights and can generate visual
  * waveform images for display purposes.
+ *
+ * Decoded PCM is bounded by [maxPcmBytes] to prevent unbounded heap growth when processing
+ * untrusted or decode-bomb audio files. Exceeding the ceiling throws [AudioWaveformProcessingException].
  */
 @Serializable
 class ScalableAudioWaveform(
     override val id: Int,
-    override val audioFilePath: Path
+    override val audioFilePath: Path,
+    val maxPcmBytes: Long = DEFAULT_MAX_PCM_BYTES
 ) : ReactiveEntityBase<Int, AudioWaveform>(), AudioWaveform {
+
+    companion object {
+
+        /**
+         * Default maximum PCM bytes accumulated during waveform extraction (~1 GiB, enough for
+         * roughly 1.7 hours of stereo 44.1 kHz/16-bit audio). This ceiling exists to bound
+         * memory growth when decoding untrusted audio content; a crafted or infinitely-looping
+         * file would otherwise exhaust the JVM heap before `getRawAudioPcm` returns.
+         */
+        const val DEFAULT_MAX_PCM_BYTES: Long = 1_073_741_824L
+    }
 
     @Transient private val cacheMutex = Mutex()
 
@@ -73,8 +88,9 @@ class ScalableAudioWaveform(
         id: Int,
         audioFilePath: Path,
         cachedWidth: Int,
-        normalizedAmplitudes: FloatArray
-    ) : this(id, audioFilePath) {
+        normalizedAmplitudes: FloatArray,
+        maxPcmBytes: Long = DEFAULT_MAX_PCM_BYTES
+    ) : this(id, audioFilePath, maxPcmBytes) {
         this.cachedWidth = cachedWidth
         this.normalizedAmplitudes = normalizedAmplitudes
     }
@@ -102,9 +118,18 @@ class ScalableAudioWaveform(
                 pcmStream.use { stream ->
                     val buf = ByteArrayOutputStream()
                     val buffer = ByteArray(8192)
+                    var accumulated = 0L
                     var bytesRead = stream.read(buffer)
                     while (bytesRead != -1) {
-                        if (bytesRead > 0) buf.write(buffer, 0, bytesRead)
+                        if (bytesRead > 0) {
+                            accumulated += bytesRead
+                            if (accumulated > maxPcmBytes) {
+                                throw AudioWaveformProcessingException(
+                                    "PCM data for '$audioFilePath' exceeds the $maxPcmBytes-byte limit"
+                                )
+                            }
+                            buf.write(buffer, 0, bytesRead)
+                        }
                         bytesRead = stream.read(buffer)
                     }
                     buf.toByteArray()
@@ -247,9 +272,9 @@ class ScalableAudioWaveform(
     override fun clone(): ScalableAudioWaveform {
         val cached = normalizedAmplitudes
         return if (cached != null) {
-            ScalableAudioWaveform(id, audioFilePath, cachedWidth, cached.copyOf())
+            ScalableAudioWaveform(id, audioFilePath, cachedWidth, cached.copyOf(), maxPcmBytes)
         } else {
-            ScalableAudioWaveform(id, audioFilePath)
+            ScalableAudioWaveform(id, audioFilePath, maxPcmBytes)
         }
     }
 

--- a/music-commons-media/src/test/kotlin/net/transgressoft/commons/media/player/CoreAudioItemPlayerFormatIntegrationTest.kt
+++ b/music-commons-media/src/test/kotlin/net/transgressoft/commons/media/player/CoreAudioItemPlayerFormatIntegrationTest.kt
@@ -1,0 +1,142 @@
+/******************************************************************************
+ * Copyright (C) 2026  Octavio Calleya Garcia                                 *
+ *                                                                            *
+ * This program is free software: you can redistribute it and/or modify       *
+ * it under the terms of the GNU General Public License as published by       *
+ * the Free Software Foundation, either version 3 of the License, or          *
+ * (at your option) any later version.                                        *
+ *                                                                            *
+ * This program is distributed in the hope that it will be useful,            *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
+ * GNU General Public License for more details.                               *
+ *                                                                            *
+ * You should have received a copy of the GNU General Public License          *
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.     *
+ ******************************************************************************/
+
+package net.transgressoft.commons.media.player
+
+import net.transgressoft.commons.media.util.decodeToPcmStream
+import net.transgressoft.commons.music.audio.ArbitraryAudioFile
+import net.transgressoft.commons.music.audio.FakeAudioLine
+import net.transgressoft.commons.music.audio.audioItem
+import net.transgressoft.commons.music.player.AudioItemPlayer.Status
+import io.kotest.assertions.nondeterministic.eventually
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.annotation.Tags
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.datatest.withData
+import io.kotest.matchers.longs.shouldBeGreaterThan
+import io.kotest.matchers.longs.shouldBeLessThan
+import io.kotest.matchers.shouldBe
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.next
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Per-format end-to-end integration tests for [CoreAudioItemPlayer] using [FakeAudioLine] to
+ * exercise the real SPI decode pipeline without audio hardware.
+ *
+ * Each test row drives the real [decodeToPcmStream] factory so actual codec-specific decoding
+ * happens; only the hardware output sink is replaced by [FakeAudioLine]. The test matrix covers
+ * the 6 formats for which [net.transgressoft.commons.music.player.AudioItemPlayer.isPlayable]
+ * returns `true`: MP3 VBR, MP3 CBR, FLAC, AAC/M4A, WAV, and Vorbis/OGG.
+ *
+ * ALAC (`testeable_alac.m4a`) and Opus (`testeable_opus.ogg`) are excluded from the playback
+ * matrix because [net.transgressoft.commons.music.player.AudioItemPlayer.isPlayable] returns
+ * `false` for them — calling `play()` on an ALAC or Opus item throws
+ * [net.transgressoft.commons.music.player.UnsupportedAudioPlaybackException]. Their SPI-decode
+ * coverage lives in [SpiProviderVerificationTest] at the `AudioSystem.getAudioInputStream()` level.
+ */
+@DisplayName("CoreAudioItemPlayer per-format integration")
+internal class CoreAudioItemPlayerFormatIntegrationTest : FunSpec({
+
+    /**
+     * Describes a single playable format row in the test matrix.
+     *
+     * @param label human-readable format name used in test output
+     * @param resourcePath classpath-relative path under `/testfiles/`
+     * @param expectedMs ground-truth duration in milliseconds (from ffprobe)
+     * @param toleranceMs acceptable deviation from [expectedMs] in milliseconds
+     */
+    data class FormatCase(
+        val label: String,
+        val resourcePath: String,
+        val expectedMs: Long,
+        val toleranceMs: Long
+    )
+
+    context("CoreAudioItemPlayer plays each bundled format end-to-end with FakeAudioLine") {
+        withData(
+            nameFn = { it.label },
+            // WAV — PCM byte-aligned, near-exact duration probe
+            FormatCase("WAV", "testeable.wav", expectedMs = 8_787L, toleranceMs = 10L),
+            // FLAC — one FLAC frame ≤ 4096 samples (~93 ms at 44.1 kHz); decoder reports close to exact
+            FormatCase("FLAC", "testeable.flac", expectedMs = 27_609L, toleranceMs = 50L),
+            // MP3 VBR — Xing header duration probe reliable; one MPEG frame ~26 ms
+            FormatCase("MP3 VBR", "testeable.mp3", expectedMs = 16_867L, toleranceMs = 100L),
+            // MP3 CBR — DurationProber resolves asynchronously (no Xing header); wider tolerance
+            FormatCase("MP3 CBR", "testeable_cbr.mp3", expectedMs = 16_901L, toleranceMs = 500L),
+            // Vorbis-OGG — granulepos accurate; OGG container duration reads well
+            FormatCase("Vorbis-OGG", "testeable_vorbis.ogg", expectedMs = 24_705L, toleranceMs = 100L),
+            // AAC/M4A — DurationProber probes asynchronously for M4A; wider tolerance
+            FormatCase("AAC/M4A", "testeable_aac.m4a", expectedMs = 41_559L, toleranceMs = 500L)
+        ) { (_, resourcePath, expectedMs, toleranceMs) ->
+            val player = testPlayer(::decodeToPcmStream) { FakeAudioLine() }
+            val file = ArbitraryAudioFile.getResourceAsFile("/testfiles/$resourcePath")
+            val audioItem = Arb.audioItem { path = file.toPath() }.next()
+            player.setVolume(0.0)
+
+            try {
+                player.play(audioItem)
+                player.status() shouldBe Status.PLAYING
+
+                // CBR/AAC resolve totalDuration asynchronously via a background probe thread;
+                // wait for the value to settle before asserting the tolerance window.
+                eventually(5.seconds) {
+                    player.totalDuration.toMillis() shouldBeGreaterThan 0L
+                }
+                val durationMs = player.totalDuration.toMillis()
+                durationMs shouldBeGreaterThan (expectedMs - toleranceMs)
+                durationMs shouldBeLessThan (expectedMs + toleranceMs)
+
+                // FakeAudioLine drains near-instantly; wait for the pump to reach READY.
+                eventually(10.seconds) {
+                    player.status() shouldBe Status.READY
+                }
+            } finally {
+                player.dispose()
+            }
+        }
+    }
+})
+
+/**
+ * PCM-to-line smoke test for [CoreAudioItemPlayer] that opens a real [javax.sound.sampled.SourceDataLine].
+ *
+ * Excluded from default CI via `-PexcludeAudioHardware=true`; run on a machine with
+ * audio output to verify the full JavaSound SPI pipeline end-to-end.
+ */
+@Tags("audio-hardware")
+internal class CoreAudioItemPlayerFormatSmokeTest : FunSpec({
+
+    test("PCM-to-line smoke: MP3 CBR plays through real SourceDataLine") {
+        val player = CoreAudioItemPlayer()
+        val file = ArbitraryAudioFile.getResourceAsFile("/testfiles/testeable_cbr.mp3")
+        val audioItem = Arb.audioItem { path = file.toPath() }.next()
+        player.setVolume(0.0)
+
+        try {
+            player.play(audioItem)
+            player.status() shouldBe Status.PLAYING
+
+            // Generous timeout because audio output is real-time and CI runners add latency
+            eventually(15.seconds) {
+                player.status() shouldBe Status.READY
+            }
+        } finally {
+            player.dispose()
+        }
+    }
+})

--- a/music-commons-media/src/test/kotlin/net/transgressoft/commons/media/player/CoreAudioItemPlayerPlaybackTest.kt
+++ b/music-commons-media/src/test/kotlin/net/transgressoft/commons/media/player/CoreAudioItemPlayerPlaybackTest.kt
@@ -20,7 +20,6 @@ package net.transgressoft.commons.media.player
 import net.transgressoft.commons.media.util.decodeToPcmStream
 import net.transgressoft.commons.music.audio.ArbitraryAudioFile.realAudioFile
 import net.transgressoft.commons.music.audio.AudioFileTagType.WAV
-import net.transgressoft.commons.music.audio.FakeAudioLine
 import net.transgressoft.commons.music.audio.audioItem
 import net.transgressoft.commons.music.player.AudioItemPlayer.Status
 import net.transgressoft.commons.music.player.UnsupportedAudioPlaybackException

--- a/music-commons-media/src/test/kotlin/net/transgressoft/commons/media/player/CoreAudioItemPlayerSeekIntegrationTest.kt
+++ b/music-commons-media/src/test/kotlin/net/transgressoft/commons/media/player/CoreAudioItemPlayerSeekIntegrationTest.kt
@@ -18,7 +18,6 @@
 package net.transgressoft.commons.media.player
 
 import net.transgressoft.commons.music.audio.ArbitraryAudioFile
-import net.transgressoft.commons.music.audio.FakeAudioLine
 import net.transgressoft.commons.music.audio.audioItem
 import io.kotest.assertions.nondeterministic.eventually
 import io.kotest.core.annotation.DisplayName

--- a/music-commons-media/src/test/kotlin/net/transgressoft/commons/media/player/CoreAudioItemPlayerSeekIntegrationTest.kt
+++ b/music-commons-media/src/test/kotlin/net/transgressoft/commons/media/player/CoreAudioItemPlayerSeekIntegrationTest.kt
@@ -1,0 +1,174 @@
+/******************************************************************************
+ * Copyright (C) 2026  Octavio Calleya Garcia                                 *
+ *                                                                            *
+ * This program is free software: you can redistribute it and/or modify       *
+ * it under the terms of the GNU General Public License as published by       *
+ * the Free Software Foundation, either version 3 of the License, or          *
+ * (at your option) any later version.                                        *
+ *                                                                            *
+ * This program is distributed in the hope that it will be useful,            *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
+ * GNU General Public License for more details.                               *
+ *                                                                            *
+ * You should have received a copy of the GNU General Public License          *
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.     *
+ ******************************************************************************/
+
+package net.transgressoft.commons.media.player
+
+import net.transgressoft.commons.music.audio.ArbitraryAudioFile
+import net.transgressoft.commons.music.audio.FakeAudioLine
+import net.transgressoft.commons.music.audio.audioItem
+import io.kotest.assertions.nondeterministic.eventually
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.longs.shouldBeGreaterThan
+import io.kotest.matchers.longs.shouldBeLessThan
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.next
+import java.io.InputStream
+import java.time.Duration
+import javax.sound.sampled.AudioFormat
+import javax.sound.sampled.AudioInputStream
+import javax.sound.sampled.AudioSystem
+import kotlin.time.Duration.Companion.seconds
+
+private val PCM_FORMAT_SEEK = AudioFormat(44_100f, 16, 2, true, false)
+
+/**
+ * A PCM stream whose reads always return 0 (no data yet, not EOF), causing the pump to loop
+ * at [PlaybackPump]'s [ZERO_READ_BACKOFF_MILLIS][PlaybackPump.ZERO_READ_BACKOFF_MILLIS]-ms
+ * intervals and re-check [CoreAudioItemPlayer.seekTargetMillis] on every iteration.
+ *
+ * [FakeAudioLine] drains real fixtures near-instantly, which races the pump to READY before a
+ * seek can be consumed. A zero-read source keeps the player in PLAYING indefinitely without
+ * blocking the pump thread, so the test can issue a seek and the pump picks it up on the next
+ * loop iteration rather than after the fixture drains to EOF.
+ */
+private fun zeroPcmStream(): AudioInputStream {
+    val zero =
+        object : InputStream() {
+            override fun read(): Int = 0
+
+            override fun read(b: ByteArray, off: Int, len: Int): Int = 0
+        }
+    return AudioInputStream(zero, PCM_FORMAT_SEEK, AudioSystem.NOT_SPECIFIED.toLong())
+}
+
+/**
+ * End-to-end seek integration tests for [CoreAudioItemPlayer] that exercise the frame-accurate
+ * [Mp3PcmStreamSeeker] and [OggPcmStreamSeeker] code paths through the real decode pipeline.
+ *
+ * Each test drives a seek-while-playing flow. The initial PCM source is a zero-read stream that
+ * keeps the pump looping in PLAYING without blocking it — the pump checks
+ * [CoreAudioItemPlayer.seekTargetMillis] on every zero-read iteration. When a seek is issued,
+ * the pump consumes [CoreAudioItemPlayer.seekTargetMillis] and calls [reopenAtSeekTarget], which
+ * calls [openStreamSession] against the real fixture file via the registered seeker chain
+ * ([Mp3PcmStreamSeeker] or [OggPcmStreamSeeker]). The seeker sets
+ * [CoreAudioItemPlayer.framePosition] to the actual landed PCM byte offset, and [openLine]
+ * copies that into [CoreAudioItemPlayer.lineStartFrameOffset]. After the pump writes the first
+ * buffer from the seeked stream it clears [CoreAudioItemPlayer.seekPreviewMillis].
+ *
+ * The assertion checks [CoreAudioItemPlayer.lineStartFrameOffset] once
+ * [CoreAudioItemPlayer.seekPreviewMillis] has cleared, converting it to milliseconds with the
+ * same formula used by [CoreAudioItemPlayer.getCurrentTime]. This value reflects what the seeker
+ * actually produced — not the preview shortcut that [seek] sets directly — so the assertion
+ * can only pass when the real per-format seeker positioned the stream correctly.
+ *
+ * Seek-precision tolerance is ±500 ms for both formats, which comfortably covers one MP3 frame
+ * (~26 ms at 128 kbps) and the OGG granulepos drain margin.
+ */
+@DisplayName("CoreAudioItemPlayer seek integration")
+internal class CoreAudioItemPlayerSeekIntegrationTest : FunSpec({
+
+    test("CoreAudioItemPlayer seeks CBR MP3 to correct frame boundary via Mp3PcmStreamSeeker") {
+        // testeable_cbr.mp3 has no Xing/Info header — exercises the Mp3PcmStreamSeeker
+        // frame-scan fallback (CBR path, not TOC path).
+        val cbrFile = ArbitraryAudioFile.getResourceAsFile("/testfiles/testeable_cbr.mp3")
+        val audioItem = Arb.audioItem { path = cbrFile.toPath() }.next()
+
+        // zeroPcmStream holds the pump in PLAYING without blocking it, so seek() is consumed
+        // naturally by the pump's seek-target check at the top of its main loop.
+        // decodeToPcmStream is NOT used for the initial open; the seeker chain uses the real
+        // fixture file directly when processing the seek, so Mp3PcmStreamSeeker is exercised.
+        val player = testPlayer(pcmStreamFactory = { zeroPcmStream() }) { FakeAudioLine() }
+        player.setVolume(0.0)
+
+        try {
+            player.play(audioItem)
+
+            // Wait for the pump to enter the streaming loop (pcmFormat resolved from zeroPcmStream).
+            eventually(3.seconds) {
+                player.pcmFormat.get() shouldNotBe null
+            }
+
+            val targetMs = 5_000L
+            val toleranceMs = 500L
+
+            // Issue seek while PLAYING so the pump consumes seekTargetMillis in its main loop.
+            // Pausing before seeking would leave seekPreviewMillis permanently set (pump never
+            // runs reopenAtSeekTarget while PAUSED), making getCurrentTime() return the preview
+            // value rather than the seeker-computed lineStartFrameOffset.
+            player.seek(Duration.ofMillis(targetMs))
+
+            // Wait for the pump to process the seek. lineStartFrameOffset > 0 confirms the seeker
+            // set framePosition from seekResult.startByteOffset (not from a zero-offset initial open).
+            // seekPreviewMillis < 0 confirms the pump wrote at least one buffer from the seeked stream.
+            eventually(5.seconds) {
+                player.lineStartFrameOffset shouldBeGreaterThan 0L
+                player.seekPreviewMillis shouldBe -1L
+            }
+
+            // lineStartFrameOffset is the seeker's actual output, copied into the player by openLine().
+            // Converting it to ms with the same formula as getCurrentTime() proves the seeker
+            // repositioned the stream — not that seekPreviewMillis was echoed back.
+            val fs = player.frameSize.toLong()
+            val rate = player.frameRate
+            val landedMs = (player.lineStartFrameOffset * 1000.0 / fs / rate).toLong()
+            landedMs shouldBeGreaterThan (targetMs - toleranceMs)
+            landedMs shouldBeLessThan (targetMs + toleranceMs)
+        } finally {
+            player.dispose()
+        }
+    }
+
+    test("CoreAudioItemPlayer seeks Vorbis OGG to correct PCM offset via OggPcmStreamSeeker") {
+        // testeable_vorbis.ogg (~24.7 s) exercises the OggPcmStreamSeeker granulepos bisection
+        // and forward-drain path to a sample-accurate PCM offset.
+        val oggFile = ArbitraryAudioFile.getResourceAsFile("/testfiles/testeable_vorbis.ogg")
+        val audioItem = Arb.audioItem { path = oggFile.toPath() }.next()
+
+        val player = testPlayer(pcmStreamFactory = { zeroPcmStream() }) { FakeAudioLine() }
+        player.setVolume(0.0)
+
+        try {
+            player.play(audioItem)
+
+            eventually(3.seconds) {
+                player.pcmFormat.get() shouldNotBe null
+            }
+
+            // Pick a mid-track target well within the fixture duration.
+            val targetMs = 10_000L
+            val toleranceMs = 500L
+
+            player.seek(Duration.ofMillis(targetMs))
+
+            eventually(15.seconds) {
+                player.lineStartFrameOffset shouldBeGreaterThan 0L
+                player.seekPreviewMillis shouldBe -1L
+            }
+
+            val fs = player.frameSize.toLong()
+            val rate = player.frameRate
+            val landedMs = (player.lineStartFrameOffset * 1000.0 / fs / rate).toLong()
+            landedMs shouldBeGreaterThan (targetMs - toleranceMs)
+            landedMs shouldBeLessThan (targetMs + toleranceMs)
+        } finally {
+            player.dispose()
+        }
+    }
+})

--- a/music-commons-media/src/test/kotlin/net/transgressoft/commons/media/player/FakeAudioLineTest.kt
+++ b/music-commons-media/src/test/kotlin/net/transgressoft/commons/media/player/FakeAudioLineTest.kt
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.     *
  ******************************************************************************/
 
-package net.transgressoft.commons.music.audio
+package net.transgressoft.commons.media.player
 
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe

--- a/music-commons-media/src/test/kotlin/net/transgressoft/commons/media/waveform/ScalableAudioWaveformTest.kt
+++ b/music-commons-media/src/test/kotlin/net/transgressoft/commons/media/waveform/ScalableAudioWaveformTest.kt
@@ -1,6 +1,7 @@
 package net.transgressoft.commons.media.waveform
 
 import net.transgressoft.commons.media.player.SUPPORTED_FORMATS
+import net.transgressoft.commons.music.audio.ArbitraryAudioFile
 import net.transgressoft.commons.music.audio.ArbitraryAudioFile.realAudioFile
 import net.transgressoft.commons.music.audio.AudioFileTagType.WAV
 import net.transgressoft.commons.music.waveform.AudioWaveformProcessingException
@@ -126,6 +127,29 @@ internal class ScalableAudioWaveformTest : FunSpec({
                 waveform.amplitudes(width, height)
             }
         }
+    }
+
+    test("ScalableAudioWaveform throws AudioWaveformProcessingException when PCM exceeds maxPcmBytes") {
+        // WAV at 44.1kHz/16-bit stereo: ~8787ms * 44100 * 2 * 2 ≈ 1,553,846 bytes — well above 1024
+        val wavFile = ArbitraryAudioFile.getResourceAsFile("/testfiles/testeable.wav")
+        val tinyCapWaveform = ScalableAudioWaveform(1, wavFile.toPath(), maxPcmBytes = 1024L)
+
+        val exception =
+            shouldThrow<AudioWaveformProcessingException> {
+                tinyCapWaveform.amplitudes(780, 335, testDispatcher)
+            }
+
+        exception.message shouldContain wavFile.name
+        exception.message shouldContain "1024"
+    }
+
+    test("ScalableAudioWaveform with default ceiling computes amplitudes for a real WAV fixture") {
+        val wavFile = ArbitraryAudioFile.getResourceAsFile("/testfiles/testeable.wav")
+        val waveform = ScalableAudioWaveform(2, wavFile.toPath())
+
+        val result = waveform.amplitudes(780, 335, testDispatcher)
+
+        result.size shouldBe 780
     }
 })
 

--- a/music-commons-media/src/testFixtures/kotlin/net/transgressoft/commons/media/player/CoreAudioItemPlayerTestSupport.kt
+++ b/music-commons-media/src/testFixtures/kotlin/net/transgressoft/commons/media/player/CoreAudioItemPlayerTestSupport.kt
@@ -17,35 +17,32 @@
 
 package net.transgressoft.commons.media.player
 
-import net.transgressoft.commons.music.audio.AudioFileTagType
-import net.transgressoft.commons.music.audio.AudioFileTagType.FLAC
-import net.transgressoft.commons.music.audio.AudioFileTagType.ID3_V_24
-import net.transgressoft.commons.music.audio.AudioFileTagType.MP4_INFO
-import net.transgressoft.commons.music.audio.AudioFileTagType.VORBIS_COMMENT
-import net.transgressoft.commons.music.audio.AudioFileTagType.WAV
-import io.mockk.every
-import io.mockk.mockk
+import net.transgressoft.commons.media.util.decodeToPcmStream
+import java.nio.file.Path
+import javax.sound.sampled.AudioFormat
+import javax.sound.sampled.AudioInputStream
 import javax.sound.sampled.SourceDataLine
 
 /**
- * The five audio formats the media pipeline supports end-to-end, keyed by the display name used
- * in data-driven test tables and mapped to the tag type that selects the matching real fixture.
+ * Constructs a [CoreAudioItemPlayer] wired with test-friendly defaults.
+ *
+ * The frozen `nanoTime` clock and a stall threshold disabled via [Long.MAX_VALUE] make
+ * playback state-machine tests deterministic without real audio hardware. The caller
+ * supplies the PCM stream source and line factory to control what the pump reads and
+ * where it writes.
+ *
+ * @param pcmStreamFactory produces the decoded PCM stream for a given audio file path;
+ *   defaults to the real [decodeToPcmStream] decoder for tests that exercise actual fixtures.
+ * @param lineFactory produces the audio output line; defaults to [FakeAudioLine].
+ * @return a fully-wired [CoreAudioItemPlayer] ready for test-driven playback control.
  */
-val SUPPORTED_FORMATS: Map<String, AudioFileTagType> =
-    mapOf(
-        "mp3" to ID3_V_24,
-        "m4a" to MP4_INFO,
-        "wav" to WAV,
-        "flac" to FLAC,
-        "ogg" to VORBIS_COMMENT
+fun testPlayer(
+    pcmStreamFactory: (Path) -> AudioInputStream = ::decodeToPcmStream,
+    lineFactory: (AudioFormat) -> SourceDataLine = { FakeAudioLine() }
+): CoreAudioItemPlayer =
+    CoreAudioItemPlayer(
+        pcmStreamFactory = pcmStreamFactory,
+        lineFactory = lineFactory,
+        nanoTime = { 0L },
+        stallThresholdNanos = Long.MAX_VALUE
     )
-
-/**
- * A relaxed mock [SourceDataLine] that reports itself open and echoes back the byte count handed
- * to `write`, so the pump advances without real audio hardware.
- */
-fun fakeLine(): SourceDataLine =
-    mockk(relaxed = true) {
-        every { isOpen } returns true
-        every { write(any(), any(), any()) } answers { thirdArg() }
-    }

--- a/music-commons-media/src/testFixtures/kotlin/net/transgressoft/commons/media/player/FakeAudioLine.kt
+++ b/music-commons-media/src/testFixtures/kotlin/net/transgressoft/commons/media/player/FakeAudioLine.kt
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.     *
  ******************************************************************************/
 
-package net.transgressoft.commons.music.audio
+package net.transgressoft.commons.media.player
 
 import javax.sound.sampled.AudioFormat
 import javax.sound.sampled.AudioSystem
@@ -29,17 +29,16 @@ import javax.sound.sampled.SourceDataLine
  * [SourceDataLine] test double that replaces real hardware output with a virtual clock.
  *
  * Position advances deterministically from bytes written ÷ frame size × frame rate of the
- * open [AudioFormat]; [write] is non-blocking and always accepts all bytes. Use via the
- * [CoreAudioItemPlayer][net.transgressoft.commons.media.player.CoreAudioItemPlayer]
- * `lineFactory` constructor parameter to run playback state-machine tests without
- * real audio hardware or thread sleeps.
+ * open [AudioFormat]; [write] is non-blocking and always accepts all bytes. Use via
+ * [CoreAudioItemPlayerTestSupport] to run playback state-machine tests without real audio
+ * hardware or thread sleeps.
  *
- * Virtual-clock formula (D-01):
+ * Virtual-clock formula:
  * `getMicrosecondPosition() = (totalBytesWritten × 1_000_000.0 / frameSize / frameRate).toLong()`
  *
- * The clock halts while the line is stopped and resumes on [start] (D-03). [flush] resets
+ * The clock halts while the line is stopped and resumes on [start]. [flush] resets
  * the accumulated byte count to zero. [drain] is a no-op. [available] and [getBufferSize]
- * return [Int.MAX_VALUE] so the pump thread never simulates backpressure (D-04).
+ * return [Int.MAX_VALUE] so the pump thread never simulates backpressure.
  *
  * @see SourceDataLine
  */
@@ -80,7 +79,7 @@ class FakeAudioLine : SourceDataLine {
     }
 
     override fun drain() {
-        // No-op: virtual line has no buffered bytes to wait for (D-03)
+        // No-op: virtual line has no buffered bytes to wait for
     }
 
     override fun flush() {

--- a/music-commons-test/src/main/kotlin/net/transgressoft/commons/music/testing/RegistryIsolationExtension.kt
+++ b/music-commons-test/src/main/kotlin/net/transgressoft/commons/music/testing/RegistryIsolationExtension.kt
@@ -1,0 +1,98 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.commons.music.testing
+
+import io.kotest.core.extensions.SpecExtension
+import io.kotest.core.spec.Spec
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+// Process-wide mutex shared by all specs that touch the [net.transgressoft.lirp.persistence.RegistryBase]
+// singleton. Serializes every registry-touching spec against every other spec doing the same,
+// preventing "A repository for X is already registered." collision errors under parallel execution.
+internal val registryMutex = Mutex()
+
+/**
+ * Kotest [SpecExtension] that serializes specs touching the process-wide
+ * `RegistryBase` / `LirpContext.default` registry against each other.
+ *
+ * `RegistryBase.registerRepository` binds entity-type → repository on the singleton
+ * `LirpContext.default`. When two specs both call `registerRepository` for the same entity type
+ * without a preceding `deregisterRepository`, the second call hits the
+ * `"A repository for X is already registered."` check error. Under `LimitedConcurrency(4)` in
+ * `music-commons-core`, this collision is an active test-parallelism hazard whenever more than
+ * one registry-touching spec runs simultaneously.
+ *
+ * This extension wraps the full spec body in [registryMutex] so registry-touching specs are
+ * serialized against each other while all other specs remain free to run in parallel.
+ *
+ * **Residual production risk:** the collision described above only arises when multiple library
+ * instances share `LirpContext.default` in one process. Normal production usage is a single
+ * library instance per process, so the collision is not a practical production concern. The
+ * `music-commons-fx` module already runs its specs sequentially (JavaFX toolkit is process-global),
+ * providing an independent layer of protection there; the active surface is `music-commons-core`
+ * at `LimitedConcurrency(4)`.
+ *
+ * **Durable fix:** the root cause is that `RegistryBase.registerRepository` has no instance-scoped
+ * registration path — it is hard-wired to `LirpContext.default`. An instance-scoped registration
+ * API in lirp (so registries can bind to an application-owned context rather than the process-wide
+ * default) would remove the need for this serialization entirely. That enhancement is tracked as
+ * an upstream lirp improvement.
+ *
+ * Register per-spec via the [registryIsolation] convenience factory:
+ *
+ *     class FooPlaylistTest : StringSpec({
+ *         registryIsolation()
+ *
+ *         beforeEach {
+ *             RegistryBase.deregisterRepository(AudioItem::class.java)
+ *             RegistryBase.registerRepository(AudioItem::class.java, audioItemRepository)
+ *         }
+ *     })
+ *
+ * The per-spec `deregisterRepository`/`registerRepository` bracketing in `beforeEach`/`afterEach`
+ * blocks should be kept — entity types differ per spec and the extension's job is serialization
+ * only, not per-spec state setup.
+ *
+ * @see ReactiveScopeSerialization for the analogous extension serializing [net.transgressoft.lirp.event.ReactiveScope]-touching specs.
+ */
+object RegistryIsolationExtension : SpecExtension {
+
+    override suspend fun intercept(spec: Spec, execute: suspend (Spec) -> Unit) {
+        registryMutex.withLock { execute(spec) }
+    }
+}
+
+/**
+ * Convenience factory that registers [RegistryIsolationExtension] on the spec.
+ *
+ * Call once at the top of the [Spec] body, alongside other shared extensions:
+ *
+ *     class FooPlaylistTest : StringSpec({
+ *         registryIsolation()
+ *         val reactive = reactiveScope()
+ *
+ *         beforeEach {
+ *             RegistryBase.deregisterRepository(AudioItem::class.java)
+ *             RegistryBase.registerRepository(AudioItem::class.java, myRepo)
+ *         }
+ *     })
+ */
+fun Spec.registryIsolation() {
+    extension(RegistryIsolationExtension)
+}


### PR DESCRIPTION
## Summary
Closes the framework and media tech-debt items under #178: the hand-written lirp aggregate-reference accessors are re-validated and guarded, the process-wide registry collision risk is mitigated for tests, every bundled audio decoder is exercised end-to-end, untrusted decoding is memory-bounded, and per-format seek behavior is documented and tested.

## Framework
- **#179 / #181** — Re-validated the `MutablePlaylist`/`FXPlaylist` `_LirpRefAccessor` files; corrected their docs to the real rationale (the reactive base modules deliberately omit lirp-ksp to stay persistence-agnostic — codegen works when the entity is annotated) and added `Class.forName` naming-contract guard tests.
- **#180** — Added `RegistryIsolationExtension` serializing registry-touching test specs, closing a latent cross-instance registration race; documented residual risk.

## Media
- **#190** — Bounded PCM accumulation in `ScalableAudioWaveform`: a configurable maximum (1 GiB default) throws `AudioWaveformProcessingException` when exceeded, so a crafted file cannot drive unbounded memory growth.
- **#183** — Documented AAC/M4A byte-skip seek behavior on `AudioItemPlayer.seek`; added real-fixture seek tests for the frame-accurate MP3 and OGG paths.
- **#182** — Per-format end-to-end playback tests over a real `CoreAudioItemPlayer`, plus ALAC/Opus SPI-decode coverage. Added `THIRD-PARTY-LICENSES.md` auditing every bundled decoder (tritonus-share LGPL-2.1 confirmed GPL-3.0-compatible), linked from the README.
- **#189** — FX per-format integration over a real core player. Added a `music-commons-media` test-fixtures module hosting player test-support (`FakeAudioLine`, a deterministic-player factory) consumed by the FX tests.

## Testing
`gradle compileKotlin compileTestKotlin ktlintCheck test -PexcludeAudioHardware=true` — 820 tests, 0 failures. The one hardware-dependent smoke test is tagged `audio-hardware` and excluded via `-PexcludeAudioHardware=true` (as CI runs it).

## Breaking changes
None to the public API.

Closes #179
Closes #180
Closes #181
Closes #182
Closes #183
Closes #189
Closes #190
