### PR TITLE
#193 Right-size logging levels and add missing diagnostic logs

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,6 +41,7 @@ kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "
 coroutines-bom = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-bom", version.ref = "coroutines" }
 coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core" }
 coroutines-javafx = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-javafx" }
+coroutines-slf4j = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-slf4j" }
 coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines-test" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 lirp-api = { module = "net.transgressoft:lirp-api", version.ref = "lirp" }

--- a/music-commons-core/build.gradle
+++ b/music-commons-core/build.gradle
@@ -8,6 +8,7 @@ dependencies {
     implementation libs.jaudiotagger.get()
     implementation libs.lirp.core.get()
     implementation libs.dd.plist.get()
+    implementation libs.coroutines.slf4j.get()
 
     testImplementation project(path: ':music-commons-test')
     testImplementation project(path: ':music-commons-persistence')

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/AlbumRegistryBase.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/AlbumRegistryBase.kt
@@ -25,7 +25,9 @@ import net.transgressoft.lirp.event.StandardCrudEvent.Delete
 import net.transgressoft.lirp.event.StandardCrudEvent.Update
 import net.transgressoft.lirp.persistence.projection.ObservableProjection
 import mu.KotlinLogging
+import mu.withLoggingContext
 import java.util.Optional
+import java.util.UUID
 
 /**
  * Abstract base for album registries backed by a lirp [ObservableProjection].
@@ -65,24 +67,27 @@ abstract class AlbumRegistryBase<I, AE>(private val publisherName: String = "Alb
     protected fun observeAlbumChanges(projection: ObservableProjection<AlbumDetails, AE>) {
         entriesChangedHandle =
             projection.addOnEntriesChangedListener { changes ->
-                for ((album, oldAlbum, newAlbum) in changes) {
-                    when {
-                        oldAlbum == null && newAlbum != null -> {
-                            albumPublisher.emitAsync(Create(newAlbum))
-                            log.debug { "Album created for ${album.name}" }
-                        }
-                        oldAlbum != null && newAlbum != null -> {
-                            // Use the canonical bucket key (not the representative album.id) as the shared
-                            // map key so the Update consistency check passes even when the representative's
-                            // year, label, or casing differs between old and new values.
-                            albumPublisher.emitAsync(Update(mapOf(album to newAlbum), mapOf(album to oldAlbum)))
-                            log.debug { "Album updated for ${album.name}" }
-                        }
-                        oldAlbum != null && newAlbum == null -> {
-                            albumPublisher.emitAsync(Delete(oldAlbum))
-                            log.debug { "Album deleted for ${album.name}" }
+                withLoggingContext("catalogRebuildId" to UUID.randomUUID().toString()) {
+                    for ((album, oldAlbum, newAlbum) in changes) {
+                        when {
+                            oldAlbum == null && newAlbum != null -> {
+                                albumPublisher.emitAsync(Create(newAlbum))
+                                log.trace { "Album created for ${album.name}" }
+                            }
+                            oldAlbum != null && newAlbum != null -> {
+                                // Use the canonical bucket key (not the representative album.id) as the shared
+                                // map key so the Update consistency check passes even when the representative's
+                                // year, label, or casing differs between old and new values.
+                                albumPublisher.emitAsync(Update(mapOf(album to newAlbum), mapOf(album to oldAlbum)))
+                                log.trace { "Album updated for ${album.name}" }
+                            }
+                            oldAlbum != null && newAlbum == null -> {
+                                albumPublisher.emitAsync(Delete(oldAlbum))
+                                log.trace { "Album deleted for ${album.name}" }
+                            }
                         }
                     }
+                    log.debug { "Album registry rebuilt: ${projection.size} entries" }
                 }
             }
     }

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/ArtistCatalogRegistryBase.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/ArtistCatalogRegistryBase.kt
@@ -25,7 +25,9 @@ import net.transgressoft.lirp.event.StandardCrudEvent.Delete
 import net.transgressoft.lirp.event.StandardCrudEvent.Update
 import net.transgressoft.lirp.persistence.projection.ObservableProjection
 import mu.KotlinLogging
+import mu.withLoggingContext
 import java.util.Optional
+import java.util.UUID
 
 /**
  * Abstract base for artist catalog registries backed by a lirp [ObservableProjection].
@@ -65,21 +67,24 @@ abstract class ArtistCatalogRegistryBase<I, AC>(private val publisherName: Strin
     protected fun observeCatalogChanges(projection: ObservableProjection<Artist, AC>) {
         entriesChangedHandle =
             projection.addOnEntriesChangedListener { changes ->
-                for ((artist, oldCatalog, newCatalog) in changes) {
-                    when {
-                        oldCatalog == null && newCatalog != null -> {
-                            artistCatalogPublisher.emitAsync(Create(newCatalog))
-                            log.debug { "Artist catalog created for ${artist.name}" }
-                        }
-                        oldCatalog != null && newCatalog != null -> {
-                            artistCatalogPublisher.emitAsync(Update(newCatalog, oldCatalog))
-                            log.debug { "Artist catalog updated for ${artist.name}" }
-                        }
-                        oldCatalog != null && newCatalog == null -> {
-                            artistCatalogPublisher.emitAsync(Delete(oldCatalog))
-                            log.debug { "Artist catalog deleted for ${artist.name}" }
+                withLoggingContext("catalogRebuildId" to UUID.randomUUID().toString()) {
+                    for ((artist, oldCatalog, newCatalog) in changes) {
+                        when {
+                            oldCatalog == null && newCatalog != null -> {
+                                artistCatalogPublisher.emitAsync(Create(newCatalog))
+                                log.trace { "Artist catalog created for ${artist.name}" }
+                            }
+                            oldCatalog != null && newCatalog != null -> {
+                                artistCatalogPublisher.emitAsync(Update(newCatalog, oldCatalog))
+                                log.trace { "Artist catalog updated for ${artist.name}" }
+                            }
+                            oldCatalog != null && newCatalog == null -> {
+                                artistCatalogPublisher.emitAsync(Delete(oldCatalog))
+                                log.trace { "Artist catalog deleted for ${artist.name}" }
+                            }
                         }
                     }
+                    log.debug { "Artist catalog rebuilt: ${projection.size} entries" }
                 }
             }
     }

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/DefaultAudioLibrary.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/DefaultAudioLibrary.kt
@@ -62,7 +62,7 @@ internal class DefaultAudioLibrary
                     val audioItemClone = audioItem.clone()
                     audioItem.incrementPlayCount()
                     repository.emitAsync(Update(audioItem, audioItemClone))
-                    logger.debug { "Play count for audio item ${audioItem.id} increased to ${audioItem.playCount}" }
+                    logger.trace { "Play count for audio item ${audioItem.id} increased to ${audioItem.playCount}" }
                 }
             }
         }
@@ -94,7 +94,7 @@ internal class DefaultAudioLibrary
             val tag = metadataIO.readMetadata(audioItemPath)
             return MutableAudioItem(audioItemPath, newId(), tag).also { audioItem ->
                 add(audioItem)
-                logger.debug { "New AudioItem was created from file $audioItemPath with id ${audioItem.id}" }
+                logger.trace { "New AudioItem was created from file $audioItemPath with id ${audioItem.id}" }
             }
         }
 

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/GenreIndexRegistryBase.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/GenreIndexRegistryBase.kt
@@ -25,7 +25,9 @@ import net.transgressoft.lirp.event.StandardCrudEvent.Delete
 import net.transgressoft.lirp.event.StandardCrudEvent.Update
 import net.transgressoft.lirp.persistence.projection.ObservableProjection
 import mu.KotlinLogging
+import mu.withLoggingContext
 import java.util.Optional
+import java.util.UUID
 
 /**
  * Abstract base for genre index registries backed by a lirp [ObservableProjection].
@@ -69,21 +71,24 @@ abstract class GenreIndexRegistryBase<I, GI>(private val publisherName: String =
     protected fun observeGenreIndexChanges(projection: ObservableProjection<Genre, GI>) {
         entriesChangedHandle =
             projection.addOnEntriesChangedListener { changes ->
-                for ((genre, oldIndex, newIndex) in changes) {
-                    when {
-                        oldIndex == null && newIndex != null -> {
-                            genreIndexPublisher.emitAsync(Create(newIndex))
-                            log.debug { "Genre index created for ${genre.name}" }
-                        }
-                        oldIndex != null && newIndex != null -> {
-                            genreIndexPublisher.emitAsync(Update(newIndex, oldIndex))
-                            log.debug { "Genre index updated for ${genre.name}" }
-                        }
-                        oldIndex != null && newIndex == null -> {
-                            genreIndexPublisher.emitAsync(Delete(oldIndex))
-                            log.debug { "Genre index deleted for ${genre.name}" }
+                withLoggingContext("catalogRebuildId" to UUID.randomUUID().toString()) {
+                    for ((genre, oldIndex, newIndex) in changes) {
+                        when {
+                            oldIndex == null && newIndex != null -> {
+                                genreIndexPublisher.emitAsync(Create(newIndex))
+                                log.trace { "Genre index created for ${genre.name}" }
+                            }
+                            oldIndex != null && newIndex != null -> {
+                                genreIndexPublisher.emitAsync(Update(newIndex, oldIndex))
+                                log.trace { "Genre index updated for ${genre.name}" }
+                            }
+                            oldIndex != null && newIndex == null -> {
+                                genreIndexPublisher.emitAsync(Delete(oldIndex))
+                                log.trace { "Genre index deleted for ${genre.name}" }
+                            }
                         }
                     }
+                    log.debug { "Genre index rebuilt: ${projection.size} entries" }
                 }
             }
     }

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/ImmutableAlbum.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/ImmutableAlbum.kt
@@ -103,6 +103,6 @@ internal class ImmutableAlbum<I>(override val album: AlbumDetails, tracks: List<
     override fun toString() = "ImmutableAlbum(album=$album, size=$size)"
 
     init {
-        logger.debug { "Album created for ${album.name}" }
+        logger.trace { "Album created for ${album.name}" }
     }
 }

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/ImmutableArtistCatalog.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/ImmutableArtistCatalog.kt
@@ -94,7 +94,7 @@ internal class ImmutableArtistCatalog<I>(override val artist: Artist, audioItems
     override fun toString() = "ImmutableArtistCatalog(artist=$artist, size=$size)"
 
     init {
-        logger.debug { "Artist catalog created for ${artist.id()}" }
+        logger.trace { "Artist catalog created for ${artist.id()}" }
     }
 
     companion object {

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/ImmutableGenreIndex.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/ImmutableGenreIndex.kt
@@ -73,6 +73,6 @@ internal class ImmutableGenreIndex<I>(override val genre: Genre, tracks: List<I>
     override fun toString() = "ImmutableGenreIndex(genre=$genre, size=$size)"
 
     init {
-        logger.debug { "Genre index created for ${genre.name}" }
+        logger.trace { "Genre index created for ${genre.name}" }
     }
 }

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/itunes/ItunesImportService.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/itunes/ItunesImportService.kt
@@ -11,10 +11,12 @@ import net.transgressoft.commons.music.audio.ReactiveAudioItem
 import net.transgressoft.commons.music.audio.parseGenre
 import net.transgressoft.commons.music.playlist.ReactiveAudioPlaylist
 import mu.KotlinLogging
+import org.slf4j.MDC
 import java.nio.file.FileSystem
 import java.nio.file.FileSystems
 import java.nio.file.Files
 import java.nio.file.Path
+import java.util.UUID
 import java.util.concurrent.CompletableFuture
 import kotlin.io.path.extension
 import kotlinx.coroutines.CancellationException
@@ -23,6 +25,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.future.future
+import kotlinx.coroutines.slf4j.MDCContext
 
 /**
  * Orchestrates importing tracks and playlists from a parsed [ItunesLibrary] into a [MusicLibrary].
@@ -95,18 +98,31 @@ class ItunesImportService<I, P>
         policy: ItunesImportPolicy = ItunesImportPolicy(),
         rootDirectoryName: String? = null,
         onProgress: (ImportProgress) -> Unit = {}
-    ): CompletableFuture<ImportResult> =
-        CoroutineScope(Dispatchers.IO).future {
-            val effectivePlaylists = playlistBuilder.expandWithAncestors(selectedPlaylists, itunesLibrary)
-            val trackImportResult = importTracks(itunesLibrary, policy, onProgress)
-            val rejectedNames = playlistBuilder.createPlaylists(effectivePlaylists, trackImportResult.trackIdToItem, rootDirectoryName)
+    ): CompletableFuture<ImportResult> {
+        val sessionId = UUID.randomUUID().toString()
+        MDC.put("importSessionId", sessionId)
+        try {
+            return CoroutineScope(Dispatchers.IO + MDCContext()).future {
+                val effectivePlaylists = playlistBuilder.expandWithAncestors(selectedPlaylists, itunesLibrary)
+                val trackImportResult = importTracks(itunesLibrary, policy, onProgress)
+                val rejectedNames = playlistBuilder.createPlaylists(effectivePlaylists, trackImportResult.trackIdToItem, rootDirectoryName)
 
-            ImportResult(
-                imported = trackImportResult.imported.toList(),
-                unresolved = trackImportResult.unresolved.toList(),
-                rejectedPlaylistNames = rejectedNames
-            )
+                ImportResult(
+                    imported = trackImportResult.imported.toList(),
+                    unresolved = trackImportResult.unresolved.toList(),
+                    rejectedPlaylistNames = rejectedNames
+                ).also {
+                    logger.debug {
+                        "iTunes import complete: ${trackImportResult.imported.size} imported, " +
+                            "${trackImportResult.unresolved.size} unresolved, " +
+                            "${rejectedNames.size} playlists rejected"
+                    }
+                }
+            }
+        } finally {
+            MDC.remove("importSessionId")
         }
+    }
 
     private suspend fun importTracks(
         itunesLibrary: ItunesLibrary,
@@ -130,13 +146,13 @@ class ItunesImportService<I, P>
             val path = trackResolver.resolveTrackPath(track)
 
             if (trackResolver.isUnsupportedFileType(path, policy)) {
-                logger.debug { "Skipping track '${track.title}': unsupported file type '${path.extension.lowercase()}'" }
+                logger.trace { "Skipping track '${track.title}': unsupported file type '${path.extension.lowercase()}'" }
                 accumulator.unresolved.add(UnresolvedTrack(path, track.title, UnresolvedReason.UnsupportedType(path.extension.lowercase())))
                 return
             }
 
             if (!Files.exists(path)) {
-                logger.debug { "Track '${track.title}': file not found at $path" }
+                logger.trace { "Track '${track.title}': file not found at $path" }
                 accumulator.unresolved.add(UnresolvedTrack(path, track.title, UnresolvedReason.FileNotFound))
                 return
             }
@@ -144,7 +160,7 @@ class ItunesImportService<I, P>
             val audioItem = importTrack(track, path, policy)
             accumulator.trackIdToItem[trackId] = audioItem
             accumulator.imported.add(audioItem)
-            logger.debug { "Imported track '${track.title}' with id ${audioItem.id}" }
+            logger.trace { "Imported track '${track.title}' with id ${audioItem.id}" }
         } catch (e: CancellationException) {
             // Cooperative cancellation must propagate; recording it as an UnresolvedTrack would
             // contradict importAsync's "stops processing between tracks" contract.

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/itunes/ItunesPlaylistBuilder.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/itunes/ItunesPlaylistBuilder.kt
@@ -62,7 +62,7 @@ internal class ItunesPlaylistBuilder<I, P>(
             val uniqueName = resolveUniqueName(playlist.name)
             musicLibrary.createPlaylistDirectory(uniqueName)
             createdNameByPersistentId[playlist.persistentId] = uniqueName
-            logger.debug { "Created playlist directory '$uniqueName'" }
+            logger.trace { "Created playlist directory '$uniqueName'" }
         }
     }
 
@@ -79,7 +79,7 @@ internal class ItunesPlaylistBuilder<I, P>(
             val uniqueName = resolveUniqueName(playlist.name)
             musicLibrary.createPlaylist(uniqueName, audioItemIds)
             createdNameByPersistentId[playlist.persistentId] = uniqueName
-            logger.debug { "Created playlist '$uniqueName' with ${audioItemIds.size} items" }
+            logger.trace { "Created playlist '$uniqueName' with ${audioItemIds.size} items" }
         }
     }
 
@@ -110,7 +110,7 @@ internal class ItunesPlaylistBuilder<I, P>(
                 }
             try {
                 musicLibrary.playlistHierarchy().addPlaylistsToDirectory(setOf(childName), parentName)
-                logger.debug { "Wired '$childName' to folder '$parentName'" }
+                logger.trace { "Wired '$childName' to folder '$parentName'" }
             } catch (e: Exception) {
                 logger.warn("Could not wire '$childName' to folder '$parentName': ${e.message}")
             }

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/m3u/M3uImportService.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/m3u/M3uImportService.kt
@@ -23,9 +23,11 @@ import net.transgressoft.commons.music.audio.ReactiveAudioItem
 import net.transgressoft.commons.music.playlist.ReactiveAudioPlaylist
 import net.transgressoft.lirp.entity.toIds
 import mu.KotlinLogging
+import mu.withLoggingContext
 import java.io.IOException
 import java.nio.file.NoSuchFileException
 import java.nio.file.Path
+import java.util.UUID
 import java.util.concurrent.CompletableFuture
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
@@ -35,6 +37,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.slf4j.MDCContext
 
 /**
  * Exception thrown when an unrecoverable error occurs during M3U playlist import.
@@ -109,9 +112,14 @@ class M3uImportService<I : ReactiveAudioItem<I>, P : ReactiveAudioPlaylist<I, P>
      * @throws M3uParseException if the root M3U file cannot be parsed
      */
     fun import(rootM3u: Path): P {
-        val plan = planImport(rootM3u, visited = emptyList(), depth = 0)
-        rejectCollisions(plan)
-        return materialize(plan, existingAudioItemsByPath())
+        val sessionId = UUID.randomUUID().toString()
+        return withLoggingContext("importSessionId" to sessionId) {
+            val plan = planImport(rootM3u, visited = emptyList(), depth = 0)
+            rejectCollisions(plan)
+            materialize(plan, existingAudioItemsByPath()).also { playlist ->
+                logger.debug { "M3U import complete: '${plan.name}', ${playlist.audioItems.size} items, ${plan.children.size} nested" }
+            }
+        }
     }
 
     /**
@@ -133,7 +141,7 @@ class M3uImportService<I : ReactiveAudioItem<I>, P : ReactiveAudioPlaylist<I, P>
      */
     @OptIn(ExperimentalCoroutinesApi::class)
     fun importAsync(rootM3u: Path, dispatcher: CoroutineDispatcher): CompletableFuture<P> {
-        val deferred = serviceScope.async(dispatcher) { import(rootM3u) }
+        val deferred = serviceScope.async(dispatcher + MDCContext()) { import(rootM3u) }
         val future = CompletableFuture<P>()
         deferred.invokeOnCompletion { error ->
             if (error == null) {

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/playlist/DefaultPlaylistHierarchy.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/playlist/DefaultPlaylistHierarchy.kt
@@ -62,7 +62,7 @@ internal class DefaultPlaylistHierarchy(
     ): MutableAudioPlaylist {
         require(findByName(name).isEmpty) { "Playlist with name '$name' already exists" }
         return MutablePlaylist(newId(), name, false, audioItemIds).also {
-            logger.debug { "Created playlist $it" }
+            logger.trace { "Created playlist $it" }
             add(it)
         }
     }
@@ -75,7 +75,7 @@ internal class DefaultPlaylistHierarchy(
     ): MutableAudioPlaylist {
         require(findByName(name).isEmpty) { "Playlist with name '$name' already exists" }
         return MutablePlaylist(newId(), name, true, audioItems.toIds()).also {
-            logger.debug { "Created playlist directory $it" }
+            logger.trace { "Created playlist directory $it" }
             add(it)
         }
     }

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/playlist/MutablePlaylistBase.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/playlist/MutablePlaylistBase.kt
@@ -64,14 +64,14 @@ abstract class MutablePlaylistBase<I : ReactiveAudioItem<I>, P : ReactiveAudioPl
         val toAdd = audioItems.filter { it.id !in currentIds }
         if (toAdd.isEmpty()) return false
         this.audioItems.addAll(toAdd)
-        logger.debug { "Added $toAdd to playlist $uniqueId" }
+        logger.trace { "Added $toAdd to playlist $uniqueId" }
         return true
     }
 
     override fun removeAudioItems(audioItems: Collection<I>): Boolean {
         val result = this.audioItems.removeAll(audioItems.toSet())
         if (result)
-            logger.debug { "Removed $audioItems from playlist $uniqueId" }
+            logger.trace { "Removed $audioItems from playlist $uniqueId" }
         return result
     }
 
@@ -85,21 +85,21 @@ abstract class MutablePlaylistBase<I : ReactiveAudioItem<I>, P : ReactiveAudioPl
             return false
 
         audioItems.removeAll(toRemove.toSet())
-        logger.debug { "Removed audio items with ids $idsToRemove from playlist $uniqueId" }
+        logger.trace { "Removed audio items with ids $idsToRemove from playlist $uniqueId" }
         return true
     }
 
     override fun addPlaylists(playlists: Collection<P>): Boolean {
         val result = playlists.stream().anyMatch { it !in this.playlists }
         this.playlists.addAll(playlists)
-        logger.debug { "Added $playlists to playlist $uniqueId" }
+        logger.trace { "Added $playlists to playlist $uniqueId" }
         return result
     }
 
     override fun removePlaylists(playlists: Collection<P>): Boolean {
         val result = playlists.stream().anyMatch { it in this.playlists }
         this.playlists.removeAll(playlists.toSet())
-        logger.debug { "Removed $playlists from playlist $uniqueId" }
+        logger.trace { "Removed $playlists from playlist $uniqueId" }
         return result
     }
 
@@ -110,7 +110,7 @@ abstract class MutablePlaylistBase<I : ReactiveAudioItem<I>, P : ReactiveAudioPl
         val result = toRemove.isNotEmpty()
         if (result) {
             this.playlists.removeAll(toRemove.toSet())
-            logger.debug { "Removed playlists with ids $playlistIds from playlist $uniqueId" }
+            logger.trace { "Removed playlists with ids $playlistIds from playlist $uniqueId" }
         }
         return result
     }
@@ -119,7 +119,7 @@ abstract class MutablePlaylistBase<I : ReactiveAudioItem<I>, P : ReactiveAudioPl
         if (audioItems.isNotEmpty()) {
             val size = audioItems.size
             audioItems.clear()
-            logger.debug { "Cleared $size audio items from playlist $uniqueId" }
+            logger.trace { "Cleared $size audio items from playlist $uniqueId" }
         }
     }
 
@@ -127,7 +127,7 @@ abstract class MutablePlaylistBase<I : ReactiveAudioItem<I>, P : ReactiveAudioPl
         if (playlists.isNotEmpty()) {
             val size = playlists.size
             playlists.clear()
-            logger.debug { "Cleared $size playlists from playlist $uniqueId" }
+            logger.trace { "Cleared $size playlists from playlist $uniqueId" }
         }
     }
 

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/playlist/PlaylistHierarchyBase.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/playlist/PlaylistHierarchyBase.kt
@@ -29,6 +29,7 @@ import net.transgressoft.lirp.event.LirpEventSubscriber
 import net.transgressoft.lirp.event.LirpEventSubscription
 import net.transgressoft.lirp.persistence.Repository
 import mu.KotlinLogging
+import mu.withLoggingContext
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger
@@ -200,13 +201,15 @@ abstract class PlaylistHierarchyBase<I : ReactiveAudioItem<I>, P : ReactiveAudio
             "Cannot move playlist '$playlistNameToMove' into its own descendant '$destinationPlaylistName'"
         }
 
-        findParentPlaylist(playlistToMove.get()).ifPresent { parentPlaylist: P ->
-            parentPlaylist.removePlaylist(playlistToMove.get())
-            logger.debug { "Playlist '$playlistNameToMove' removed from '$parentPlaylist'" }
-        }
+        withLoggingContext("playlistId" to playlistToMove.get().id.toString()) {
+            findParentPlaylist(playlistToMove.get()).ifPresent { parentPlaylist: P ->
+                parentPlaylist.removePlaylist(playlistToMove.get())
+                logger.trace { "Playlist '$playlistNameToMove' removed from '$parentPlaylist'" }
+            }
 
-        destinationPlaylist.get().addPlaylist(playlistToMove.get())
-        logger.debug { "Playlist '$playlistNameToMove' moved to '$destinationPlaylistName'" }
+            destinationPlaylist.get().addPlaylist(playlistToMove.get())
+            logger.trace { "Playlist '$playlistNameToMove' moved to '$destinationPlaylistName'" }
+        }
     }
 
     private fun isDescendant(parent: P, candidate: P): Boolean {

--- a/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/audio/FXAlbum.kt
+++ b/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/audio/FXAlbum.kt
@@ -142,7 +142,7 @@ internal class FXAlbum(
     }
 
     init {
-        logger.debug { "FXAlbum created for ${album.name}" }
+        logger.trace { "FXAlbum created for ${album.name}" }
         tracksProperty.setAll(trackList)
         sizeProperty.set(size)
     }

--- a/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/audio/FXArtistCatalog.kt
+++ b/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/audio/FXArtistCatalog.kt
@@ -94,7 +94,7 @@ internal class FXArtistCatalog private constructor(
     override val uniqueId: String = artist.id()
 
     init {
-        logger.debug { "FXArtistCatalog created for ${artist.id()}" }
+        logger.trace { "FXArtistCatalog created for ${artist.id()}" }
         populateFxProperties()
     }
 

--- a/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/audio/FXAudioLibrary.kt
+++ b/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/audio/FXAudioLibrary.kt
@@ -201,7 +201,7 @@ internal class FXAudioLibrary
                 val audioItem = event.audioItem
                 if (audioItem is FXAudioItem) {
                     audioItem.incrementPlayCount()
-                    logger.debug { "Play count of audio item with id ${audioItem.id} increased to ${audioItem.playCount}" }
+                    logger.trace { "Play count of audio item with id ${audioItem.id} increased to ${audioItem.playCount}" }
                 }
             }
         }
@@ -348,7 +348,7 @@ internal class FXAudioLibrary
             val metadata = metadataIO.readMetadata(audioItemPath)
             return FXAudioItem(audioItemPath, newId(), metadata).also { fxAudioItem ->
                 add(fxAudioItem)
-                logger.debug { "New ObservableAudioItem was created from file $audioItemPath with id ${fxAudioItem.id}" }
+                logger.trace { "New ObservableAudioItem was created from file $audioItemPath with id ${fxAudioItem.id}" }
             }
         }
 

--- a/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/audio/FXGenreIndex.kt
+++ b/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/audio/FXGenreIndex.kt
@@ -81,7 +81,7 @@ internal class FXGenreIndex(
         field = SimpleObjectProperty(this, "genre", genre)
 
     init {
-        logger.debug { "FXGenreIndex created for ${genre.name}" }
+        logger.trace { "FXGenreIndex created for ${genre.name}" }
         tracksProperty.setAll(trackList)
         sizeProperty.set(size)
     }

--- a/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/playlist/FXPlaylist.kt
+++ b/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/playlist/FXPlaylist.kt
@@ -238,7 +238,7 @@ internal class FXPlaylist(
         val itemsToAdd = audioItems.filter { it.id !in currentIds }
         if (itemsToAdd.isEmpty()) return false
         audioItemsAggregate.addAll(itemsToAdd)
-        logger.debug { "Added $itemsToAdd to playlist $uniqueId" }
+        logger.trace { "Added $itemsToAdd to playlist $uniqueId" }
         return true
     }
 
@@ -246,7 +246,7 @@ internal class FXPlaylist(
         val hasItems = audioItems.any { it in audioItemsAggregate }
         if (hasItems) {
             audioItemsAggregate.removeAll(audioItems.toSet())
-            logger.debug { "Removed $audioItems from playlist $uniqueId" }
+            logger.trace { "Removed $audioItems from playlist $uniqueId" }
         }
         return hasItems
     }
@@ -259,7 +259,7 @@ internal class FXPlaylist(
         val toRemove = audioItemsAggregate.filter { it.id in idsToRemove }
         if (toRemove.isEmpty()) return false
         audioItemsAggregate.removeAll(toRemove.toSet())
-        logger.debug { "Removed audio items with ids $idsToRemove from playlist $uniqueId" }
+        logger.trace { "Removed audio items with ids $idsToRemove from playlist $uniqueId" }
         return true
     }
 
@@ -267,7 +267,7 @@ internal class FXPlaylist(
         val newPlaylists = playlists.filter { it !in playlistsAggregate }
         if (newPlaylists.isEmpty()) return false
         playlistsAggregate.addAll(newPlaylists)
-        logger.debug { "Added $playlists to playlist $uniqueId" }
+        logger.trace { "Added $playlists to playlist $uniqueId" }
         return true
     }
 
@@ -275,7 +275,7 @@ internal class FXPlaylist(
         val containsPlaylists = playlists.any { it in playlistsAggregate }
         if (containsPlaylists) {
             playlistsAggregate.removeAll(playlists.toSet())
-            logger.debug { "Removed $playlists from playlist $uniqueId" }
+            logger.trace { "Removed $playlists from playlist $uniqueId" }
         }
         return containsPlaylists
     }
@@ -287,7 +287,7 @@ internal class FXPlaylist(
         val toRemove = playlistsAggregate.filter { it.id in idsToRemove }
         if (toRemove.isEmpty()) return false
         playlistsAggregate.removeAll(toRemove.toSet())
-        logger.debug { "Removed playlists with ids $playlistIds from playlist $uniqueId" }
+        logger.trace { "Removed playlists with ids $playlistIds from playlist $uniqueId" }
         return true
     }
 
@@ -295,7 +295,7 @@ internal class FXPlaylist(
         if (audioItemsAggregate.isNotEmpty()) {
             val size = audioItemsAggregate.size
             audioItemsAggregate.clear()
-            logger.debug { "Cleared $size audio items from playlist $uniqueId" }
+            logger.trace { "Cleared $size audio items from playlist $uniqueId" }
         }
     }
 
@@ -303,7 +303,7 @@ internal class FXPlaylist(
         if (playlistsAggregate.isNotEmpty()) {
             val size = playlistsAggregate.size
             playlistsAggregate.clear()
-            logger.debug { "Cleared $size playlists from playlist $uniqueId" }
+            logger.trace { "Cleared $size playlists from playlist $uniqueId" }
         }
     }
 

--- a/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/playlist/FXPlaylistHierarchy.kt
+++ b/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/playlist/FXPlaylistHierarchy.kt
@@ -33,6 +33,7 @@ import javafx.beans.property.SimpleSetProperty
 import javafx.collections.FXCollections
 import javafx.collections.ObservableSet
 import mu.KotlinLogging
+import mu.withLoggingContext
 
 /**
  * JavaFX-compatible playlist hierarchy with observable playlist collections.
@@ -129,7 +130,7 @@ internal class FXPlaylistHierarchy(
     ): ObservablePlaylist {
         require(findByName(name).isEmpty) { "Playlist with name '$name' already exists" }
         return FXPlaylist(newId(), name, false, audioItemIds).also {
-            logger.debug { "Created playlist $it" }
+            withLoggingContext("playlistId" to it.id.toString()) { logger.trace { "Created playlist $it" } }
             add(it)
             // The FXPlaylist init runs refreshDerivedState before lirp registry binding completes,
             // so its cover and audioItemsRecursive view are computed against an empty aggregate.
@@ -147,7 +148,7 @@ internal class FXPlaylistHierarchy(
     ): ObservablePlaylist {
         require(findByName(name).isEmpty) { "Playlist with name '$name' already exists" }
         return FXPlaylist(newId(), name, true, audioItems.toIds()).also {
-            logger.debug { "Created playlist $it" }
+            withLoggingContext("playlistId" to it.id.toString()) { logger.trace { "Created playlist $it" } }
             add(it)
             it.triggerCoverHydration()
         }

--- a/music-commons-media/src/main/kotlin/net/transgressoft/commons/media/player/CoreAudioItemPlayer.kt
+++ b/music-commons-media/src/main/kotlin/net/transgressoft/commons/media/player/CoreAudioItemPlayer.kt
@@ -27,6 +27,7 @@ import net.transgressoft.commons.music.player.event.AudioItemPlayerEvent
 import net.transgressoft.lirp.event.FlowEventPublisher
 import net.transgressoft.lirp.event.LirpEventPublisher
 import mu.KotlinLogging
+import mu.withLoggingContext
 import java.nio.file.Path
 import java.time.Duration
 import java.util.concurrent.atomic.AtomicLong
@@ -179,14 +180,17 @@ open class CoreAudioItemPlayer private constructor(
         pumpThread.get()?.start()
         if (audioFileFormat == null || durationProber.requiresDecodedDurationProbe(file, audioFileFormat)) {
             val fileName = audioItem.path.fileName.toString()
+            val audioItemIdStr = audioItem.id.toString()
             durationProbeThread.set(
                 Thread({
-                    val resolved =
-                        runCatching { durationProber.resolvePlayableDurationMillis(file, fileName) }
-                            .onFailure { logger.debug(it) { "Decoded-duration probe failed for '${file.name}' after playback started" } }
-                            .getOrNull()
-                    if (resolved != null && resolved > 0L && activeSessionId.get() == mySession && state.get() != InternalState.DISPOSED) {
-                        sourceDurationMillis = resolved
+                    withLoggingContext("audioItemId" to audioItemIdStr) {
+                        val resolved =
+                            runCatching { durationProber.resolvePlayableDurationMillis(file, fileName) }
+                                .onFailure { logger.debug(it) { "Decoded-duration probe failed for '${file.name}' after playback started" } }
+                                .getOrNull()
+                        if (resolved != null && resolved > 0L && activeSessionId.get() == mySession && state.get() != InternalState.DISPOSED) {
+                            sourceDurationMillis = resolved
+                        }
                     }
                 }, "CoreAudioPlayer-duration-probe").apply { isDaemon = true }
             )

--- a/music-commons-media/src/main/kotlin/net/transgressoft/commons/media/player/PcmVolume.kt
+++ b/music-commons-media/src/main/kotlin/net/transgressoft/commons/media/player/PcmVolume.kt
@@ -50,7 +50,7 @@ internal object PcmVolume {
         }
         val sampleSizeInBits = format.sampleSizeInBits
         if (sampleSizeInBits <= 0 || sampleSizeInBits % 8 != 0) {
-            logger.debug {
+            logger.trace {
                 "Volume control skipped: sample size ${format.sampleSizeInBits}-bit not supported (requires byte-aligned PCM)"
             }
             return
@@ -66,7 +66,7 @@ internal object PcmVolume {
             }
             in 1..4 -> scaleSignedSamples(buffer, chunk, bytesPerSample, gain, format.isBigEndian)
             else -> {
-                logger.debug {
+                logger.trace {
                     "Volume control skipped: sample size ${format.sampleSizeInBits}-bit not supported (requires 8/16/24/32-bit PCM)"
                 }
             }

--- a/music-commons-media/src/main/kotlin/net/transgressoft/commons/media/player/PlaybackPump.kt
+++ b/music-commons-media/src/main/kotlin/net/transgressoft/commons/media/player/PlaybackPump.kt
@@ -20,6 +20,7 @@ package net.transgressoft.commons.media.player
 import net.transgressoft.commons.music.audio.ReactiveAudioItem
 import net.transgressoft.commons.music.player.AudioItemPlayer.Status
 import net.transgressoft.commons.music.player.event.AudioItemPlayerEvent.Played
+import mu.withLoggingContext
 import java.io.File
 import javax.sound.sampled.AudioFormat
 import javax.sound.sampled.AudioInputStream
@@ -50,13 +51,21 @@ internal class PlaybackPump(
      * streams PCM until the stream ends or playback is interrupted, then calls [onPlaybackComplete].
      */
     fun asThread(): Thread =
-        Thread({
+        Thread({ runPump() }, "CoreAudioPlayer-pump").apply {
+            isDaemon = true
+            setUncaughtExceptionHandler { _, t -> player.logger.error(t) { "Uncaught exception in pump thread" } }
+        }
+
+    private fun runPump() {
+        // A stop()/dispose() or a newer play() racing ahead of this thread invalidates the active
+        // session; bail before entering the try/finally so a stale pump never reaches
+        // onPlaybackComplete(), which would flush/drain player.lineRef before its own session check
+        // and could cut off a line the active playback has already opened.
+        if (player.activeSessionId.get() != mySession) return
+        withLoggingContext("audioItemId" to audioItem.id.toString()) {
             var hadError = false
             var halted = false
             try {
-                // A stop()/dispose() racing ahead of this thread invalidates the active session;
-                // bail before flipping the state to PLAYING so a stopped player is not resurrected.
-                if (player.activeSessionId.get() != mySession) return@Thread
                 player.state.set(InternalState.PLAYING)
                 streamPcm()
             } catch (_: InterruptedException) {
@@ -67,19 +76,25 @@ internal class PlaybackPump(
                 hadError = true
                 halted = true
             } catch (e: Exception) {
-                val current = player.state.get()
-                if (current != InternalState.STOPPED && current != InternalState.DISPOSED) {
-                    player.logger.error(e) { "Error playing '${audioItem.path.fileName}'" }
-                    halted = true
-                }
+                halted = handlePlaybackError(e)
                 hadError = true
             } finally {
                 onPlaybackComplete(!hadError && player.state.get() == InternalState.PLAYING, halted)
             }
-        }, "CoreAudioPlayer-pump").apply {
-            isDaemon = true
-            setUncaughtExceptionHandler { _, t -> player.logger.error(t) { "Uncaught exception in pump thread" } }
         }
+    }
+
+    /**
+     * Logs an unexpected playback error unless the player was already stopped or disposed (in which
+     * case the failure is an expected consequence of the shutdown). Returns whether the session
+     * should be reported as halted.
+     */
+    private fun handlePlaybackError(e: Exception): Boolean {
+        val current = player.state.get()
+        if (current == InternalState.STOPPED || current == InternalState.DISPOSED) return false
+        player.logger.error(e) { "Error playing '${audioItem.path.fileName}'" }
+        return true
+    }
 
     private fun streamPcm() {
         var session = openStreamSession(player.framePosition)

--- a/music-commons-media/src/main/kotlin/net/transgressoft/commons/media/waveform/ScalableAudioWaveform.kt
+++ b/music-commons-media/src/main/kotlin/net/transgressoft/commons/media/waveform/ScalableAudioWaveform.kt
@@ -28,6 +28,7 @@ import java.io.ByteArrayOutputStream
 import java.io.File
 import java.nio.file.Path
 import javax.imageio.ImageIO
+import javax.sound.sampled.AudioInputStream
 import kotlin.io.path.exists
 import kotlin.io.path.extension
 import kotlin.math.abs
@@ -114,50 +115,53 @@ class ScalableAudioWaveform(
         return try {
             val pcmStream = decodeToPcmStream(audioFilePath)
             val isBigEndian = pcmStream.format.isBigEndian
-            val pcmBytes: ByteArray =
-                pcmStream.use { stream ->
-                    val buf = ByteArrayOutputStream()
-                    val buffer = ByteArray(8192)
-                    var accumulated = 0L
-                    var bytesRead = stream.read(buffer)
-                    while (bytesRead != -1) {
-                        if (bytesRead > 0) {
-                            accumulated += bytesRead
-                            if (accumulated > maxPcmBytes) {
-                                throw AudioWaveformProcessingException(
-                                    "PCM data for '$audioFilePath' exceeds the $maxPcmBytes-byte limit"
-                                )
-                            }
-                            buf.write(buffer, 0, bytesRead)
-                        }
-                        bytesRead = stream.read(buffer)
-                    }
-                    buf.toByteArray()
-                }
+            val pcmBytes = pcmStream.use { readBoundedPcmBytes(it, audioFilePath) }
             if (pcmBytes.isEmpty()) {
                 throw AudioWaveformProcessingException(
                     "No PCM data produced for '$audioFilePath' — format conversion may not be supported"
                 )
             }
-            val sampleCount = pcmBytes.size / 2
-            IntArray(sampleCount) { i ->
-                val byteOffset = i * 2
-                if (isBigEndian) {
-                    val high = pcmBytes[byteOffset].toInt()
-                    val low = pcmBytes[byteOffset + 1].toInt() and 0xFF
-                    (high shl 8) or low
-                } else {
-                    val low = pcmBytes[byteOffset].toInt() and 0xFF
-                    val high = pcmBytes[byteOffset + 1].toInt()
-                    (high shl 8) or low
-                }
-            }
+            decodePcmSamples(pcmBytes, isBigEndian)
         } catch (exception: AudioWaveformProcessingException) {
             throw exception
         } catch (exception: Exception) {
             throw AudioWaveformProcessingException("Error processing waveform", exception)
         }
     }
+
+    /** Reads the full PCM stream into a byte array, failing if it exceeds [maxPcmBytes]. */
+    private fun readBoundedPcmBytes(stream: AudioInputStream, audioFilePath: Path): ByteArray {
+        val buf = ByteArrayOutputStream()
+        val buffer = ByteArray(8192)
+        var accumulated = 0L
+        var bytesRead = stream.read(buffer)
+        while (bytesRead != -1) {
+            if (bytesRead > 0) {
+                accumulated += bytesRead
+                if (accumulated > maxPcmBytes) {
+                    throw AudioWaveformProcessingException(
+                        "PCM data for '$audioFilePath' exceeds the $maxPcmBytes-byte limit"
+                    )
+                }
+                buf.write(buffer, 0, bytesRead)
+            }
+            bytesRead = stream.read(buffer)
+        }
+        return buf.toByteArray()
+    }
+
+    /** Decodes 16-bit PCM bytes into signed sample values, respecting the stream's endianness. */
+    private fun decodePcmSamples(pcmBytes: ByteArray, isBigEndian: Boolean): IntArray =
+        IntArray(pcmBytes.size / 2) { i ->
+            val byteOffset = i * 2
+            val first = pcmBytes[byteOffset].toInt()
+            val second = pcmBytes[byteOffset + 1].toInt()
+            if (isBigEndian) {
+                (first shl 8) or (second and 0xFF)
+            } else {
+                (second shl 8) or (first and 0xFF)
+            }
+        }
 
     /**
      * Computes width-normalized amplitude values from the raw PCM data, without applying

--- a/music-commons-media/src/test/kotlin/net/transgressoft/commons/media/player/CoreAudioItemPlayerUnitTest.kt
+++ b/music-commons-media/src/test/kotlin/net/transgressoft/commons/media/player/CoreAudioItemPlayerUnitTest.kt
@@ -74,6 +74,7 @@ internal class CoreAudioItemPlayerUnitTest : FunSpec({
 
     fun audioItem(path: Path): ReactiveAudioItem<*> =
         mockk(relaxed = true) {
+            every { id } returns 1
             every { this@mockk.path } returns path
             every { fileName } returns path.fileName.toString()
             every { extension } returns path.toString().substringAfterLast('.', "")


### PR DESCRIPTION
## Summary

Per-entity construction and lifecycle records were logged at `DEBUG`, flooding the `DEBUG` stream (visible now that a downstream consumer captures `DEBUG` records for display). This right-sizes logging levels across the `core`, `fx`, and `media` modules so `DEBUG` carries coarse-grained operations rather than per-entity noise.

Level counts on the main source sets go from **43 DEBUG / 0 TRACE** to **11 DEBUG / 49 TRACE**; `INFO`/`WARN`/`ERROR` are unchanged.

## Changes

- **Reclassified per-item / hot-path statements to `TRACE`:**
  - Catalog/index registry lifecycle (`created`/`updated`/`deleted` per projection entity), immutable value-object construction, and per-item audio-library lines.
  - Playlist mutation/hierarchy operations and `PcmVolume` hot-path lines.
  - Per-track / per-playlist iTunes and M3U import lines.
- **Added coarse `DEBUG` summaries** at real boundaries: catalog/index rebuild (`… rebuilt: N entries`) and iTunes/M3U import completion summaries.
- **Wired MDC (Mapped Diagnostic Context) contextual keys** across the major flows: `catalogRebuildId` (rebuild batches), `playlistId` (playlist/hierarchy ops), `audioItemId` (playback pump + duration-probe threads, cleared in `finally`), and `importSessionId` (iTunes/M3U import). iTunes' coroutine import path propagates the context via `kotlinx-coroutines-slf4j` `MDCContext()`.
- **Dependency:** added BOM-managed `kotlinx-coroutines-slf4j` to `music-commons-core`.
- **Level convention** (TRACE = per-item/hot-path/construction, DEBUG = coarse operations, INFO = user-meaningful milestones, WARN/ERROR = recoverable problems/failures) documented in the project's contributor guide.

Cache-eviction and persistence-flush diagnostics from the original request are intentionally omitted — the flyweight caches never evict and persistence is consumer-owned in separate opt-in modules, so those boundaries do not exist in the reactive modules.

## Testing

`gradle compileKotlin compileTestKotlin ktlintCheck test` — BUILD SUCCESSFUL. Repaired the `CoreAudioItemPlayer` unit-test mock to stub the audio-item id that the new `audioItemId` MDC read requires.

Closes #193