### PR TITLE
Lifecycle hardening: idempotent close(), use-after-close guards, and import-service scope linkage

### DIFF
--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/CoreMusicLibrary.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/CoreMusicLibrary.kt
@@ -26,6 +26,8 @@ import net.transgressoft.commons.music.audio.AudioMetadataIO
 import net.transgressoft.commons.music.audio.DefaultAudioLibrary
 import net.transgressoft.commons.music.audio.JAudioTaggerMetadataIO
 import net.transgressoft.commons.music.audio.event.AudioItemEventSubscriber
+import net.transgressoft.commons.music.itunes.ItunesImportService
+import net.transgressoft.commons.music.m3u.M3uImportService
 import net.transgressoft.commons.music.player.event.AudioItemPlayerEvent
 import net.transgressoft.commons.music.playlist.DefaultPlaylistHierarchy
 import net.transgressoft.commons.music.playlist.MutableAudioPlaylist
@@ -41,6 +43,7 @@ import java.nio.file.Path
 import java.util.Optional
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Flow
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * Unified entry point for managing an audio library, playlist hierarchy, and waveform repository.
@@ -65,8 +68,12 @@ import java.util.concurrent.Flow
 class CoreMusicLibrary private constructor(
     private val _audioLibrary: AudioLibrary,
     private val _playlistHierarchy: PlaylistHierarchy,
-    private val _waveformRepository: AudioWaveformRepository<AudioWaveform, AudioItem>
+    private val _waveformRepository: AudioWaveformRepository<AudioWaveform, AudioItem>,
+    private val _metadataIO: AudioMetadataIO
 ) : MusicLibrary<AudioItem, MutableAudioPlaylist> {
+
+    private val closed = AtomicBoolean(false)
+    private val importLock = Any()
 
     override fun audioLibrary(): AudioLibrary = _audioLibrary
 
@@ -76,6 +83,34 @@ class CoreMusicLibrary private constructor(
      * Returns the underlying waveform repository for direct access to waveform management.
      */
     fun waveformRepository(): AudioWaveformRepository<AudioWaveform, AudioItem> = _waveformRepository
+
+    private var _itunesImport: ItunesImportService<AudioItem, MutableAudioPlaylist>? = null
+
+    /**
+     * Accessor for the iTunes import service. Constructed on first access and cancelled on [close].
+     *
+     * @throws IllegalStateException if this library has already been closed.
+     */
+    val itunesImport: ItunesImportService<AudioItem, MutableAudioPlaylist>
+        get() =
+            synchronized(importLock) {
+                check(!closed.get()) { "This music library has been closed and can no longer be used." }
+                _itunesImport ?: ItunesImportService(this, _metadataIO).also { _itunesImport = it }
+            }
+
+    private var _m3uImport: M3uImportService<AudioItem, MutableAudioPlaylist>? = null
+
+    /**
+     * Accessor for the M3U import service. Constructed on first access and cancelled on [close].
+     *
+     * @throws IllegalStateException if this library has already been closed.
+     */
+    val m3uImport: M3uImportService<AudioItem, MutableAudioPlaylist>
+        get() =
+            synchronized(importLock) {
+                check(!closed.get()) { "This music library has been closed and can no longer be used." }
+                _m3uImport ?: M3uImportService(this).also { _m3uImport = it }
+            }
 
     /**
      * The subscriber for player events. Wire this to an audio player to track play counts.
@@ -154,9 +189,16 @@ class CoreMusicLibrary private constructor(
         _playlistHierarchy.subscribe(subscriber)
 
     /**
-     * Closes all components in reverse subscription order: playlist hierarchy, waveform repository, then audio library.
+     * Closes all components idempotently. The first call cancels the import services first, then the
+     * playlist hierarchy, waveform repository, and audio library in reverse subscription order.
+     * Subsequent calls return immediately without re-closing the components.
      */
     override fun close() {
+        if (!closed.compareAndSet(false, true)) return
+        synchronized(importLock) {
+            _itunesImport?.close()
+            _m3uImport?.close()
+        }
         _playlistHierarchy.close()
         _waveformRepository.close()
         _audioLibrary.close()
@@ -251,7 +293,7 @@ class CoreMusicLibrary private constructor(
                 audioLibrary.subscribe(waveformRepo)
                 audioLibrary.subscribe(playlistHierarchy)
 
-                return CoreMusicLibrary(audioLibrary, playlistHierarchy, waveformRepo)
+                return CoreMusicLibrary(audioLibrary, playlistHierarchy, waveformRepo, metadataIO)
             } catch (ex: Exception) {
                 (playlistHierarchy as? AutoCloseable)?.close()
                 waveformRepo?.close()

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/AudioLibraryBase.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/AudioLibraryBase.kt
@@ -36,6 +36,7 @@ import net.transgressoft.lirp.event.StandardCrudEvent.Update
 import net.transgressoft.lirp.persistence.Repository
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 
 /**
@@ -92,6 +93,22 @@ abstract class AudioLibraryBase<I, AC, ALC, GC>(
     /** Publisher exposing the internal genre index registry for reactive genre index updates. */
     override val genreIndexPublisher: LirpEventPublisher<CrudEvent.Type, CrudEvent<Genre, GC>> =
         observableGenreIndexRegistry.genreIndexPublisher
+
+    /**
+     * Tracks whether this library has been closed. Once set to `true`, mutations and queries throw
+     * [IllegalStateException]. Protected so subtypes can read and transition it while external callers
+     * cannot reopen a closed library.
+     */
+    protected val closed = AtomicBoolean(false)
+
+    /**
+     * Asserts that this library has not been closed.
+     *
+     * @throws IllegalStateException if [close] has already been called on this library.
+     */
+    protected fun checkOpen() {
+        check(!closed.get()) { "This audio library has been closed and can no longer be used." }
+    }
 
     private val entitySubscriptions: MutableMap<Int, LirpEventSubscription<in I, MutationEvent.Type, MutationEvent<Int, I>>> =
         ConcurrentHashMap()
@@ -177,15 +194,29 @@ abstract class AudioLibraryBase<I, AC, ALC, GC>(
         return id
     }
 
-    override fun createAudioItem(factory: (id: Int) -> I): I = factory(newId()).also { add(it) }
+    override fun createAudioItem(factory: (id: Int) -> I): I {
+        checkOpen()
+        return factory(newId()).also { add(it) }
+    }
+
+    override fun add(entity: I): Boolean {
+        checkOpen()
+        return repository.add(entity)
+    }
 
     override val playerSubscriber = PlayedEventSubscriber()
 
     override fun findAlbumAudioItems(artist: Artist, albumName: String): Set<I> = observableArtistCatalogRegistry.findAlbumAudioItems(artist, albumName)
 
-    override fun getArtistCatalog(artist: Artist): Optional<out AC> = observableArtistCatalogRegistry.findById(artist)
+    override fun getArtistCatalog(artist: Artist): Optional<out AC> {
+        checkOpen()
+        return observableArtistCatalogRegistry.findById(artist)
+    }
 
-    override fun getArtistCatalog(artistName: String): Optional<out AC> = observableArtistCatalogRegistry.findFirst(artistName)
+    override fun getArtistCatalog(artistName: String): Optional<out AC> {
+        checkOpen()
+        return observableArtistCatalogRegistry.findFirst(artistName)
+    }
 
     override fun containsAudioItemWithArtist(artistName: String) =
         repository.contains {
@@ -197,9 +228,15 @@ abstract class AudioLibraryBase<I, AC, ALC, GC>(
     override fun getRandomAudioItemsFromArtist(artist: Artist, size: Short): List<I> =
         repository.search(size.toInt()) { it.artistsInvolved.contains(artist) }.shuffled().toList()
 
-    override fun getAlbum(album: AlbumDetails): Optional<out ALC> = observableAlbumRegistry.findById(album)
+    override fun getAlbum(album: AlbumDetails): Optional<out ALC> {
+        checkOpen()
+        return observableAlbumRegistry.findById(album)
+    }
 
-    override fun getAlbum(albumName: String): Optional<out ALC> = observableAlbumRegistry.findFirst(albumName)
+    override fun getAlbum(albumName: String): Optional<out ALC> {
+        checkOpen()
+        return observableAlbumRegistry.findFirst(albumName)
+    }
 
     override fun containsAudioItemWithAlbum(albumName: String): Boolean =
         repository.contains { it.album.name.contentEquals(albumName, true) }
@@ -207,9 +244,15 @@ abstract class AudioLibraryBase<I, AC, ALC, GC>(
     override fun getRandomAudioItemsFromAlbum(album: AlbumDetails, size: Short): List<I> =
         repository.search(size.toInt()) { it.album.canonicalKey() == album.canonicalKey() }.shuffled().toList()
 
-    override fun getGenreIndex(genre: Genre): Optional<out GC> = observableGenreIndexRegistry.findById(genre)
+    override fun getGenreIndex(genre: Genre): Optional<out GC> {
+        checkOpen()
+        return observableGenreIndexRegistry.findById(genre)
+    }
 
-    override fun getGenreIndex(genreName: String): Optional<out GC> = observableGenreIndexRegistry.findFirst(genreName)
+    override fun getGenreIndex(genreName: String): Optional<out GC> {
+        checkOpen()
+        return observableGenreIndexRegistry.findFirst(genreName)
+    }
 
     override fun containsAudioItemWithGenre(genreName: String): Boolean {
         // A blank name targets the no-genre bucket: true iff at least one untagged item exists.
@@ -221,12 +264,14 @@ abstract class AudioLibraryBase<I, AC, ALC, GC>(
         repository.search(size.toInt()) { it.genres.contains(genre) }.shuffled().toList()
 
     /**
-     * Cancels all event subscriptions managed by this library.
+     * Cancels all base-class event subscriptions and closes the catalog registries.
      *
-     * Cancels the repository event subscription, all per-entity mutation subscriptions,
-     * the player subscriber's subscription, and all catalog registries.
+     * Subclasses that take ownership of the idempotency CAS in their own [close] override
+     * (to interpose teardown steps before the base teardown runs) should call this method
+     * directly rather than delegating to [close], which would no-op because [closed] is already
+     * set by the time `super.close()` is reached.
      */
-    override fun close() {
+    protected fun cancelBaseSubscriptions() {
         subscription.cancel()
         entitySubscriptions.values.forEach { it.cancel() }
         entitySubscriptions.clear()
@@ -234,6 +279,18 @@ abstract class AudioLibraryBase<I, AC, ALC, GC>(
         observableArtistCatalogRegistry.close()
         observableAlbumRegistry.close()
         observableGenreIndexRegistry.close()
+    }
+
+    /**
+     * Closes this library idempotently.
+     *
+     * The first call sets the closed flag and cancels all event subscriptions: the repository
+     * subscription, all per-entity mutation subscriptions, the player subscriber, and all
+     * catalog registries. Subsequent calls return immediately without repeating the teardown.
+     */
+    override fun close() {
+        if (!closed.compareAndSet(false, true)) return
+        cancelBaseSubscriptions()
     }
 
     override fun equals(other: Any?): Boolean {

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/itunes/ItunesImportService.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/itunes/ItunesImportService.kt
@@ -22,6 +22,9 @@ import kotlin.io.path.extension
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.future.future
@@ -58,10 +61,12 @@ class ItunesImportService<I, P>
         private val musicLibrary: MusicLibrary<I, P>,
         private val metadataIO: AudioMetadataIO = JAudioTaggerMetadataIO(),
         private val fileSystem: FileSystem = FileSystems.getDefault()
-    ) where I : ReactiveAudioItem<I>,
+    ) : AutoCloseable where I : ReactiveAudioItem<I>,
           P : ReactiveAudioPlaylist<I, P> {
 
     private val logger = KotlinLogging.logger {}
+    private val serviceJob: Job = SupervisorJob()
+    private val serviceScope: CoroutineScope = CoroutineScope(Dispatchers.IO + serviceJob)
 
     internal var trackResolver: ItunesTrackResolver = ItunesTrackResolver(fileSystem)
     internal var playlistBuilder: ItunesPlaylistBuilder<I, P> = ItunesPlaylistBuilder(musicLibrary)
@@ -102,7 +107,7 @@ class ItunesImportService<I, P>
         val sessionId = UUID.randomUUID().toString()
         MDC.put("importSessionId", sessionId)
         try {
-            return CoroutineScope(Dispatchers.IO + MDCContext()).future {
+            return serviceScope.future(MDCContext()) {
                 val effectivePlaylists = playlistBuilder.expandWithAncestors(selectedPlaylists, itunesLibrary)
                 val trackImportResult = importTracks(itunesLibrary, policy, onProgress)
                 val rejectedNames = playlistBuilder.createPlaylists(effectivePlaylists, trackImportResult.trackIdToItem, rootDirectoryName)
@@ -122,6 +127,14 @@ class ItunesImportService<I, P>
         } finally {
             MDC.remove("importSessionId")
         }
+    }
+
+    /**
+     * Releases the coroutine resources backing [importAsync]. After close, async imports
+     * will fail; the underlying music library is not affected.
+     */
+    override fun close() {
+        serviceScope.cancel()
     }
 
     private suspend fun importTracks(

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/playlist/PlaylistHierarchyBase.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/playlist/PlaylistHierarchyBase.kt
@@ -32,6 +32,7 @@ import mu.KotlinLogging
 import mu.withLoggingContext
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.reflect.KClass
 
@@ -57,6 +58,22 @@ abstract class PlaylistHierarchyBase<I : ReactiveAudioItem<I>, P : ReactiveAudio
      * The runtime type of playlist elements in this hierarchy, used for typed collection change subscriptions.
      */
     protected abstract val playlistElementType: KClass<P>
+
+    /**
+     * Tracks whether this hierarchy has been closed. Once set to `true`, mutations and queries throw
+     * [IllegalStateException]. Protected so subtypes can read and transition it while external callers
+     * cannot reopen a closed hierarchy.
+     */
+    protected val closed = AtomicBoolean(false)
+
+    /**
+     * Asserts that this playlist hierarchy has not been closed.
+     *
+     * @throws IllegalStateException if [close] has already been called on this hierarchy.
+     */
+    protected fun checkOpen() {
+        check(!closed.get()) { "This playlist hierarchy has been closed and can no longer be used." }
+    }
 
     init {
         repository.disableEvents(CREATE, UPDATE, DELETE)
@@ -86,6 +103,7 @@ abstract class PlaylistHierarchyBase<I : ReactiveAudioItem<I>, P : ReactiveAudio
     }
 
     override fun add(entity: P): Boolean {
+        checkOpen()
         require(findByName(entity.name).isEmpty || findByName(entity.name).get().id == entity.id) {
             "Playlist with name '${entity.name}' already exists"
         }
@@ -133,13 +151,15 @@ abstract class PlaylistHierarchyBase<I : ReactiveAudioItem<I>, P : ReactiveAudio
         playlistMutationSubscriptions[playlist.id] = subscription
     }
 
-    override fun remove(entity: P): Boolean =
-        repository.remove(entity).also { removed ->
+    override fun remove(entity: P): Boolean {
+        checkOpen()
+        return repository.remove(entity).also { removed ->
             if (removed) {
                 cancelPlaylistMutationSubscription(entity.id)
                 removeFromPlaylistsHierarchy(entity)
             }
         }
+    }
 
     private fun cancelPlaylistMutationSubscription(playlistId: Int) {
         playlistMutationSubscriptions.remove(playlistId)?.cancel()
@@ -163,6 +183,7 @@ abstract class PlaylistHierarchyBase<I : ReactiveAudioItem<I>, P : ReactiveAudio
     }
 
     override fun removeAll(entities: Collection<P>): Boolean {
+        checkOpen()
         // Materialize before removal: aggregate proxies resolve lazily from the registry,
         // so iterating them after repository.removeAll() would throw NoSuchElementException.
         val materialized = entities.toList()
@@ -176,10 +197,14 @@ abstract class PlaylistHierarchyBase<I : ReactiveAudioItem<I>, P : ReactiveAudio
         }
     }
 
-    override fun findByName(name: String): Optional<out P> = findFirst { it.name == name }
+    override fun findByName(name: String): Optional<out P> {
+        checkOpen()
+        return findFirst { it.name == name }
+    }
 
-    override fun findParentPlaylist(playlist: ReactiveAudioPlaylist<I, P>): Optional<P> =
-        if (playlistsHierarchyMultiMap.containsValue(playlist)) {
+    override fun findParentPlaylist(playlist: ReactiveAudioPlaylist<I, P>): Optional<P> {
+        checkOpen()
+        return if (playlistsHierarchyMultiMap.containsValue(playlist)) {
             playlistsHierarchyMultiMap.entries().stream()
                 .filter { playlist == it.value }
                 .map { findByUniqueId(it.key) }
@@ -189,8 +214,10 @@ abstract class PlaylistHierarchyBase<I : ReactiveAudioItem<I>, P : ReactiveAudio
         } else {
             Optional.empty()
         }
+    }
 
     override fun movePlaylist(playlistNameToMove: String, destinationPlaylistName: String) {
+        checkOpen()
         val playlistToMove = findByName(playlistNameToMove)
         val destinationPlaylist = findByName(destinationPlaylistName)
 
@@ -313,9 +340,25 @@ abstract class PlaylistHierarchyBase<I : ReactiveAudioItem<I>, P : ReactiveAudio
     override fun numberOfPlaylistDirectories() = search { it.isDirectory }.count()
 
     /**
-     * Cancels the audio item event subscription and all per-playlist mutation subscriptions.
+     * Closes this hierarchy idempotently.
+     *
+     * The first call sets the closed flag and cancels the audio item event subscription and all
+     * per-playlist mutation subscriptions. Subsequent calls return immediately without repeating
+     * the teardown.
      */
     override fun close() {
+        if (!closed.compareAndSet(false, true)) return
+        cancelBaseSubscriptions()
+    }
+
+    /**
+     * Cancels the audio item event subscription and all per-playlist mutation subscriptions.
+     *
+     * Extracted from [close] so a subclass that owns the [closed] compare-and-set as its first
+     * statement can perform its own teardown before invoking the base teardown, without the base
+     * re-running the flag transition.
+     */
+    protected fun cancelBaseSubscriptions() {
         audioItemEventSubscriber.cancelSubscription()
         playlistMutationSubscriptions.values.forEach { it.cancel() }
         playlistMutationSubscriptions.clear()

--- a/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/LifecycleIntegrationTest.kt
+++ b/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/LifecycleIntegrationTest.kt
@@ -6,6 +6,7 @@ import net.transgressoft.commons.music.audio.AlbumDetails
 import net.transgressoft.commons.music.audio.Artist
 import net.transgressoft.commons.music.audio.AudioItem
 import net.transgressoft.commons.music.audio.DefaultAudioLibrary
+import net.transgressoft.commons.music.audio.MutableAudioItem
 import net.transgressoft.commons.music.audio.event.AudioItemEventSubscriber
 import net.transgressoft.commons.music.audio.virtualFiles
 import net.transgressoft.commons.music.playlist.DefaultPlaylistHierarchy
@@ -14,6 +15,7 @@ import net.transgressoft.commons.music.testing.registryIsolation
 import net.transgressoft.commons.music.waveform.AudioWaveform
 import net.transgressoft.commons.music.waveform.AudioWaveformRepository
 import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.optional.shouldBePresent
 import io.kotest.matchers.shouldBe
@@ -71,7 +73,11 @@ internal class LifecycleIntegrationTest : StringSpec({
 
         audioLibrary.close()
 
-        val audioItem2 = audioLibrary.createFromFile(files.virtualAudioFile().next())
+        // After close(), add directly to the repository to bypass the AudioLibraryBase guard
+        // and verify that the catalog subscription no longer processes the new item.
+        val audioFile2 = files.virtualAudioFile().next()
+        val audioItem2 = MutableAudioItem(audioFile2, audioLibrary.size() + 1, files.metadataIO.readMetadata(audioFile2))
+        repos.audioRepository.add(audioItem2)
         reactive.advance()
 
         // After close(), the artist catalog registry subscription is cancelled
@@ -98,8 +104,9 @@ internal class LifecycleIntegrationTest : StringSpec({
         reactive.advance()
 
         // After close(), the audio item deletion event is no longer processed —
-        // the playlist's audioItemIds still contains the id even though the audio item was removed from the library
-        playlistHierarchy.findByName("Lifecycle Test Playlist") shouldBePresent {
+        // the playlist's audioItemIds still contains the id even though the audio item was removed from the library.
+        // Query through the underlying repository directly to avoid the use-after-close guard on findByName.
+        repos.playlistRepository.findFirst { it.name == "Lifecycle Test Playlist" } shouldBePresent {
             it shouldReferenceItemId audioItem.id
         }
     }
@@ -149,6 +156,32 @@ internal class LifecycleIntegrationTest : StringSpec({
             waveforms.close()
             playlistHierarchy.close()
             audioLibrary.close()
+        }
+    }
+
+    "AudioLibraryBase close() is idempotent — second call is a no-op" {
+        shouldNotThrowAny {
+            repeat(2) { audioLibrary.close() }
+        }
+    }
+
+    "AudioLibrary throws IllegalStateException when used after close" {
+        audioLibrary.close()
+        shouldThrow<IllegalStateException> {
+            audioLibrary.createFromFile(files.virtualAudioFile().next())
+        }
+    }
+
+    "PlaylistHierarchyBase close() is idempotent — second call is a no-op" {
+        shouldNotThrowAny {
+            repeat(2) { playlistHierarchy.close() }
+        }
+    }
+
+    "PlaylistHierarchy throws IllegalStateException when used after close" {
+        playlistHierarchy.close()
+        shouldThrow<IllegalStateException> {
+            playlistHierarchy.createPlaylist("Post-close Playlist")
         }
     }
 })

--- a/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/MusicLibraryIntegrationTest.kt
+++ b/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/MusicLibraryIntegrationTest.kt
@@ -4,6 +4,7 @@ import net.transgressoft.commons.music.audio.AlbumDetails
 import net.transgressoft.commons.music.audio.Artist
 import net.transgressoft.commons.music.audio.AudioItem
 import net.transgressoft.commons.music.audio.AudioLibrary
+import net.transgressoft.commons.music.audio.MutableAudioItem
 import net.transgressoft.commons.music.audio.virtualFiles
 import net.transgressoft.commons.music.playlist.PlaylistHierarchy
 import net.transgressoft.commons.music.playlist.asJsonKeyValues
@@ -221,8 +222,11 @@ internal class MusicLibraryIntegrationTest : StringSpec({
 
         audioLibrary.close()
 
-        // After close, newly created items are no longer indexed in the artist catalog
-        val item2 = audioLibrary.createFromFile(files.virtualAudioFile().next())
+        // After close, add directly to the underlying repository to bypass the AudioLibraryBase guard
+        // and verify that the catalog subscription no longer processes the new item.
+        val audioFile2 = files.virtualAudioFile().next()
+        val item2 = MutableAudioItem(audioFile2, audioLibrary.size() + 1, files.metadataIO.readMetadata(audioFile2))
+        repos.audioRepository.add(item2)
         reactive.advance()
 
         audioLibrary shouldNotIndex item2

--- a/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/MusicLibraryTest.kt
+++ b/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/MusicLibraryTest.kt
@@ -9,6 +9,7 @@ import net.transgressoft.commons.util.OsDetector
 import net.transgressoft.commons.util.WindowsPathException
 import com.google.common.jimfs.Configuration
 import com.google.common.jimfs.Jimfs
+import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.optional.shouldBePresent
@@ -98,13 +99,14 @@ internal class MusicLibraryTest : StringSpec({
         library.audioLibrary().findAlbumAudioItems(artist, album.name)
             .any { it.id == audioItem.id } shouldBe true
 
-        library.close()
+        // close() twice to verify idempotency of the full facade
+        shouldNotThrowAny { library.close() }
+        shouldNotThrowAny { library.close() }
 
-        // After close, newly created items are no longer indexed in the artist catalog
-        val item2 = library.audioItemFromFile(files.virtualAudioFile().next())
-        reactive.advance()
-
-        library.audioLibrary() shouldNotIndex item2
+        // After close, mutations on the audio library throw IllegalStateException
+        shouldThrow<IllegalStateException> {
+            library.audioItemFromFile(files.virtualAudioFile().next())
+        }
     }
 
     "MusicLibrary persistence round-trip restores state from JSON files" {

--- a/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/audio/AudioLibraryBaseTest.kt
+++ b/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/audio/AudioLibraryBaseTest.kt
@@ -113,10 +113,13 @@ internal class AudioLibraryBaseTest : StringSpec({
         repository.add(newItem)
         reactive.advance()
 
-        // The catalog for the new item's artist should not exist because subscription was cancelled
-        audioLibrary.getArtistCatalog(Artist.of(newItem.artist.name)).shouldBeEmpty()
+        // Query the catalog registry directly (bypassing the use-after-close guard) to verify
+        // that the subscription was cancelled and the new item's artist was not indexed.
+        audioLibrary.artistCatalogRegistryForTest().findById(Artist.of(newItem.artist.name)).shouldBeEmpty()
         // The original item's catalog is still present from before close
-        audioLibrary.getArtistCatalog(Artist.of("The Cure")) shouldBePresent { it.artist.name shouldBe "The Cure" }
+        audioLibrary.artistCatalogRegistryForTest().findById(Artist.of("The Cure")) shouldBePresent {
+            it.artist.name shouldBe "The Cure"
+        }
     }
 
     "AudioLibraryBase findAlbumAudioItems returns items by artist and album" {

--- a/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/audio/TestAudioLibrary.kt
+++ b/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/audio/TestAudioLibrary.kt
@@ -25,4 +25,7 @@ internal class TestAudioLibrary(
         val cover = metadataIO.loadCover(audioItemPath)
         return MutableAudioItem(audioItemPath, newId(), tag.copy(coverBytes = cover)).also { add(it) }
     }
+
+    /** Exposes the artist catalog registry for test assertions on post-close catalog state. */
+    fun artistCatalogRegistryForTest() = observableArtistCatalogRegistry
 }

--- a/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/itunes/ItunesImportServiceTest.kt
+++ b/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/itunes/ItunesImportServiceTest.kt
@@ -35,6 +35,8 @@ import java.time.LocalDateTime
 import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ExecutionException
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 
 @ExperimentalCoroutinesApi
@@ -94,6 +96,10 @@ internal class ItunesImportServiceTest : StringSpec({
     }
 
     afterEach {
+        // service is built directly (not via musicLibrary.itunesImport), so musicLibrary.close()
+        // does not cancel its scope — close it explicitly. close() is idempotent, so tests that
+        // already close it in the body are unaffected.
+        service.close()
         musicLibrary.close()
     }
 
@@ -612,5 +618,52 @@ internal class ItunesImportServiceTest : StringSpec({
         result.unresolved shouldHaveSize 1
         result.unresolved.first().reason shouldBe UnresolvedReason.FileNotFound
         result.unresolved.first().title shouldBe "iCloud Only Song"
+    }
+
+    "ItunesImportService close() cancels serviceScope — importAsync after close adds nothing" {
+        service.close()
+        val track = trackFor(1, mp3File)
+        val playlist = playlistFor("PL", "PL1", listOf(1))
+        val library = ItunesLibrary(mapOf(1 to track), listOf(playlist))
+        val policy = ItunesImportPolicy(useFileMetadata = true, writeMetadata = false)
+
+        val result = service.importAsync(listOf(playlist), library, policy)
+
+        shouldThrow<Exception> { result.get() }
+        musicLibrary.audioLibrary().size() shouldBe 0
+    }
+
+    "ItunesImportService in-flight importAsync adds nothing when musicLibrary is closed mid-import" {
+        // SC4: close the library after the first track processes; checkOpen() in add() rejects
+        // any track processed after close as an ImportError, so post-close tracks never reach the repository.
+        // If playlist creation also runs after close it throws IllegalStateException, surfaced via future.get().
+        val tracks = (1..20).associateWith { i -> trackFor(i, mp3File, title = "Track $i") }
+        val playlist = playlistFor("PL", "PL1", (1..20).toList())
+        val library = ItunesLibrary(tracks, listOf(playlist))
+        val policy = ItunesImportPolicy(useFileMetadata = true, writeMetadata = false)
+
+        // Atomics: written from the import coroutine's progress callback, read from the test thread.
+        val libraryClosed = AtomicBoolean(false)
+        val countBeforeClose = AtomicInteger(0)
+        val future: CompletableFuture<ImportResult> =
+            service.importAsync(listOf(playlist), library, policy) { progress ->
+                if (progress.itemsProcessed >= 1 && libraryClosed.compareAndSet(false, true)) {
+                    countBeforeClose.set(musicLibrary.audioLibrary().size())
+                    musicLibrary.close()
+                }
+            }
+
+        // The future may complete normally (if all tracks finished before close) or throw
+        // (if playlist creation hits checkOpen on the closed hierarchy). Either way, the
+        // library size must not exceed countBeforeClose once the library is closed.
+        try {
+            future.get()
+        } catch (e: Exception) {
+            // IllegalStateException from checkOpen() propagated as ExecutionException — expected
+        }
+        // Progress is reported per track, so close lands mid-import: strictly fewer than all
+        // tracks are added. Guards against a vacuous pass where close happens after every add.
+        countBeforeClose.get() shouldBeLessThan tracks.size
+        musicLibrary.audioLibrary().size() shouldBe countBeforeClose.get()
     }
 })

--- a/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/playlist/PlaylistHierarchyBaseTest.kt
+++ b/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/playlist/PlaylistHierarchyBaseTest.kt
@@ -122,10 +122,9 @@ internal class PlaylistHierarchyBaseTest : StringSpec({
         reactive.advance()
 
         // After close(), the audio item deletion event is no longer processed —
-        // the playlist's audioItemIds still contains the id even though the audio item was removed from the library
-        playlistHierarchy.findByName("Close Test Playlist") shouldBePresent { found ->
-            found shouldReferenceItemId audioItem.id
-        }
+        // the playlist's audioItemIds still contains the id even though the audio item was removed from the library.
+        // Access the captured playlist reference directly to avoid the use-after-close guard on findByName.
+        playlist shouldReferenceItemId audioItem.id
         audioLibrary.close()
         deregisterRepository(AudioItem::class.java)
     }

--- a/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/FXMusicLibrary.kt
+++ b/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/FXMusicLibrary.kt
@@ -32,6 +32,8 @@ import net.transgressoft.commons.music.audio.Artist
 import net.transgressoft.commons.music.audio.AudioMetadataIO
 import net.transgressoft.commons.music.audio.JAudioTaggerMetadataIO
 import net.transgressoft.commons.music.audio.event.AudioItemEventSubscriber
+import net.transgressoft.commons.music.itunes.ItunesImportService
+import net.transgressoft.commons.music.m3u.M3uImportService
 import net.transgressoft.commons.music.waveform.AudioWaveform
 import net.transgressoft.commons.music.waveform.AudioWaveformRepository
 import net.transgressoft.commons.util.WindowsPathValidator
@@ -45,6 +47,7 @@ import javafx.beans.property.ReadOnlyListProperty
 import javafx.beans.property.ReadOnlySetProperty
 import java.nio.file.Path
 import java.util.Optional
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * JavaFX-compatible entry point for managing an observable audio library, playlist hierarchy,
@@ -65,8 +68,12 @@ import java.util.Optional
 class FXMusicLibrary private constructor(
     private val _audioLibrary: FXAudioLibrary,
     private val _playlistHierarchy: FXPlaylistHierarchy,
-    private val _waveformRepository: AudioWaveformRepository<AudioWaveform, ObservableAudioItem>
+    private val _waveformRepository: AudioWaveformRepository<AudioWaveform, ObservableAudioItem>,
+    private val _metadataIO: AudioMetadataIO
 ) : MusicLibrary<ObservableAudioItem, ObservablePlaylist> {
+
+    private val closed = AtomicBoolean(false)
+    private val importLock = Any()
 
     /** Returns the underlying observable audio library for advanced operations. */
     override fun audioLibrary(): ObservableAudioLibrary = _audioLibrary
@@ -76,6 +83,34 @@ class FXMusicLibrary private constructor(
 
     /** Returns the underlying waveform repository for advanced operations. */
     fun waveformRepository(): AudioWaveformRepository<AudioWaveform, ObservableAudioItem> = _waveformRepository
+
+    private var _itunesImport: ItunesImportService<ObservableAudioItem, ObservablePlaylist>? = null
+
+    /**
+     * Accessor for the iTunes import service. Constructed on first access and cancelled on [close].
+     *
+     * @throws IllegalStateException if this library has already been closed.
+     */
+    val itunesImport: ItunesImportService<ObservableAudioItem, ObservablePlaylist>
+        get() =
+            synchronized(importLock) {
+                check(!closed.get()) { "This music library has been closed and can no longer be used." }
+                _itunesImport ?: ItunesImportService(this, _metadataIO).also { _itunesImport = it }
+            }
+
+    private var _m3uImport: M3uImportService<ObservableAudioItem, ObservablePlaylist>? = null
+
+    /**
+     * Accessor for the M3U import service. Constructed on first access and cancelled on [close].
+     *
+     * @throws IllegalStateException if this library has already been closed.
+     */
+    val m3uImport: M3uImportService<ObservableAudioItem, ObservablePlaylist>
+        get() =
+            synchronized(importLock) {
+                check(!closed.get()) { "This music library has been closed and can no longer be used." }
+                _m3uImport ?: M3uImportService(this).also { _m3uImport = it }
+            }
 
     /** Observable list of all audio items in the library, suitable for direct JavaFX binding. */
     val audioItemsProperty: ReadOnlyListProperty<ObservableAudioItem> get() = _audioLibrary.audioItemsProperty
@@ -148,7 +183,17 @@ class FXMusicLibrary private constructor(
 
     override fun findPlaylistByName(name: String): Optional<out ObservablePlaylist> = _playlistHierarchy.findByName(name)
 
+    /**
+     * Closes all components idempotently. The first call cancels the import services first, then the
+     * playlist hierarchy, waveform repository, and audio library. Subsequent calls return immediately
+     * without re-closing the components.
+     */
     override fun close() {
+        if (!closed.compareAndSet(false, true)) return
+        synchronized(importLock) {
+            _itunesImport?.close()
+            _m3uImport?.close()
+        }
         _playlistHierarchy.close()
         _waveformRepository.close()
         _audioLibrary.close()
@@ -246,7 +291,7 @@ class FXMusicLibrary private constructor(
                 audioLibrary.subscribe(waveformRepo)
                 audioLibrary.subscribe(playlistHierarchy)
 
-                return FXMusicLibrary(audioLibrary, playlistHierarchy, waveformRepo)
+                return FXMusicLibrary(audioLibrary, playlistHierarchy, waveformRepo, metadataIO)
             } catch (ex: Exception) {
                 if (playlistRepoRegistered) {
                     conditionalDeregister(ObservablePlaylist::class.java, playlistRepository)

--- a/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/audio/FXAudioLibrary.kt
+++ b/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/audio/FXAudioLibrary.kt
@@ -49,6 +49,7 @@ import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.CopyOnWriteArraySet
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
@@ -215,6 +216,7 @@ internal class FXAudioLibrary
             ReactiveScope.flowScope.launch {
                 delay(FX_REFRESH_DEBOUNCE_MILLIS.milliseconds)
                 Platform.runLater {
+                    if (closed.get()) return@runLater
                     try {
                         drainAudioItemChanges()
                     } finally {
@@ -253,6 +255,7 @@ internal class FXAudioLibrary
             ReactiveScope.flowScope.launch {
                 delay(FX_REFRESH_DEBOUNCE_MILLIS.milliseconds)
                 Platform.runLater {
+                    if (closed.get()) return@runLater
                     try {
                         catalogRefreshRequested.set(false)
                         refreshCatalogProperties()
@@ -308,12 +311,17 @@ internal class FXAudioLibrary
         }
 
         /**
-         * Cancels all event subscriptions managed by this library, including those from the base class
-         * and the FX-specific internal and catalog subscriptions, then conditionally deregisters the
-         * repository from LirpContext only if this instance still owns the slot.
+         * Closes this library idempotently, cancelling all event subscriptions. The closed flag is set
+         * first so any in-flight debounce [Platform.runLater] callbacks observe it and no-op instead of
+         * mutating the observable state after close; the debounce coroutines themselves are short-lived
+         * and release their reference to this library as soon as they run. The base-class subscriptions
+         * are cancelled via [cancelBaseSubscriptions] rather than `super.close()` to prevent the base CAS
+         * from swallowing the teardown body when this override has already set the flag. Only the first
+         * call performs teardown; subsequent calls return immediately.
          */
         override fun close() {
-            super.close()
+            if (!closed.compareAndSet(false, true)) return
+            cancelBaseSubscriptions()
             internalSubscription.cancel()
             artistCatalogSubscription.cancel()
             albumSubscription.cancel()
@@ -330,6 +338,7 @@ internal class FXAudioLibrary
             // Empty the observable collections up front so bindings do not show stale items or
             // catalog buckets during the debounce window before the queued refresh runs.
             Platform.runLater {
+                if (closed.get()) return@runLater
                 audioItems.clear()
                 observableArtistCatalogSet.clear()
                 observableAlbumList.clear()
@@ -339,6 +348,7 @@ internal class FXAudioLibrary
         }
 
         override fun createFromFile(audioItemPath: Path): FXAudioItem {
+            checkOpen()
             if (!Files.exists(audioItemPath)) {
                 throw InvalidAudioFilePathException("File '${audioItemPath.toAbsolutePath()}' does not exist")
             }
@@ -356,6 +366,7 @@ internal class FXAudioLibrary
         }
 
         override fun add(entity: ObservableAudioItem): Boolean {
+            checkOpen()
             if (entity is FXAudioItem) entity.metadataIO = metadataIO
             return super.add(entity)
         }

--- a/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/playlist/FXPlaylistHierarchy.kt
+++ b/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/playlist/FXPlaylistHierarchy.kt
@@ -70,7 +70,10 @@ internal class FXPlaylistHierarchy(
         AudioPlaylistEventSubscriber<ObservablePlaylist, ObservableAudioItem>("InternalAudioPlaylistSubscriber").apply {
             addOnNextEventAction(CREATE, UPDATE) { event ->
                 synchronized(playlistsProperty) {
-                    Platform.runLater { observablePlaylistsSet.addAll(event.entities.values) }
+                    Platform.runLater {
+                        if (closed.get()) return@runLater
+                        observablePlaylistsSet.addAll(event.entities.values)
+                    }
                 }
             }
             addOnNextEventAction(DELETE) { event ->
@@ -78,7 +81,10 @@ internal class FXPlaylistHierarchy(
                     if (playlist is FXPlaylist) playlist.detachAllChildRecursiveListeners()
                 }
                 synchronized(playlistsProperty) {
-                    Platform.runLater { observablePlaylistsSet.removeAll(event.entities.values.toSet()) }
+                    Platform.runLater {
+                        if (closed.get()) return@runLater
+                        observablePlaylistsSet.removeAll(event.entities.values.toSet())
+                    }
                 }
             }
         }
@@ -112,7 +118,10 @@ internal class FXPlaylistHierarchy(
         }
 
         forEach { playlist ->
-            Platform.runLater { observablePlaylistsSet.add(playlist) }
+            Platform.runLater {
+                if (closed.get()) return@runLater
+                observablePlaylistsSet.add(playlist)
+            }
         }
 
         subscribe(playlistChangesSubscriber)
@@ -158,15 +167,20 @@ internal class FXPlaylistHierarchy(
     }
 
     /**
-     * Cancels the base class subscriptions and the internal playlist changes subscriber,
-     * then conditionally deregisters the playlist repository from LirpContext only if this
-     * instance still owns the slot.
+     * Marks this hierarchy closed as the first action, then detaches child listeners, cancels the
+     * base class subscriptions and the internal playlist changes subscriber, and finally
+     * conditionally deregisters the playlist repository from LirpContext only if this instance still
+     * owns the slot.
+     *
+     * The [closed] compare-and-set runs before any teardown so a concurrent `Platform.runLater` body
+     * guarded by `closed.get()` never observes an open flag while the hierarchy is being torn down.
      */
     override fun close() {
+        if (!closed.compareAndSet(false, true)) return
         forEach { playlist ->
             if (playlist is FXPlaylist) playlist.detachAllChildRecursiveListeners()
         }
-        super.close()
+        cancelBaseSubscriptions()
         playlistChangesSubscriber.cancelSubscription()
         conditionalDeregister(ObservablePlaylist::class.java, repository)
     }

--- a/music-commons-fx/src/test/kotlin/net/transgressoft/commons/fx/music/FXAudioLibraryLifecycleTest.kt
+++ b/music-commons-fx/src/test/kotlin/net/transgressoft/commons/fx/music/FXAudioLibraryLifecycleTest.kt
@@ -1,0 +1,116 @@
+/******************************************************************************
+ * Copyright (C) 2025  Octavio Calleya Garcia                                 *
+ *                                                                            *
+ * This program is free software: you can redistribute it and/or modify       *
+ * it under the terms of the GNU General Public License as published by       *
+ * the Free Software Foundation, either version 3 of the License, or          *
+ * (at your option) any later version.                                        *
+ *                                                                            *
+ * This program is distributed in the hope that it will be useful,            *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
+ * GNU General Public License for more details.                               *
+ *                                                                            *
+ * You should have received a copy of the GNU General Public License          *
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.     *
+ ******************************************************************************/
+
+package net.transgressoft.commons.fx.music
+
+import net.transgressoft.commons.fx.music.eventuallyAfterFxEvents
+import net.transgressoft.commons.music.audio.virtualFiles
+import net.transgressoft.commons.music.testing.ReactiveScopeSerialization
+import net.transgressoft.commons.music.testing.registryIsolation
+import io.kotest.assertions.nondeterministic.eventually
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.property.arbitrary.next
+import org.testfx.api.FxToolkit
+import org.testfx.util.WaitForAsyncUtils
+import java.lang.ref.WeakReference
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+
+/**
+ * Verifies the close-lifecycle contracts of [FXMusicLibrary] and its underlying [FXAudioLibrary]:
+ * idempotency, use-after-close rejection, no stale items across create-close-create cycles, and
+ * no retained instance after close.
+ */
+@ExperimentalCoroutinesApi
+internal class FXAudioLibraryLifecycleTest : StringSpec({
+
+    registryIsolation()
+    // This spec exercises the real debounce/refresh timing (create-close cycles, WeakReference leak
+    // detection) with eventuallyAfterFxEvents, so it keeps ReactiveScope's production dispatchers via
+    // ReactiveScopeSerialization rather than swapping in a TestDispatcher.
+    extension(ReactiveScopeSerialization)
+    val files = virtualFiles()
+
+    beforeSpec {
+        FxToolkit.registerPrimaryStage()
+    }
+
+    afterSpec {
+        FxToolkit.cleanupStages()
+    }
+
+    "FXMusicLibrary close() is idempotent" {
+        val library = FXMusicLibrary.builder().metadataIO(files.metadataIO).build()
+        shouldNotThrowAny {
+            library.close()
+            library.close()
+        }
+    }
+
+    "FXAudioLibrary throws IllegalStateException on mutation after close" {
+        val library = FXMusicLibrary.builder().metadataIO(files.metadataIO).build()
+        library.close()
+
+        shouldThrow<IllegalStateException> {
+            library.audioItemFromFile(files.virtualAudioFile().next())
+        }
+        shouldThrow<IllegalStateException> {
+            library.createPlaylistDirectory("after-close")
+        }
+        // Accessing an import service after close must fail fast rather than construct a new,
+        // never-cancelled service scope against the closed library.
+        shouldThrow<IllegalStateException> {
+            library.itunesImport
+        }
+    }
+
+    "100 create-close-create cycles leave no stale items in a fresh library" {
+        repeat(100) {
+            val lib = FXMusicLibrary.builder().metadataIO(files.metadataIO).build()
+            lib.audioItemFromFile(files.virtualAudioFile().next())
+            eventuallyAfterFxEvents(500.milliseconds) {
+                lib.audioItemsProperty.isEmpty() shouldBe false
+            }
+            lib.close()
+        }
+
+        val fresh = FXMusicLibrary.builder().metadataIO(files.metadataIO).build()
+        eventuallyAfterFxEvents(200.milliseconds) {
+            fresh.audioItemsProperty.isEmpty() shouldBe true
+        }
+        fresh.close()
+    }
+
+    "FXAudioLibrary is not retained after close" {
+        var library: FXMusicLibrary? = FXMusicLibrary.builder().metadataIO(files.metadataIO).build()
+        val ref = WeakReference(library!!.audioLibrary())
+
+        library.close()
+        WaitForAsyncUtils.waitForFxEvents()
+        library = null
+
+        eventually(5.seconds) {
+            WaitForAsyncUtils.waitForFxEvents()
+            System.gc()
+            ref.get() shouldBe null
+        }
+    }
+})

--- a/music-commons-fx/src/test/kotlin/net/transgressoft/commons/fx/music/FXMusicLibraryTest.kt
+++ b/music-commons-fx/src/test/kotlin/net/transgressoft/commons/fx/music/FXMusicLibraryTest.kt
@@ -123,26 +123,23 @@ internal class FXMusicLibraryTest : StringSpec({
         library.close()
     }
 
-    "FXMusicLibrary close releases all resources" {
+    "FXMusicLibrary close releases all resources and rejects further mutations" {
         val library = FXMusicLibrary.builder().metadataIO(files.metadataIO).build()
 
-        val audioItem = library.audioItemFromFile(files.virtualAudioFile().next())
+        library.audioItemFromFile(files.virtualAudioFile().next())
 
         reactive.advance()
 
         library.audioLibrary().size() shouldBe 1
         WaitForAsyncUtils.waitForFxEvents()
-        val sizeBeforeClose = library.audioItemsProperty.size
 
         library.close()
 
-        // After close, the library retains already-added items but does not track new ones
+        // After close, the library retains its state but mutating operations throw IllegalStateException
         library.audioLibrary().size() shouldBe 1
-        library.audioLibrary().add(library.audioItemFromFile(files.virtualAudioFile().next()))
-        reactive.advance()
-        WaitForAsyncUtils.waitForFxEvents()
-
-        library.audioItemsProperty.size shouldBe sizeBeforeClose
+        shouldThrow<IllegalStateException> {
+            library.audioItemFromFile(files.virtualAudioFile().next())
+        }
     }
 
     "FXMusicLibrary albumsProperty and genreIndexesProperty are index-addressable ordered lists" {


### PR DESCRIPTION
Closes #199.

## Summary

Hardens the `close()` contracts of the four facade types (`CoreMusicLibrary`, `FXMusicLibrary`, `DefaultPlaylistHierarchy`, `FXPlaylistHierarchy`) so a closed library is safe to close again and rejects further use, guards the JavaFX debounce/refresh path against firing after close, and links import-service scopes to library lifetime.

## Changes

### Core lifecycle layer
- `AudioLibraryBase` and `PlaylistHierarchyBase` gain an `AtomicBoolean closed` flag, a `checkOpen()` guard, and an idempotent compare-and-set `close()`.
- Every mutation and explicit-query entry point routes through `checkOpen()` first and throws `IllegalStateException` once closed — `add`, `createAudioItem`, the artist/album/genre getters, and the playlist `add`/`remove`/`removeAll`/`findByName`/`movePlaylist`/`findParentPlaylist` methods.

### JavaFX debounce/refresh lifecycle
- `FXAudioLibrary.close()` sets the closed flag first, and every debounce `Platform.runLater` body checks it, so a refresh launched before close cannot mutate the closed library's observable collections.
- `FXPlaylistHierarchy.close()` takes the compare-and-set as its first action before detaching child listeners, so a concurrent `runLater` never observes an open flag mid-teardown.
- The debounce launches run on the shared reactive scope so large create bursts still coalesce into a single observable change.

### Import-service lifetime
- `ItunesImportService` now mirrors `M3uImportService`: a persistent `SupervisorJob`-backed scope and an `AutoCloseable.close()` that cancels it.
- `CoreMusicLibrary` and `FXMusicLibrary` own their import services lazily and cancel them as the first step of `close()`, so an in-flight `importAsync` completing after `close()` adds no items to the closed library. Both facades also carry their own idempotency guard so double-close is a clean no-op at the facade level.

## Verification

- [x] Full multi-module test suite passes (`gradle test`), including ktlint checks.
- Idempotency and use-after-close cases for both core base types.
- A JavaFX lifecycle suite proving no stale items across 100 create-close-create cycles and no retained `FXAudioLibrary` after close (via `WeakReference` + GC).
- Post-close-cancel and in-flight-import cases for `ItunesImportService`.

## Notes

- Public-facing README/wiki documentation of the full lifecycle and thread-safety contract is handled as part of the upcoming API-lock work.
