### PR TITLE
Corner-case coverage and hardening for the 1.0 release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -278,8 +278,9 @@ subprojects {
             events 'passed', 'skipped', 'failed'
         }
 
-        def excludeTags = ['windows-only']
+        def excludeTags = ['windows-only', 'stress']
         if (project.findProperty('includeWindowsOnly')?.toString()?.toBoolean()) excludeTags.remove('windows-only')
+        if (project.findProperty('includeStress')?.toString()?.toBoolean()) excludeTags.remove('stress')
         if (project.findProperty('excludeLinuxOnly')?.toString()?.toBoolean()) excludeTags << 'linux-only'
         if (project.findProperty('excludePosixOnly')?.toString()?.toBoolean()) excludeTags << 'posix-only'
         if (project.findProperty('excludeAudioHardware')?.toString()?.toBoolean()) excludeTags << 'audio-hardware'

--- a/music-commons-api/src/main/kotlin/net/transgressoft/commons/music/MusicLibrary.kt
+++ b/music-commons-api/src/main/kotlin/net/transgressoft/commons/music/MusicLibrary.kt
@@ -48,9 +48,11 @@ import java.util.Optional
  * - **`id`** — a repository-local integer assigned when an entity is persisted. It is not stable
  *   across library instances: the same audio file reloaded into a freshly built library may
  *   receive a different `id`. Do not use `id` to correlate entities across instances.
- * - **`uniqueId`** — a content-derived stable identifier that is consistent across library
- *   instances. Combined with content-based [equals], `uniqueId` is the correct way to match
- *   the same logical entity when comparing across instances or reloads.
+ * - **`uniqueId`** — a physical-identity key derived from the file name, the track duration in
+ *   whole seconds, and the bit rate. It is stable under re-tagging: mutating the title or other
+ *   metadata tags does not change the key, so two copies of the same physical track with different
+ *   titles compute the same `uniqueId`. Combined with content-based [equals], `uniqueId` is the
+ *   correct way to match the same physical track across library instances or reloads.
  *
  * Entities are bound to the library instance that created them and must not be mixed across
  * instances: aggregate lookups (playlist → audio items) use the repository-local `id` channel,

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/CoreMusicLibrary.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/CoreMusicLibrary.kt
@@ -39,11 +39,13 @@ import net.transgressoft.lirp.event.CrudEvent
 import net.transgressoft.lirp.event.LirpEventPublisher
 import net.transgressoft.lirp.persistence.Repository
 import net.transgressoft.lirp.persistence.VolatileRepository
+import mu.withLoggingContext
 import java.nio.file.Path
 import java.util.Optional
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Flow
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * Unified entry point for managing an audio library, playlist hierarchy, and waveform repository.
@@ -69,7 +71,9 @@ class CoreMusicLibrary private constructor(
     private val _audioLibrary: AudioLibrary,
     private val _playlistHierarchy: PlaylistHierarchy,
     private val _waveformRepository: AudioWaveformRepository<AudioWaveform, AudioItem>,
-    private val _metadataIO: AudioMetadataIO
+    private val _metadataIO: AudioMetadataIO,
+    /** Diagnostic label for this library instance, used in MDC logging context. */
+    val instanceName: String
 ) : MusicLibrary<AudioItem, MutableAudioPlaylist> {
 
     private val closed = AtomicBoolean(false)
@@ -95,7 +99,7 @@ class CoreMusicLibrary private constructor(
         get() =
             synchronized(importLock) {
                 check(!closed.get()) { "This music library has been closed and can no longer be used." }
-                _itunesImport ?: ItunesImportService(this, _metadataIO).also { _itunesImport = it }
+                _itunesImport ?: ItunesImportService(this, _metadataIO, instanceName = instanceName).also { _itunesImport = it }
             }
 
     private var _m3uImport: M3uImportService<AudioItem, MutableAudioPlaylist>? = null
@@ -109,7 +113,7 @@ class CoreMusicLibrary private constructor(
         get() =
             synchronized(importLock) {
                 check(!closed.get()) { "This music library has been closed and can no longer be used." }
-                _m3uImport ?: M3uImportService(this).also { _m3uImport = it }
+                _m3uImport ?: M3uImportService(this, instanceName = instanceName).also { _m3uImport = it }
             }
 
     /**
@@ -123,12 +127,13 @@ class CoreMusicLibrary private constructor(
     val artistCatalogPublisher: LirpEventPublisher<CrudEvent.Type, CrudEvent<Artist, ArtistCatalog<AudioItem>>>
         get() = _audioLibrary.artistCatalogPublisher
 
-    override fun audioItemFromFile(path: Path): AudioItem {
-        // Defensive boundary check at the public API entry point — MutableAudioItem.init validates
-        // again, but failing here surfaces the exception before the audio item construction kicks off.
-        WindowsPathValidator.validatePath(path)
-        return _audioLibrary.createFromFile(path)
-    }
+    override fun audioItemFromFile(path: Path): AudioItem =
+        withLoggingContext("libraryInstance" to instanceName) {
+            // Defensive boundary check at the public API entry point — MutableAudioItem.init validates
+            // again, but failing here surfaces the exception before the audio item construction kicks off.
+            WindowsPathValidator.validatePath(path)
+            _audioLibrary.createFromFile(path)
+        }
 
     override fun createPlaylist(name: String): MutableAudioPlaylist = _playlistHierarchy.createPlaylist(name)
 
@@ -219,6 +224,7 @@ class CoreMusicLibrary private constructor(
         private var playlistRepository: Repository<Int, MutableAudioPlaylist> = VolatileRepository("PlaylistHierarchy")
         private var waveformRepository: Repository<Int, AudioWaveform> = VolatileRepository("AudioWaveformRepository")
         private var metadataIO: AudioMetadataIO = JAudioTaggerMetadataIO()
+        private var instanceName: String? = null
 
         /**
          * Injects the [repository] backing the audio library.
@@ -266,6 +272,26 @@ class CoreMusicLibrary private constructor(
         fun metadataIO(utils: AudioMetadataIO): Builder = apply { metadataIO = utils }
 
         /**
+         * Sets a human-readable diagnostic label for this library instance.
+         *
+         * The name is surfaced as the `libraryInstance` MDC key around library operations and
+         * import-service scopes, making logs attributable when multiple library instances are
+         * active across time (e.g., sequential open/close cycles or concurrent imports).
+         *
+         * When not set, a short stable default is auto-generated from a per-JVM monotonic
+         * counter (e.g., `music-library-1`, `music-library-2`). The name is the caller's
+         * responsibility when set explicitly — it is a diagnostic label, not a trust boundary.
+         *
+         * @param name the label to assign; must be non-blank
+         * @return this builder, for chaining
+         */
+        fun instanceName(name: String): Builder =
+            apply {
+                require(name.isNotBlank()) { "instanceName must be non-blank" }
+                instanceName = name
+            }
+
+        /**
          * Builds a [CoreMusicLibrary] by injecting the configured repositories and wiring event
          * subscriptions automatically.
          *
@@ -274,6 +300,8 @@ class CoreMusicLibrary private constructor(
          * Rollback on partial failure closes everything constructed so far before rethrowing.
          */
         fun build(): CoreMusicLibrary {
+            val resolvedName = instanceName ?: "core-music-library-${instanceCounter.incrementAndGet()}"
+
             // 1. Audio library first — registers AudioItem in LirpContext
             val audioLibrary = DefaultAudioLibrary(audioRepository, metadataIO)
 
@@ -293,7 +321,7 @@ class CoreMusicLibrary private constructor(
                 audioLibrary.subscribe(waveformRepo)
                 audioLibrary.subscribe(playlistHierarchy)
 
-                return CoreMusicLibrary(audioLibrary, playlistHierarchy, waveformRepo, metadataIO)
+                return CoreMusicLibrary(audioLibrary, playlistHierarchy, waveformRepo, metadataIO, resolvedName)
             } catch (ex: Exception) {
                 (playlistHierarchy as? AutoCloseable)?.close()
                 waveformRepo?.close()
@@ -304,6 +332,9 @@ class CoreMusicLibrary private constructor(
     }
 
     companion object {
+
+        private val instanceCounter = AtomicInteger(0)
+
         /**
          * Returns a new [Builder] to configure and construct a [CoreMusicLibrary].
          */

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/AudioLibraryBase.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/AudioLibraryBase.kt
@@ -77,6 +77,13 @@ abstract class AudioLibraryBase<I, AC, ALC, GC>(
           GC : ReactiveGenreIndex<GC, I>,
           GC : Comparable<GC> {
 
+    private companion object {
+        // Upper bound on id-allocation retries; large enough that it is never reached in practice
+        // but prevents an infinite loop when the id space is exhausted (e.g. in tests that
+        // fill the Int range).
+        const val MAX_ID_ALLOCATION_ATTEMPTS = 1_000_000
+    }
+
     /**
      * Publisher exposing the internal artist catalog registry.
      *
@@ -113,7 +120,15 @@ abstract class AudioLibraryBase<I, AC, ALC, GC>(
     private val entitySubscriptions: MutableMap<Int, LirpEventSubscription<in I, MutationEvent.Type, MutationEvent<Int, I>>> =
         ConcurrentHashMap()
 
-    init {
+    /**
+     * Subscribes existing repository items to catalog-key mutation tracking.
+     *
+     * Subclasses must call this method as the final step of their own initialization, after any
+     * per-item back-references (such as a metadata I/O delegate) have been wired. Calling it
+     * earlier opens a window where an item mutation event fires before back-references are set,
+     * producing a null-reference access on the first catalog-relevant property change.
+     */
+    protected fun subscribeExistingItems() {
         if (repository.isEmpty.not()) {
             repository.forEach {
                 subscribeCatalogKeyChanges(it)
@@ -130,6 +145,12 @@ abstract class AudioLibraryBase<I, AC, ALC, GC>(
      * non-key mutations (title, bpm, track number, …), which would otherwise cause needless catalog
      * churn. The projection's reverse index re-keys the item to its current bucket from the UPDATE;
      * emitting Update also causes JsonFileRepository to persist the change.
+     *
+     * Documented behavior: subscribers must not mutate catalog-relevant properties (artist, album,
+     * or genres) during event delivery. Doing so re-triggers the projection rebuild synchronously,
+     * causing a re-entrant UPDATE before the current one completes. This leads to redundant
+     * re-key cycles and may produce inconsistent intermediate catalog states visible to other
+     * subscribers observing the same event sequence.
      */
     private fun subscribeCatalogKeyChanges(audioItem: I) {
         entitySubscriptions.remove(audioItem.id)?.cancel()
@@ -188,8 +209,15 @@ abstract class AudioLibraryBase<I, AC, ALC, GC>(
 
     protected fun newId(): Int {
         var id: Int
+        var attempts = 0
         do {
+            check(attempts++ < MAX_ID_ALLOCATION_ATTEMPTS) {
+                "Cannot allocate a new audio item id: the id space appears to be exhausted after $MAX_ID_ALLOCATION_ATTEMPTS attempts."
+            }
             id = idCounter.getAndIncrement()
+            check(id > 0) {
+                "Cannot allocate a new audio item id: the positive id space is exhausted (the id counter overflowed Int.MAX_VALUE)."
+            }
         } while (contains(id))
         return id
     }

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/DefaultAudioLibrary.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/DefaultAudioLibrary.kt
@@ -56,6 +56,14 @@ internal class DefaultAudioLibrary
 
         init {
             guardedRegister(AudioItem::class.java, repository)
+            // Wire metadataIO onto items already hydrated from the repository before subscribing
+            // them to catalog-key mutation events. Doing so first closes the window where an item
+            // mutation fires during the subscription pass while metadataIO is still null on
+            // deserialized items.
+            repository.forEach { item ->
+                if (item is MutableAudioItem) item.metadataIO = metadataIO
+            }
+            subscribeExistingItems()
             playerSubscriber.addOnNextEventAction(PLAYED) { event ->
                 val audioItem = event.audioItem
                 logger.info { "Audio item with id ${audioItem.id} was played" }
@@ -68,17 +76,17 @@ internal class DefaultAudioLibrary
             }
         }
 
-        init {
-            // Wire the metadataIO back-ref onto items already hydrated from the repository.
-            // AudioLibraryBase.init iterates repository.forEach directly without routing through add(),
-            // so this loop is required in addition to the add() override to cover the hydration path.
-            repository.forEach { item ->
-                if (item is MutableAudioItem) item.metadataIO = metadataIO
-            }
-        }
-
         override fun add(entity: AudioItem): Boolean {
-            if (entity is MutableAudioItem) entity.metadataIO = metadataIO
+            if (entity is MutableAudioItem) {
+                val existingMetadataIO = entity.metadataIO
+                if (existingMetadataIO != null && existingMetadataIO !== metadataIO) {
+                    logger.warn {
+                        "Audio item ${entity.id} was created by a different library instance. " +
+                            "Re-wiring its metadata delegate to this library."
+                    }
+                }
+                entity.metadataIO = metadataIO
+            }
             return super.add(entity)
         }
 
@@ -93,6 +101,16 @@ internal class DefaultAudioLibrary
                 throw InvalidAudioFilePathException("File '${audioItemPath.toAbsolutePath()}' is not readable")
             }
             val tag = metadataIO.readMetadata(audioItemPath)
+            // Dedup by physical identity: if an item with the same fileName-duration-bitRate key
+            // already exists, return it without allocating a new id or adding a duplicate.
+            val candidateUniqueId =
+                buildString {
+                    append(audioItemPath.fileName.toString().replace(' ', '_'))
+                    append("-${tag.duration.toSeconds()}")
+                    append("-${tag.bitRate}")
+                }
+            val existing = findByUniqueId(candidateUniqueId)
+            if (existing.isPresent) return existing.get()
             return MutableAudioItem(audioItemPath, newId(), tag).also { audioItem ->
                 add(audioItem)
                 logger.trace { "New AudioItem was created from file $audioItemPath with id ${audioItem.id}" }

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/ImmutableAlbum.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/ImmutableAlbum.kt
@@ -38,6 +38,12 @@ import java.lang.ref.SoftReference
  * [SoftReference] so that memory pressure can evict the bytes and re-resolution happens
  * transparently on the next access.
  *
+ * Documented behavior: `Artist`, `Album`, and `Label` flyweight instances are cached in
+ * [SoftReference]-backed maps and may be GC-evicted under memory pressure. After eviction a
+ * subsequent lookup creates a new instance that is `equals`-equivalent but not `===`-identical
+ * to the prior one. Always use value-based `equals` (or standard collection operations) to compare
+ * flyweight instances; reference equality (`===`) is not a stable identity across GC cycles.
+ *
  * @param I The type of audio items contained in this album
  */
 internal class ImmutableAlbum<I>(override val album: AlbumDetails, tracks: List<I>) :
@@ -65,15 +71,27 @@ internal class ImmutableAlbum<I>(override val album: AlbumDetails, tracks: List<
     @Volatile
     private var coverRef: SoftReference<ByteArray>? = null
 
+    // `noCover` means "no cover was found at the last load attempt".
+    // It is reset whenever `coverRef` had been set (a cover was found previously) and is then
+    // evicted by the GC — indicated by a non-null `coverRef` whose referent is null — so that
+    // the next access retries loading from the tracks rather than returning null permanently.
     @Volatile
     private var noCover: Boolean = false
 
     override val coverImageBytes: ByteArray?
         get() {
-            coverRef?.get()?.let { return it }
+            val currentRef = coverRef
+            val cached = currentRef?.get()
+            if (cached != null) return cached
+            // If coverRef was previously set (a cover was loaded) but has since been evicted,
+            // reset noCover so the next synchronized block retries loading.
+            if (currentRef != null && cached == null) noCover = false
             if (noCover) return null
             synchronized(this) {
-                coverRef?.get()?.let { return it }
+                val lockedRef = coverRef
+                lockedRef?.get()?.let { return it }
+                // Inner eviction check: re-clear noCover if coverRef was evicted while waiting.
+                if (lockedRef != null && lockedRef.get() == null) noCover = false
                 if (noCover) return null
                 val bytes = firstCoverImageBytes(tracks)
                 return if (bytes != null) {

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/JAudioTaggerMetadataIO.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/JAudioTaggerMetadataIO.kt
@@ -55,6 +55,14 @@ import java.time.Duration
  * instead — the guard surfaces the mismatch with a helpful message rather than the cryptic
  * upstream exception.
  *
+ * Documented behavior: [TagOptionSingleton] is a process-wide mutable singleton shared by all
+ * JAudioTagger operations. Its genre-text flags are set once at construction time. Constructing
+ * multiple [JAudioTaggerMetadataIO] instances concurrently — or mutating [TagOptionSingleton]
+ * from application code while write operations are in progress — can cause one format's settings
+ * to be transiently observed by a concurrent write targeting a different format. For correct
+ * behavior, create a single [JAudioTaggerMetadataIO] instance per JVM and do not mutate
+ * [TagOptionSingleton] externally.
+ *
  * Future Kotlin-native metadata libraries land alongside this class as additional
  * [AudioMetadataIO] implementations.
  */

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/MutableAudioItem.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/MutableAudioItem.kt
@@ -135,7 +135,6 @@ internal class MutableAudioItem
             get() =
                 buildString {
                     append(path.fileName.toString().replace(' ', '_'))
-                    append("-$title")
                     append("-${duration.toSeconds()}")
                     append("-$bitRate")
                 }

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/itunes/ItunesImportService.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/itunes/ItunesImportService.kt
@@ -1,3 +1,20 @@
+/******************************************************************************
+ * Copyright (C) 2025  Octavio Calleya Garcia                                 *
+ *                                                                            *
+ * This program is free software: you can redistribute it and/or modify       *
+ * it under the terms of the GNU General Public License as published by       *
+ * the Free Software Foundation, either version 3 of the License, or          *
+ * (at your option) any later version.                                        *
+ *                                                                            *
+ * This program is distributed in the hope that it will be useful,            *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
+ * GNU General Public License for more details.                               *
+ *                                                                            *
+ * You should have received a copy of the GNU General Public License          *
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.     *
+ ******************************************************************************/
+
 package net.transgressoft.commons.music.itunes
 
 import net.transgressoft.commons.music.MusicLibrary
@@ -60,7 +77,8 @@ class ItunesImportService<I, P>
     constructor(
         private val musicLibrary: MusicLibrary<I, P>,
         private val metadataIO: AudioMetadataIO = JAudioTaggerMetadataIO(),
-        private val fileSystem: FileSystem = FileSystems.getDefault()
+        private val fileSystem: FileSystem = FileSystems.getDefault(),
+        private val instanceName: String = ""
     ) : AutoCloseable where I : ReactiveAudioItem<I>,
           P : ReactiveAudioPlaylist<I, P> {
 
@@ -106,6 +124,7 @@ class ItunesImportService<I, P>
     ): CompletableFuture<ImportResult> {
         val sessionId = UUID.randomUUID().toString()
         MDC.put("importSessionId", sessionId)
+        if (instanceName.isNotEmpty()) MDC.put("libraryInstance", instanceName)
         try {
             return serviceScope.future(MDCContext()) {
                 val effectivePlaylists = playlistBuilder.expandWithAncestors(selectedPlaylists, itunesLibrary)
@@ -126,6 +145,7 @@ class ItunesImportService<I, P>
             }
         } finally {
             MDC.remove("importSessionId")
+            if (instanceName.isNotEmpty()) MDC.remove("libraryInstance")
         }
     }
 

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/m3u/M3uImportService.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/m3u/M3uImportService.kt
@@ -84,7 +84,8 @@ class M3uCycleException(message: String, cause: Throwable? = null) : Exception(m
  */
 class M3uImportService<I : ReactiveAudioItem<I>, P : ReactiveAudioPlaylist<I, P>>(
     private val musicLibrary: MusicLibrary<I, P>,
-    private val maxDepth: Int = DEFAULT_MAX_DEPTH
+    private val maxDepth: Int = DEFAULT_MAX_DEPTH,
+    private val instanceName: String = ""
 ) : AutoCloseable {
 
     init {
@@ -113,7 +114,12 @@ class M3uImportService<I : ReactiveAudioItem<I>, P : ReactiveAudioPlaylist<I, P>
      */
     fun import(rootM3u: Path): P {
         val sessionId = UUID.randomUUID().toString()
-        return withLoggingContext("importSessionId" to sessionId) {
+        val context =
+            buildMap {
+                put("importSessionId", sessionId)
+                if (instanceName.isNotEmpty()) put("libraryInstance", instanceName)
+            }
+        return withLoggingContext(context) {
             val plan = planImport(rootM3u, visited = emptyList(), depth = 0)
             rejectCollisions(plan)
             materialize(plan, existingAudioItemsByPath()).also { playlist ->

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/playlist/DefaultPlaylistHierarchy.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/playlist/DefaultPlaylistHierarchy.kt
@@ -18,6 +18,7 @@
 package net.transgressoft.commons.music.playlist
 
 import net.transgressoft.commons.music.audio.AudioItem
+import net.transgressoft.commons.music.audio.UNASSIGNED_ID
 import net.transgressoft.commons.music.conditionalDeregister
 import net.transgressoft.commons.music.guardedRegister
 import net.transgressoft.lirp.entity.toIds
@@ -66,6 +67,9 @@ internal class DefaultPlaylistHierarchy(
         audioItemIds: List<Int>
     ): MutableAudioPlaylist {
         require(findByName(name).isEmpty) { "Playlist with name '$name' already exists" }
+        require(audioItemIds.none { it == UNASSIGNED_ID }) {
+            "audioItemIds must not contain unassigned (zero) ids — resolve each audio item to a persisted id before adding it to a playlist"
+        }
         return MutablePlaylist(newId(), name, false, audioItemIds).also {
             logger.trace { "Created playlist $it" }
             add(it)
@@ -79,7 +83,11 @@ internal class DefaultPlaylistHierarchy(
         audioItems: List<AudioItem>
     ): MutableAudioPlaylist {
         require(findByName(name).isEmpty) { "Playlist with name '$name' already exists" }
-        return MutablePlaylist(newId(), name, true, audioItems.toIds()).also {
+        val audioItemIds = audioItems.toIds()
+        require(audioItemIds.none { it == UNASSIGNED_ID }) {
+            "audioItemIds must not contain unassigned (zero) ids — resolve each audio item to a persisted id before adding it to a playlist"
+        }
+        return MutablePlaylist(newId(), name, true, audioItemIds).also {
             logger.trace { "Created playlist directory $it" }
             add(it)
         }

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/playlist/PlaylistHierarchyBase.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/playlist/PlaylistHierarchyBase.kt
@@ -36,6 +36,8 @@ import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.reflect.KClass
 
+private const val MAX_ID_SEARCH_ATTEMPTS = 10_000
+
 /**
  * Base implementation for [ReactivePlaylistHierarchy] managing hierarchical playlist structures.
  *
@@ -46,6 +48,12 @@ import kotlin.reflect.KClass
  *
  * Subscribes to mutation events on each playlist to keep [playlistsHierarchyMultiMap] in sync
  * when nested playlists are added or removed directly on a playlist instance.
+ *
+ * **Subscription requirement:** this hierarchy must be subscribed to an audio library's event
+ * publisher before any mutating operation is performed. The audio item delete subscriber keeps
+ * playlists in sync when items are removed from the library — without it, deleted items remain
+ * silently in playlists. Use the library builder, which wires the subscription automatically.
+ * Calling a mutating operation before the subscription is established throws [IllegalStateException].
  */
 abstract class PlaylistHierarchyBase<I : ReactiveAudioItem<I>, P : ReactiveAudioPlaylist<I, P>>(
     private val repository: Repository<Int, P>,
@@ -67,12 +75,59 @@ abstract class PlaylistHierarchyBase<I : ReactiveAudioItem<I>, P : ReactiveAudio
     protected val closed = AtomicBoolean(false)
 
     /**
+     * Tracks whether this hierarchy's audio item delete subscriber has been wired.
+     * Set to `true` inside the subscriber's own [onSubscribe] hook when the builder calls
+     * `audioLibrary.subscribe(hierarchy)`. Mutating operations check this flag to detect
+     * hierarchies that were constructed outside the builder and therefore lack the delete-sync subscriber.
+     *
+     * Subclasses may call [markDeleteSubscriberWired] to clear this guard in controlled testing
+     * scenarios where the subscriber wiring is handled differently.
+     */
+    private val subscriptionEstablished = AtomicBoolean(false)
+
+    /**
      * Asserts that this playlist hierarchy has not been closed.
      *
      * @throws IllegalStateException if [close] has already been called on this hierarchy.
      */
     protected fun checkOpen() {
         check(!closed.get()) { "This playlist hierarchy has been closed and can no longer be used." }
+    }
+
+    /**
+     * Asserts that the audio item delete subscriber is wired.
+     *
+     * @throws IllegalStateException if the hierarchy was not constructed via the library builder,
+     * which is the only supported construction path that wires the delete subscriber.
+     */
+    private fun checkSubscribed() {
+        check(subscriptionEstablished.get()) {
+            "This playlist hierarchy must be constructed via the library builder so its audio item " +
+                "delete subscriber is wired. Without it, deleted audio items are never removed from playlists."
+        }
+    }
+
+    /**
+     * Marks the audio item delete subscriber as wired, clearing the first-use subscription guard.
+     *
+     * The guard is set automatically when the library builder calls `audioLibrary.subscribe(hierarchy)`.
+     * This method is available to subclasses and same-module test code for controlled scenarios —
+     * such as test doubles or tests that exercise standalone hierarchy behavior — where the
+     * subscription is established through a different mechanism or is not required.
+     */
+    internal fun markDeleteSubscriberWired() {
+        subscriptionEstablished.set(true)
+    }
+
+    /**
+     * Subclass-visible bridge to [markDeleteSubscriberWired].
+     *
+     * [markDeleteSubscriberWired] is module-internal, so subclasses defined in other modules cannot
+     * reach it. This protected delegate lets such a subclass expose its own module-internal test hook
+     * for standalone-hierarchy scenarios where the delete subscriber is wired through a different mechanism.
+     */
+    protected fun markDeleteSubscriberWiredForTesting() {
+        markDeleteSubscriberWired()
     }
 
     init {
@@ -83,6 +138,10 @@ abstract class PlaylistHierarchyBase<I : ReactiveAudioItem<I>, P : ReactiveAudio
                 it.removeAudioItems(event.entities.values)
             }
         }
+        // Set the subscription-established flag when the audio library's publisher delivers its
+        // onSubscribe callback to this subscriber — this happens inside the builder's
+        // audioLibrary.subscribe(hierarchy) call. No builder-file edit is needed.
+        addOnSubscribeEventAction { subscriptionEstablished.set(true) }
     }
 
     private val logger = KotlinLogging.logger {}
@@ -92,18 +151,32 @@ abstract class PlaylistHierarchyBase<I : ReactiveAudioItem<I>, P : ReactiveAudio
     // Tracks per-playlist mutation subscriptions so they can be cancelled on remove/close.
     private val playlistMutationSubscriptions = ConcurrentHashMap<Int, LirpEventSubscription<*, *, *>>()
 
-    private val idCounter: AtomicInteger = AtomicInteger(1)
+    // Seeded above the highest id already present so allocation stays O(1) on a hierarchy loaded
+    // with existing playlists; the retry cap then only guards a genuinely saturated id space rather
+    // than tripping on a dense run of low ids. Seeding is deferred until first allocation so the
+    // repository is fully populated by the time the maximum id is read.
+    private val idCounter: AtomicInteger by lazy {
+        AtomicInteger((search { true }.maxOfOrNull { it.id } ?: 0) + 1)
+    }
 
     protected fun newId(): Int {
         var id: Int
+        var attempts = 0
         do {
+            check(attempts++ < MAX_ID_SEARCH_ATTEMPTS) {
+                "Playlist id space exhausted: no available id found after $MAX_ID_SEARCH_ATTEMPTS attempts"
+            }
             id = idCounter.getAndIncrement()
+            check(id > 0) {
+                "Playlist id space exhausted: the id counter overflowed Int.MAX_VALUE"
+            }
         } while (contains(id))
         return id
     }
 
     override fun add(entity: P): Boolean {
         checkOpen()
+        checkSubscribed()
         require(findByName(entity.name).isEmpty || findByName(entity.name).get().id == entity.id) {
             "Playlist with name '${entity.name}' already exists"
         }
@@ -153,6 +226,7 @@ abstract class PlaylistHierarchyBase<I : ReactiveAudioItem<I>, P : ReactiveAudio
 
     override fun remove(entity: P): Boolean {
         checkOpen()
+        checkSubscribed()
         return repository.remove(entity).also { removed ->
             if (removed) {
                 cancelPlaylistMutationSubscription(entity.id)
@@ -184,6 +258,7 @@ abstract class PlaylistHierarchyBase<I : ReactiveAudioItem<I>, P : ReactiveAudio
 
     override fun removeAll(entities: Collection<P>): Boolean {
         checkOpen()
+        checkSubscribed()
         // Materialize before removal: aggregate proxies resolve lazily from the registry,
         // so iterating them after repository.removeAll() would throw NoSuchElementException.
         val materialized = entities.toList()
@@ -218,6 +293,7 @@ abstract class PlaylistHierarchyBase<I : ReactiveAudioItem<I>, P : ReactiveAudio
 
     override fun movePlaylist(playlistNameToMove: String, destinationPlaylistName: String) {
         checkOpen()
+        checkSubscribed()
         val playlistToMove = findByName(playlistNameToMove)
         val destinationPlaylist = findByName(destinationPlaylistName)
 
@@ -244,29 +320,36 @@ abstract class PlaylistHierarchyBase<I : ReactiveAudioItem<I>, P : ReactiveAudio
         return candidate in children || children.any { isDescendant(it, candidate) }
     }
 
-    override fun addAudioItemsToPlaylist(audioItems: Collection<I>, playlistName: String): Boolean =
-        findByName(playlistName).let {
+    override fun addAudioItemsToPlaylist(audioItems: Collection<I>, playlistName: String): Boolean {
+        checkSubscribed()
+        return findByName(playlistName).let {
             require(it.isPresent) { "Playlist '$playlistName' does not exist" }
             it.get().addAudioItems(audioItems)
         }
+    }
 
-    override fun removeAudioItemsFromPlaylist(audioItems: Collection<I>, playlistName: String): Boolean =
-        findByName(playlistName).let {
+    override fun removeAudioItemsFromPlaylist(audioItems: Collection<I>, playlistName: String): Boolean {
+        checkSubscribed()
+        return findByName(playlistName).let {
             require(it.isPresent) { "Playlist '$playlistName' does not exist" }
             it.get().removeAudioItems(audioItems)
         }
+    }
 
     // @JvmName required on generic interface methods to avoid JVM signature clashes with Java callers
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("removeAudioItemIdsFromPlaylist")
-    override fun removeAudioItemsFromPlaylist(audioItemIds: Collection<Int>, playlistName: String): Boolean =
-        findByName(playlistName).let {
+    override fun removeAudioItemsFromPlaylist(audioItemIds: Collection<Int>, playlistName: String): Boolean {
+        checkSubscribed()
+        return findByName(playlistName).let {
             require(it.isPresent) { "Playlist '$playlistName' does not exist" }
             it.get().removeAudioItems(audioItemIds)
         }
+    }
 
-    override fun addPlaylistsToDirectory(playlistsToAdd: Set<P>, directoryName: String): Boolean =
-        findByName(directoryName).let {
+    override fun addPlaylistsToDirectory(playlistsToAdd: Set<P>, directoryName: String): Boolean {
+        checkSubscribed()
+        return findByName(directoryName).let {
             require(it.isPresent) { "Directory '$directoryName' does not exist" }
             require(it.get().isDirectory) { "Playlist '$directoryName' is not a directory" }
             it.get().addPlaylists(playlistsToAdd).also { added ->
@@ -275,11 +358,13 @@ abstract class PlaylistHierarchyBase<I : ReactiveAudioItem<I>, P : ReactiveAudio
                 }
             }
         }
+    }
 
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("addPlaylistNamesToDirectory")
-    override fun addPlaylistsToDirectory(playlistNamesToAdd: Set<String>, directoryName: String): Boolean =
-        findByName(directoryName).let {
+    override fun addPlaylistsToDirectory(playlistNamesToAdd: Set<String>, directoryName: String): Boolean {
+        checkSubscribed()
+        return findByName(directoryName).let {
             require(it.isPresent) { "Directory '$directoryName' does not exist" }
             require(it.get().isDirectory) { "Playlist '$directoryName' is not a directory" }
             playlistNamesToAdd.stream().map { playlistName ->
@@ -293,8 +378,10 @@ abstract class PlaylistHierarchyBase<I : ReactiveAudioItem<I>, P : ReactiveAudio
                 }
             }
         }
+    }
 
     override fun removePlaylistsFromDirectory(playlistsToRemove: Set<P>, directoryName: String): Boolean {
+        checkSubscribed()
         val directory = findByName(directoryName)
         require(directory.isPresent) { "Directory '$directoryName' does not exist" }
         val actualChildren =
@@ -314,6 +401,7 @@ abstract class PlaylistHierarchyBase<I : ReactiveAudioItem<I>, P : ReactiveAudio
     @Suppress("INAPPLICABLE_JVM_NAME")
     @JvmName("removePlaylistNamesFromDirectory")
     override fun removePlaylistsFromDirectory(playlistsNamesToRemove: Set<String>, directoryName: String): Boolean {
+        checkSubscribed()
         val directory = findByName(directoryName)
         require(directory.isPresent) { "Directory '$directoryName' does not exist" }
         val resolved =

--- a/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/CoreMusicLibraryBuilderInstanceNameTest.kt
+++ b/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/CoreMusicLibraryBuilderInstanceNameTest.kt
@@ -1,0 +1,49 @@
+package net.transgressoft.commons.music
+
+import net.transgressoft.commons.music.testing.registryIsolation
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldNotBeBlank
+
+@DisplayName("CoreMusicLibrary.Builder instanceName")
+internal class CoreMusicLibraryBuilderInstanceNameTest : StringSpec({
+
+    registryIsolation()
+
+    "CoreMusicLibrary.Builder instanceName returns the explicitly set name verbatim" {
+        val library = CoreMusicLibrary.builder().instanceName("my-library").build()
+        try {
+            library.instanceName shouldBe "my-library"
+        } finally {
+            library.close()
+        }
+    }
+
+    "CoreMusicLibrary.Builder instanceName yields a non-blank auto-generated default when not set" {
+        val library = CoreMusicLibrary.builder().build()
+        try {
+            library.instanceName.shouldNotBeBlank()
+        } finally {
+            library.close()
+        }
+    }
+
+    "CoreMusicLibrary.Builder instanceName generates distinct defaults for two libraries built without explicit name" {
+        val first = CoreMusicLibrary.builder().build()
+        first.close()
+        val second = CoreMusicLibrary.builder().build()
+        try {
+            first.instanceName shouldNotBe second.instanceName
+        } finally {
+            second.close()
+        }
+    }
+
+    "CoreMusicLibrary.Builder instanceName rejects a blank name" {
+        shouldThrow<IllegalArgumentException> { CoreMusicLibrary.builder().instanceName("") }
+        shouldThrow<IllegalArgumentException> { CoreMusicLibrary.builder().instanceName("   ") }
+    }
+})

--- a/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/audio/AudioLibraryBaseHardeningTest.kt
+++ b/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/audio/AudioLibraryBaseHardeningTest.kt
@@ -1,0 +1,158 @@
+/******************************************************************************
+ * Copyright (C) 2026  Octavio Calleya Garcia                                 *
+ *                                                                            *
+ * This program is free software: you can redistribute it and/or modify       *
+ * it under the terms of the GNU General Public License as published by       *
+ * the Free Software Foundation, either version 3 of the License, or          *
+ * (at your option) any later version.                                        *
+ *                                                                            *
+ * This program is distributed in the hope that it will be useful,            *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
+ * GNU General Public License for more details.                               *
+ *                                                                            *
+ * You should have received a copy of the GNU General Public License          *
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.     *
+ ******************************************************************************/
+
+package net.transgressoft.commons.music.audio
+
+import net.transgressoft.commons.music.CoreMusicLibrary
+import net.transgressoft.commons.music.playlist.DefaultPlaylistHierarchy
+import net.transgressoft.commons.music.testing.reactiveScope
+import net.transgressoft.commons.music.testing.registryIsolation
+import net.transgressoft.lirp.persistence.VolatileRepository
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.next
+import java.lang.ref.SoftReference
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+
+/**
+ * Regression tests pinning the Wave-1 fixes to [AudioLibraryBase] and its collaborators:
+ * bounded [AudioLibraryBase.newId] (#16), noCover reset after SoftReference eviction (#17),
+ * foreign-origin metadata re-wire (#7), UNASSIGNED_ID rejection in createPlaylist (#14),
+ * and the unsubscribed-hierarchy first-use guard (#5).
+ */
+@DisplayName("AudioLibraryBase hardening — regression tests for Wave-1 fixes")
+@ExperimentalCoroutinesApi
+internal class AudioLibraryBaseHardeningTest : StringSpec({
+
+    registryIsolation()
+    val reactive = reactiveScope()
+    val files = virtualFiles()
+
+    "#16 newId() throws IllegalStateException when the id space is saturated" {
+        val saturated =
+            object : VolatileRepository<Int, AudioItem>("SaturatedRepository") {
+                override fun contains(id: Int): Boolean = true
+            }
+        val library = TestAudioLibrary(saturated, files.metadataIO)
+        try {
+            val audioFile = files.virtualAudioFile().next()
+            val ex = shouldThrow<IllegalStateException> { library.createFromFile(audioFile) }
+            ex.message.shouldNotBeNull()
+            ex.message!!.contains("exhausted") shouldBe true
+        } finally {
+            library.close()
+        }
+    }
+
+    "#17 album coverImageBytes reloads after SoftReference eviction (noCover is not permanent)" {
+        val albumDetails = Arb.album().next()
+        val expectedCover = byteArrayOf(1, 2, 3, 4, 5)
+        val track =
+            Arb.audioItem {
+                this.album = albumDetails
+                coverImageBytes = expectedCover
+            }.next()
+        val album = ImmutableAlbum(albumDetails, listOf(track))
+
+        // First access loads and caches the cover
+        album.coverImageBytes shouldBe expectedCover
+
+        // Simulate GC eviction: replace the live SoftReference with one whose referent is null
+        val coverRefField = ImmutableAlbum::class.java.getDeclaredField("coverRef")
+        coverRefField.isAccessible = true
+        coverRefField.set(album, SoftReference(null as ByteArray?))
+
+        // After simulated eviction, coverImageBytes must reload (not return null permanently)
+        album.coverImageBytes shouldBe expectedCover
+    }
+
+    "#7 adding a foreign-origin item re-wires its metadataIO to the target library" {
+        val sourceMetadataIO = files.metadataIO
+        val targetMetadataIO = JAudioTaggerMetadataIO()
+
+        // Phase 1: create an item in library1 so its metadataIO is sourceMetadataIO
+        val audioFile = files.virtualAudioFile().next()
+        val item =
+            DefaultAudioLibrary(VolatileRepository("Hardening-L1"), sourceMetadataIO).use { library1 ->
+                library1.createFromFile(audioFile) as MutableAudioItem
+            }
+        item.metadataIO shouldBe sourceMetadataIO
+
+        // Phase 2: add the foreign item to library2 (different metadataIO) — it must be re-wired
+        DefaultAudioLibrary(VolatileRepository("Hardening-L2"), targetMetadataIO).use { library2 ->
+            library2.add(item)
+            reactive.advance()
+            item.metadataIO shouldBe targetMetadataIO
+        }
+    }
+
+    "#14 createPlaylist with UNASSIGNED_ID in the item list throws IllegalArgumentException" {
+        val library =
+            CoreMusicLibrary.builder()
+                .audioRepository(VolatileRepository("Hardening-UNASSIGNED"))
+                .metadataIO(files.metadataIO)
+                .build()
+        try {
+            shouldThrow<IllegalArgumentException> {
+                library.createPlaylist("BadPlaylist", listOf(UNASSIGNED_ID))
+            }
+        } finally {
+            library.close()
+        }
+    }
+
+    "#5 standalone hierarchy fails fast on first mutating call (must be wired via builder)" {
+        val hierarchy = DefaultPlaylistHierarchy()
+        try {
+            shouldThrow<IllegalStateException> {
+                hierarchy.createPlaylist("StandalonePlaylist")
+            }
+        } finally {
+            hierarchy.close()
+        }
+    }
+
+    "#5 builder-wired hierarchy removes audio items from playlists when the item is deleted" {
+        val library =
+            CoreMusicLibrary.builder()
+                .audioRepository(VolatileRepository("Hardening-Delete"))
+                .metadataIO(files.metadataIO)
+                .build()
+        try {
+            val audioFile = files.virtualAudioFile().next()
+            val item = library.audioItemFromFile(audioFile)
+            reactive.advance()
+
+            val playlist = library.createPlaylist("TestPlaylist", listOf(item))
+            reactive.advance()
+            playlist.audioItems.toList() shouldNotBe emptyList<Any>()
+
+            library.audioLibrary().remove(item)
+            reactive.advance()
+
+            playlist.audioItems.toList().shouldBeEmpty()
+        } finally {
+            library.close()
+        }
+    }
+})

--- a/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/audio/CrossLibraryMatrixTest.kt
+++ b/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/audio/CrossLibraryMatrixTest.kt
@@ -1,0 +1,222 @@
+/******************************************************************************
+ * Copyright (C) 2026  Octavio Calleya Garcia                                 *
+ *                                                                            *
+ * This program is free software: you can redistribute it and/or modify       *
+ * it under the terms of the GNU General Public License as published by       *
+ * the Free Software Foundation, either version 3 of the License, or          *
+ * (at your option) any later version.                                        *
+ *                                                                            *
+ * This program is distributed in the hope that it will be useful,            *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
+ * GNU General Public License for more details.                               *
+ *                                                                            *
+ * You should have received a copy of the GNU General Public License          *
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.     *
+ ******************************************************************************/
+
+package net.transgressoft.commons.music.audio
+
+import net.transgressoft.commons.media.persistence.waveform.AudioWaveformMapSerializer
+import net.transgressoft.commons.music.CoreMusicLibrary
+import net.transgressoft.commons.music.shouldReferenceItemId
+import net.transgressoft.commons.music.testing.buildTwoCoreLibrariesWithoutClosing
+import net.transgressoft.commons.music.testing.reactiveScope
+import net.transgressoft.commons.music.testing.registryIsolation
+import net.transgressoft.commons.persistence.music.audio.AudioItemMapSerializer
+import net.transgressoft.commons.persistence.music.playlist.AudioPlaylistMapSerializer
+import net.transgressoft.lirp.persistence.json.JsonFileRepository
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.engine.spec.tempfile
+import io.kotest.matchers.optional.shouldBePresent
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.property.arbitrary.next
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.asExecutor
+
+/**
+ * Exercises the cross-library operation matrix under the single-live-instance contract (Option B):
+ * two libraries are never live simultaneously; "cross-library" means foreign-object insertion or
+ * sequential lifecycle, not two concurrent live instances.
+ *
+ * The three axes covered are:
+ *
+ * - **Baseline row:** constructing a second live library while one is still live throws
+ *   [IllegalStateException], both via direct construction and via loading a JSON repository
+ *   into a new library while the first is alive.
+ * - **Foreign-object axis:** an entity created by library A, held after A is closed, is re-homed
+ *   into library B on [AudioLibrary.add], triggering the WARN + re-wire behavior and making B's
+ *   catalog reflect the item.
+ * - **Sequential-lifecycle axis:** building A, populating audio items, a playlist, and a waveform,
+ *   closing A, then building B against the same backing repositories yields the same entity ids and
+ *   the same playlist and waveform associations — no silent corruption.
+ */
+@DisplayName("CrossLibraryMatrixTest")
+@ExperimentalCoroutinesApi
+internal class CrossLibraryMatrixTest : StringSpec({
+
+    registryIsolation()
+    val reactive = reactiveScope()
+    val files = virtualFiles()
+
+    // --- Baseline row ---
+
+    "CoreMusicLibrary baseline — second live construction throws IllegalStateException" {
+        val libraries = buildTwoCoreLibrariesWithoutClosing(files.metadataIO)
+        try {
+            shouldThrow<IllegalStateException> {
+                libraries.attemptSecondConstruction()
+            }
+        } finally {
+            libraries.close()
+        }
+    }
+
+    "CoreMusicLibrary baseline — loading the same JSON repository while library A is live throws IllegalStateException" {
+        val audioFile = tempfile("crossLibrary-baseline-audio", ".json").also { it.deleteOnExit() }
+        val playlistsFile = tempfile("crossLibrary-baseline-playlists", ".json").also { it.deleteOnExit() }
+        val waveformsFile = tempfile("crossLibrary-baseline-waveforms", ".json").also { it.deleteOnExit() }
+
+        val libraryA =
+            CoreMusicLibrary.builder()
+                .metadataIO(files.metadataIO)
+                .audioRepository(JsonFileRepository(audioFile, AudioItemMapSerializer))
+                .playlistRepository(JsonFileRepository(playlistsFile, AudioPlaylistMapSerializer))
+                .waveformRepository(JsonFileRepository(waveformsFile, AudioWaveformMapSerializer))
+                .build()
+
+        try {
+            shouldThrow<IllegalStateException> {
+                // A second live library — even wired to the same files — must be rejected because the
+                // registry slot is already occupied by libraryA.
+                CoreMusicLibrary.builder()
+                    .metadataIO(files.metadataIO)
+                    .audioRepository(JsonFileRepository(audioFile, AudioItemMapSerializer))
+                    .playlistRepository(JsonFileRepository(playlistsFile, AudioPlaylistMapSerializer))
+                    .waveformRepository(JsonFileRepository(waveformsFile, AudioWaveformMapSerializer))
+                    .build()
+            }
+        } finally {
+            libraryA.close()
+        }
+    }
+
+    // --- Foreign-object axis ---
+
+    "CoreMusicLibrary foreign-object — item created in A is re-homed into B after A is closed" {
+        val libraryA = CoreMusicLibrary.builder().metadataIO(files.metadataIO).build()
+        val itemA: AudioItem = libraryA.audioItemFromFile(files.virtualAudioFile().next())
+        reactive.advance()
+
+        // Close A; item object reference is retained.
+        val originalUniqueId = itemA.uniqueId
+        libraryA.close()
+
+        // Build B against a fresh (volatile) repository — sequential, not concurrent with A.
+        val libraryB = CoreMusicLibrary.builder().metadataIO(files.metadataIO).build()
+        try {
+            // Adding A-origin item to B must re-wire the item's metadata IO to B's without error.
+            libraryB.audioLibrary().add(itemA)
+            reactive.advance()
+
+            // The uniqueId is stable across the re-home — same physical track, same identity key.
+            libraryB.audioLibrary().findByUniqueId(originalUniqueId).shouldBePresent { found ->
+                found.uniqueId shouldBe originalUniqueId
+            }
+
+            // B's library contains exactly the one re-homed item.
+            libraryB.audioLibrary().size() shouldBe 1
+        } finally {
+            libraryB.close()
+        }
+    }
+
+    // --- Sequential-lifecycle axis ---
+
+    "CoreMusicLibrary sequential-lifecycle — items, playlist, and waveform round-trip through close-reopen with identity contract" {
+        val audioFile = tempfile("crossLibrary-seq-audio", ".json").also { it.deleteOnExit() }
+        val playlistsFile = tempfile("crossLibrary-seq-playlists", ".json").also { it.deleteOnExit() }
+        val waveformsFile = tempfile("crossLibrary-seq-waveforms", ".json").also { it.deleteOnExit() }
+
+        // Build A and populate it.
+        val libraryA =
+            CoreMusicLibrary.builder()
+                .metadataIO(files.metadataIO)
+                .audioRepository(JsonFileRepository(audioFile, AudioItemMapSerializer))
+                .playlistRepository(JsonFileRepository(playlistsFile, AudioPlaylistMapSerializer))
+                .waveformRepository(JsonFileRepository(waveformsFile, AudioWaveformMapSerializer))
+                .build()
+
+        val item1 = libraryA.audioItemFromFile(files.virtualAudioFile().next())
+        val item2 = libraryA.audioItemFromFile(files.virtualAudioFile().next())
+        reactive.advance()
+
+        val playlist = libraryA.createPlaylist("Sequential Playlist")
+        playlist.addAudioItem(item1)
+        reactive.advance()
+
+        val waveform = libraryA.waveformRepository().getOrCreateWaveformAsync(item1, 780, 335, reactive.dispatcher.asExecutor())
+        reactive.advance()
+        val waveformId = waveform.get().id
+        val waveformAudioFilePath = item1.path.fileName.toString()
+
+        // Capture identity before close.
+        val item1Id = item1.id
+        val item2Id = item2.id
+        val item1UniqueId = item1.uniqueId
+        val item2UniqueId = item2.uniqueId
+        val playlistId = playlist.id
+
+        libraryA.close()
+
+        // Build B against the same backing stores — sequential construction is permitted.
+        val libraryB =
+            CoreMusicLibrary.builder()
+                .metadataIO(files.metadataIO)
+                .audioRepository(JsonFileRepository(audioFile, AudioItemMapSerializer))
+                .playlistRepository(JsonFileRepository(playlistsFile, AudioPlaylistMapSerializer))
+                .waveformRepository(JsonFileRepository(waveformsFile, AudioWaveformMapSerializer))
+                .build()
+        reactive.advance()
+
+        try {
+            // Items resolve with the same ids and stable uniqueIds.
+            // The path changes from jimfs to the default filesystem on deserialization, but the
+            // physical-identity key (fileName-duration-bitRate) remains the same because only the
+            // path segment names (title, artist, album) participate, not the filesystem URI scheme.
+            libraryB.audioLibrary().findById(item1Id).shouldBePresent { loaded ->
+                loaded.id shouldBe item1Id
+                loaded.uniqueId shouldBe item1UniqueId
+            }
+            libraryB.audioLibrary().findById(item2Id).shouldBePresent { loaded ->
+                loaded.id shouldBe item2Id
+                loaded.uniqueId shouldBe item2UniqueId
+            }
+
+            // Items do NOT resolve to the wrong entity (no cross-resolution corruption).
+            libraryB.audioLibrary().findById(item1Id).shouldBePresent { it.uniqueId shouldNotBe item2UniqueId }
+            libraryB.audioLibrary().findById(item2Id).shouldBePresent { it.uniqueId shouldNotBe item1UniqueId }
+
+            // Playlist round-trips with same id and still references item1 by id.
+            libraryB.playlistHierarchy().findByName("Sequential Playlist").shouldBePresent { restoredPlaylist ->
+                restoredPlaylist.id shouldBe playlistId
+                // Verify the playlist still holds a reference to item1's id without materializing
+                // the item (the path changes from jimfs to default fs on deserialization).
+                restoredPlaylist shouldReferenceItemId item1Id
+            }
+
+            // Waveform round-trips with the same id and its audio-file association is preserved.
+            libraryB.waveformRepository().findById(waveformId).shouldBePresent { restoredWaveform ->
+                restoredWaveform.id shouldBe waveformId
+                // The waveform links back to the audio file by its path's filename — stable across
+                // the jimfs-to-default-filesystem deserialization boundary.
+                restoredWaveform.audioFilePath.fileName.toString() shouldBe waveformAudioFilePath
+            }
+        } finally {
+            libraryB.close()
+        }
+    }
+})

--- a/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/audio/DegenerateInputSweepTest.kt
+++ b/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/audio/DegenerateInputSweepTest.kt
@@ -1,0 +1,132 @@
+/******************************************************************************
+ * Copyright (C) 2026  Octavio Calleya Garcia                                 *
+ *                                                                            *
+ * This program is free software: you can redistribute it and/or modify       *
+ * it under the terms of the GNU General Public License as published by       *
+ * the Free Software Foundation, either version 3 of the License, or          *
+ * (at your option) any later version.                                        *
+ *                                                                            *
+ * This program is distributed in the hope that it will be useful,            *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
+ * GNU General Public License for more details.                               *
+ *                                                                            *
+ * You should have received a copy of the GNU General Public License          *
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.     *
+ ******************************************************************************/
+
+package net.transgressoft.commons.music.audio
+
+import net.transgressoft.commons.music.CoreMusicLibrary
+import net.transgressoft.commons.music.testing.reactiveScope
+import net.transgressoft.commons.music.testing.registryIsolation
+import net.transgressoft.lirp.persistence.VolatileRepository
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.property.arbitrary.next
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+
+/**
+ * Documents the expected outcome for every degenerate or boundary input to the audio library and
+ * playlist hierarchy: each row ends with either a clean return value or a documented exception.
+ * None of these inputs should cause silent corruption or an infinite loop.
+ */
+@DisplayName("Degenerate/empty-input sweep — each input produces a documented outcome")
+@ExperimentalCoroutinesApi
+internal class DegenerateInputSweepTest : StringSpec({
+
+    registryIsolation()
+    val reactive = reactiveScope()
+    val files = virtualFiles()
+
+    "Empty library returns empty collections for all query methods" {
+        val library = TestAudioLibrary(VolatileRepository("DegenerateInputSweepTest-empty"), files.metadataIO)
+        try {
+            library.size() shouldBe 0
+            library.isEmpty shouldBe true
+            library.search { true }.shouldBeEmpty()
+            library.containsAudioItemWithArtist("any-artist") shouldBe false
+            library.containsAudioItemWithAlbum("any-album") shouldBe false
+            library.containsAudioItemWithGenre("any-genre") shouldBe false
+        } finally {
+            library.close()
+        }
+    }
+
+    "Empty playlist is created and queried without error and returns an empty item list" {
+        val hierarchy = net.transgressoft.commons.music.playlist.TestPlaylistHierarchy()
+        try {
+            val playlist = hierarchy.createPlaylist("EmptyPlaylist")
+            playlist.name shouldBe "EmptyPlaylist"
+            playlist.audioItems.toList().shouldBeEmpty()
+            hierarchy.findByName("EmptyPlaylist").isPresent shouldBe true
+        } finally {
+            hierarchy.close()
+        }
+    }
+
+    "Duplicate file path: adding the same physical file twice returns the existing item (idempotent add)" {
+        val library =
+            CoreMusicLibrary.builder()
+                .audioRepository(VolatileRepository("DegenerateInputSweepTest-duplicate"))
+                .metadataIO(files.metadataIO)
+                .build()
+        try {
+            val audioFile = files.virtualAudioFile().next()
+            val first = library.audioItemFromFile(audioFile)
+            reactive.advance()
+
+            val second = library.audioItemFromFile(audioFile)
+            reactive.advance()
+
+            // Physical identity: same file → same uniqueId → idempotent add
+            second.id shouldBe first.id
+            second.uniqueId shouldBe first.uniqueId
+            library.audioLibrary().size() shouldBe 1
+        } finally {
+            library.close()
+        }
+    }
+
+    "No-genre item is added and projected without error; genre index handles absent genre" {
+        val library = TestAudioLibrary(VolatileRepository("DegenerateInputSweepTest-noGenre"), files.metadataIO)
+        try {
+            val audioFile =
+                files.virtualAudioFile {
+                    genres = emptySet()
+                }.next()
+
+            val item = library.createFromFile(audioFile)
+            reactive.advance()
+
+            item.genres.shouldBeEmpty()
+            library.size() shouldBe 1
+            // Genre index must handle the item without a genre — no-genre items are queryable
+            library.containsAudioItemWithGenre("") shouldBe true
+        } finally {
+            library.close()
+        }
+    }
+
+    "Int.MAX_VALUE ID-space boundary: exhausted id space causes newId() to throw IllegalStateException" {
+        // A repository whose contains(id) always returns true simulates a saturated id space.
+        // AudioLibraryBase.newId() retries up to MAX_ID_ALLOCATION_ATTEMPTS and then throws.
+        val saturated =
+            object : VolatileRepository<Int, AudioItem>("SaturatedRepository") {
+                override fun contains(id: Int): Boolean = true
+            }
+        val library = TestAudioLibrary(saturated, files.metadataIO)
+        try {
+            val audioFile = files.virtualAudioFile().next()
+            val ex = shouldThrow<IllegalStateException> { library.createFromFile(audioFile) }
+            ex.message shouldNotBe null
+            ex.message!!.contains("exhausted") shouldBe true
+        } finally {
+            library.close()
+        }
+    }
+})

--- a/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/audio/PublicSerializerSmokeTest.kt
+++ b/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/audio/PublicSerializerSmokeTest.kt
@@ -18,8 +18,9 @@
 package net.transgressoft.commons.music.audio
 
 import net.transgressoft.commons.media.persistence.waveform.AudioWaveformMapSerializer
-import net.transgressoft.commons.music.playlist.DefaultPlaylistHierarchy
+import net.transgressoft.commons.music.CoreMusicLibrary
 import net.transgressoft.commons.music.playlist.MutableAudioPlaylist
+import net.transgressoft.commons.music.testing.registryIsolation
 import net.transgressoft.commons.music.waveform.AudioWaveform
 import net.transgressoft.commons.persistence.music.audio.AudioItemMapSerializer
 import net.transgressoft.commons.persistence.music.playlist.AudioPlaylistMapSerializer
@@ -37,6 +38,8 @@ import kotlinx.serialization.json.Json
  */
 @DisplayName("Public serializer symbols")
 internal class PublicSerializerSmokeTest : StringSpec({
+
+    registryIsolation()
 
     val json = Json { }
 
@@ -68,8 +71,8 @@ internal class PublicSerializerSmokeTest : StringSpec({
     }
 
     "AudioPlaylistMapSerializer round-trips a single playlist" {
-        val hierarchy = DefaultPlaylistHierarchy()
-        val playlist = hierarchy.createPlaylist("Smoke")
+        val library = CoreMusicLibrary.builder().build()
+        val playlist = library.createPlaylist("Smoke")
         val map: Map<Int, MutableAudioPlaylist> = mapOf(playlist.id to playlist)
 
         val encoded = json.encodeToString(AudioPlaylistMapSerializer, map)
@@ -78,6 +81,6 @@ internal class PublicSerializerSmokeTest : StringSpec({
         decoded shouldHaveSize 1
         decoded[playlist.id]?.name shouldBe "Smoke"
 
-        hierarchy.close()
+        library.close()
     }
 })

--- a/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/event/SubscriberIsolationTest.kt
+++ b/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/event/SubscriberIsolationTest.kt
@@ -1,0 +1,98 @@
+/******************************************************************************
+ * Copyright (C) 2026  Octavio Calleya Garcia                                 *
+ *                                                                            *
+ * This program is free software: you can redistribute it and/or modify       *
+ * it under the terms of the GNU General Public License as published by       *
+ * the Free Software Foundation, either version 3 of the License, or          *
+ * (at your option) any later version.                                        *
+ *                                                                            *
+ * This program is distributed in the hope that it will be useful,            *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
+ * GNU General Public License for more details.                               *
+ *                                                                            *
+ * You should have received a copy of the GNU General Public License          *
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.     *
+ ******************************************************************************/
+
+package net.transgressoft.commons.music.event
+
+import net.transgressoft.commons.music.audio.AudioItem
+import net.transgressoft.commons.music.testing.reactiveScope
+import net.transgressoft.lirp.event.CrudEvent
+import net.transgressoft.lirp.event.CrudEvent.Type.CREATE
+import net.transgressoft.lirp.event.FlowEventPublisher
+import net.transgressoft.lirp.event.StandardCrudEvent
+import io.kotest.assertions.nondeterministic.eventually
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+
+/**
+ * Confirming test that a throwing subscriber does not cancel peer subscribers on either the sync
+ * or the async event transport provided by [FlowEventPublisher].
+ *
+ * On the **sync transport**, [FlowEventPublisher] wraps each callback invocation in a try/catch, so
+ * an exception thrown by one callback is logged and swallowed without stopping delivery to the
+ * remaining callbacks in the same dispatch cycle.
+ *
+ * On the **async transport**, each subscriber runs in its own coroutine launched on
+ * [net.transgressoft.lirp.event.ReactiveScope.flowScope], which is backed by a [SupervisorJob].
+ * A cancellation-free exception in one coroutine's collect block is caught and logged; it does not
+ * propagate to the shared job hierarchy and therefore cannot cancel sibling subscriber coroutines.
+ *
+ * These tests confirm the isolation property rather than add new containment — it is a lirp
+ * invariant and no mc-side wrapper is needed.
+ */
+@DisplayName("SubscriberIsolationTest")
+@ExperimentalCoroutinesApi
+internal class SubscriberIsolationTest : StringSpec({
+
+    val reactive = reactiveScope(failOnUncaughtExceptions = false)
+
+    "sync subscriber — throwing callback does not prevent peer subscriber from receiving the event" {
+        val publisher = FlowEventPublisher<CrudEvent.Type, CrudEvent<Int, AudioItem>>("IsolationSync")
+        publisher.activateEvents(CREATE)
+
+        val peerCount = AtomicInteger(0)
+
+        // Subscriber that always throws on event delivery.
+        publisher.subscribe { throw RuntimeException("Deliberate sync failure") }
+
+        // Peer subscriber that counts received events — must not be affected by the throwing sibling.
+        publisher.subscribe { peerCount.incrementAndGet() }
+
+        val entity = mockk<AudioItem>(relaxed = true) { every { id } returns 1 }
+        publisher.emitAsync(StandardCrudEvent.Create(entity))
+        reactive.advance()
+
+        peerCount.get() shouldBe 1
+    }
+
+    "async subscriber — throwing action does not cancel peer subscriber coroutine" {
+        val publisher = FlowEventPublisher<CrudEvent.Type, CrudEvent<Int, AudioItem>>("IsolationAsync")
+        publisher.activateEvents(CREATE)
+
+        val peerCount = AtomicInteger(0)
+
+        // Async subscriber that always throws on event delivery.
+        publisher.subscribeAsync { throw RuntimeException("Deliberate async failure") }
+
+        // Peer async subscriber that counts received events — the SupervisorJob on ReactiveScope.flowScope
+        // ensures a sibling failure does not cancel this coroutine.
+        publisher.subscribeAsync { peerCount.incrementAndGet() }
+
+        val entity = mockk<AudioItem>(relaxed = true) { every { id } returns 1 }
+        publisher.emitAsync(StandardCrudEvent.Create(entity))
+        reactive.advance()
+
+        eventually(2.seconds) {
+            peerCount.get() shouldBe 1
+        }
+    }
+})

--- a/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/itunes/ConcurrentImportStressTest.kt
+++ b/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/itunes/ConcurrentImportStressTest.kt
@@ -1,0 +1,191 @@
+package net.transgressoft.commons.music.itunes
+
+import net.transgressoft.commons.music.CoreMusicLibrary
+import net.transgressoft.commons.music.audio.AudioItem
+import net.transgressoft.commons.music.audio.AudioItemMetadata
+import net.transgressoft.commons.music.audio.VolatileAudioMetadataIO
+import net.transgressoft.commons.music.audio.virtualFiles
+import net.transgressoft.commons.music.m3u.M3uImportService
+import net.transgressoft.commons.music.playlist.MutableAudioPlaylist
+import net.transgressoft.commons.music.testing.registryIsolation
+import io.kotest.assertions.nondeterministic.eventually
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.annotation.Tags
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import java.lang.ref.WeakReference
+import java.nio.file.FileSystem
+import java.nio.file.Files
+import java.util.concurrent.CompletableFuture
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Stress test for concurrent iTunes and M3U imports into a single live library over a large
+ * virtual-file corpus (jimfs). Runs outside the deterministic default suite and is opt-in
+ * via `-PincludeStress=true`.
+ *
+ * Asserts repository-consistency invariants (no lost or duplicate writes) and verifies that
+ * no coroutine scopes or library references leak after both imports complete and the library
+ * is closed. Timing is never asserted.
+ */
+@Tags("stress")
+@DisplayName("ConcurrentImportStressTest")
+internal class ConcurrentImportStressTest : StringSpec({
+
+    registryIsolation()
+
+    val files = virtualFiles()
+
+    // Corpus constants. The two corpora must be disjoint in uniqueId space, not just in path:
+    // uniqueId is derived from the file name (plus duration and bit rate), so distinct parent
+    // directories are not enough. Each corpus uses its own file-name prefix ("itunes-"/"m3u-")
+    // so no item is deduplicated on add and the expected repository size stays the full sum —
+    // making this a clean "no lost or duplicate writes under concurrency" invariant.
+    val itunesItemCount = 5_000
+    val m3uItemCount = 5_000
+
+    "ConcurrentImportStressTest imports iTunes and M3U concurrently into one library with no lost or duplicate writes and no leaked references" {
+        var lib: CoreMusicLibrary? =
+            CoreMusicLibrary
+                .builder()
+                .metadataIO(files.metadataIO)
+                .instanceName("stress-library")
+                .build()
+        var itunesService: ItunesImportService<AudioItem, MutableAudioPlaylist>? =
+            ItunesImportService(lib!!, files.metadataIO, files.fileSystem, "stress-library")
+        var m3uService: M3uImportService<AudioItem, MutableAudioPlaylist>? =
+            M3uImportService(lib!!, instanceName = "stress-library")
+
+        val itunesLibrary = buildItunesCorpus(itunesItemCount, files.fileSystem, files.metadataIO)
+        val m3uPath = buildM3uCorpus(m3uItemCount, files.fileSystem, files.metadataIO)
+
+        // Launch both imports concurrently on real IO threads — no reactiveScope, genuine race exposure.
+        val itunesPolicy = ItunesImportPolicy(useFileMetadata = true, holdPlayCount = false, writeMetadata = false)
+        val itunesFuture: CompletableFuture<ImportResult> =
+            itunesService!!.importAsync(itunesLibrary.playlists, itunesLibrary, itunesPolicy)
+        val m3uFuture: CompletableFuture<MutableAudioPlaylist> = m3uService!!.importAsync(m3uPath)
+        CompletableFuture.allOf(itunesFuture, m3uFuture).get()
+
+        val itunesResult = itunesFuture.get()
+        val totalExpected = itunesItemCount + m3uItemCount
+
+        // Invariant 1: all iTunes tracks imported without loss
+        itunesResult.unresolved shouldHaveSize 0
+        itunesResult.imported shouldHaveSize itunesItemCount
+
+        // Invariant 2: repository size matches the expected unique count
+        lib!!.audioLibrary().size() shouldBe totalExpected
+
+        // Invariant 3: no duplicate IDs in the repository
+        val allIds = lib!!.audioLibrary().search(totalExpected) { true }.map { it.id }
+        allIds.toSet().size shouldBe totalExpected
+
+        // Hold a WeakReference to the audio library component before closing.
+        val audioLibraryRef = WeakReference(lib!!.audioLibrary())
+
+        itunesService!!.close()
+        m3uService!!.close()
+        lib!!.close()
+
+        // Null all local strong references so GC can reclaim the closed audio library.
+        itunesService = null
+        m3uService = null
+        lib = null
+
+        // Invariant 4: no leaked audio library reference after close.
+        eventually(10.seconds) {
+            System.gc()
+            audioLibraryRef.get().shouldBeNull()
+        }
+    }
+})
+
+// -------------------------------------------------------------------------------------------------
+// Corpus builders — private helpers that create fully materialized virtual corpora in jimfs.
+// -------------------------------------------------------------------------------------------------
+
+/**
+ * Builds an [ItunesLibrary] backed by [count] virtual audio files in the `/corpus/itunes/`
+ * directory on [fileSystem]. Metadata is registered with [metadataIO] so the library can
+ * resolve each file via `audioItemFromFile`.
+ */
+private fun buildItunesCorpus(
+    count: Int,
+    fileSystem: FileSystem,
+    metadataIO: VolatileAudioMetadataIO
+): ItunesLibrary {
+    val tracks = mutableMapOf<Int, ItunesTrack>()
+    for (i in 1..count) {
+        val path = fileSystem.getPath("/corpus/itunes/itunes-track-${i.toString().padStart(6, '0')}.mp3")
+        Files.createDirectories(path.parent)
+        val metadata = AudioItemMetadata(title = "iTunes Track $i")
+        metadataIO.createVirtualFile(path, metadata)
+        val track =
+            ItunesTrack(
+                id = i,
+                title = "iTunes Track $i",
+                artist = "Artist ${i % 50}",
+                albumArtist = "Artist ${i % 50}",
+                album = "Album ${i % 200}",
+                genre = "Electronic",
+                year = 2024.toShort(),
+                trackNumber = (i % 20 + 1).toShort(),
+                discNumber = 1.toShort(),
+                totalTimeMs = 180_000L,
+                bitRate = 320,
+                playCount = 0,
+                rating = 0,
+                bpm = null,
+                comments = null,
+                location = path.toUri().toString(),
+                isCompilation = false,
+                persistentId = "STRESS-$i",
+                dateAdded = null
+            )
+        tracks[i] = track
+    }
+    val playlist =
+        ItunesPlaylist(
+            name = "Stress iTunes",
+            persistentId = "STRESS-PL",
+            parentPersistentId = null,
+            isFolder = false,
+            trackIds = tracks.keys.toList()
+        )
+    return ItunesLibrary(tracks, listOf(playlist))
+}
+
+/**
+ * Builds an M3U file at `/corpus/m3u/stress.m3u` on [fileSystem] referencing [count] virtual
+ * audio files under `/corpus/m3u/tracks/`. Metadata is registered with [metadataIO].
+ *
+ * @return the path to the generated M3U playlist file
+ */
+private fun buildM3uCorpus(
+    count: Int,
+    fileSystem: FileSystem,
+    metadataIO: VolatileAudioMetadataIO
+): java.nio.file.Path {
+    val tracksDir = fileSystem.getPath("/corpus/m3u/tracks")
+    Files.createDirectories(tracksDir)
+
+    val trackPaths = mutableListOf<String>()
+    for (i in 1..count) {
+        val path = tracksDir.resolve("m3u-track-${i.toString().padStart(6, '0')}.mp3")
+        val metadata = AudioItemMetadata(title = "M3U Track $i")
+        metadataIO.createVirtualFile(path, metadata)
+        trackPaths.add(path.toAbsolutePath().toString())
+    }
+
+    val m3uDir = fileSystem.getPath("/corpus/m3u")
+    val m3uPath = m3uDir.resolve("stress.m3u")
+    val content =
+        buildString {
+            appendLine("#EXTM3U")
+            trackPaths.forEach { p -> appendLine(p) }
+        }
+    Files.write(m3uPath, content.toByteArray(Charsets.UTF_8))
+    return m3uPath
+}

--- a/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/itunes/ItunesImportServiceTest.kt
+++ b/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/itunes/ItunesImportServiceTest.kt
@@ -562,7 +562,9 @@ internal class ItunesImportServiceTest : StringSpec({
         result.imported shouldHaveSize 3
         if (selectSubset) {
             result.unresolved.shouldBeEmpty()
-            musicLibrary.audioLibrary().size() shouldBe 3
+            // track1 and track3 share the same physical file (mp3File); D-07 dedup collapses
+            // them into a single item, so only 2 distinct items exist in the library.
+            musicLibrary.audioLibrary().size() shouldBe 2
         } else {
             result.rejectedPlaylistNames.shouldBeEmpty()
             musicLibrary.findPlaylistByName("Playlist A").isPresent shouldBe false

--- a/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/playlist/DefaultPlaylistHierarchyTest.kt
+++ b/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/playlist/DefaultPlaylistHierarchyTest.kt
@@ -9,6 +9,7 @@ import net.transgressoft.commons.persistence.music.playlist.AudioPlaylistMapSeri
 import net.transgressoft.commons.util.OsDetector
 import net.transgressoft.commons.util.WindowsPathException
 import net.transgressoft.lirp.persistence.RegistryBase
+import net.transgressoft.lirp.persistence.Repository
 import net.transgressoft.lirp.persistence.VolatileRepository
 import net.transgressoft.lirp.persistence.json.JsonFileRepository
 import io.kotest.assertions.assertSoftly
@@ -29,6 +30,14 @@ import io.mockk.every
 import java.time.Duration
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 
+/**
+ * Creates a [DefaultPlaylistHierarchy] backed by [repository] (or a fresh [VolatileRepository] if
+ * omitted) and marks the delete subscriber as wired so tests that exercise standalone hierarchy
+ * behavior — without a connected audio library — are not blocked by the first-use guard.
+ */
+private fun wiredHierarchy(repository: Repository<Int, MutableAudioPlaylist> = VolatileRepository()): DefaultPlaylistHierarchy =
+    DefaultPlaylistHierarchy(repository).also { it.markDeleteSubscriberWired() }
+
 @ExperimentalCoroutinesApi
 internal class DefaultPlaylistHierarchyTest : StringSpec({
 
@@ -44,7 +53,7 @@ internal class DefaultPlaylistHierarchyTest : StringSpec({
         RegistryBase.registerRepository(AudioItem::class.java, audioItemRepository)
 
         val jsonFile = tempfile("playlistRepository-test", ".json").apply { deleteOnExit() }
-        val playlistHierarchy = DefaultPlaylistHierarchy(JsonFileRepository(jsonFile, AudioPlaylistMapSerializer))
+        val playlistHierarchy = wiredHierarchy(JsonFileRepository(jsonFile, AudioPlaylistMapSerializer))
 
         val rockAudioItem = Arb.audioItem { title = "50s Rock hit 1" }.next().also { audioItemRepository.add(it) }
         val rockAudioItems = listOf(rockAudioItem)
@@ -87,7 +96,7 @@ internal class DefaultPlaylistHierarchyTest : StringSpec({
         val audioLibrary = DefaultAudioLibrary(audioLibraryRepository)
         audioLibrary.add(audioItem)
 
-        val playlistHierarchy = DefaultPlaylistHierarchy(JsonFileRepository(jsonFile, AudioPlaylistMapSerializer))
+        val playlistHierarchy = wiredHierarchy(JsonFileRepository(jsonFile, AudioPlaylistMapSerializer))
 
         reactive.advance()
 
@@ -125,7 +134,7 @@ internal class DefaultPlaylistHierarchyTest : StringSpec({
         RegistryBase.deregisterRepository(AudioItem::class.java)
         RegistryBase.registerRepository(AudioItem::class.java, audioItemRepository)
 
-        val playlistHierarchy = DefaultPlaylistHierarchy()
+        val playlistHierarchy = wiredHierarchy()
         val rockAudioItems =
             listOf(
                 Arb.audioItem {
@@ -227,7 +236,7 @@ internal class DefaultPlaylistHierarchyTest : StringSpec({
      └──Selection of playlists
      */
     "Moves playlists from/to playlist directories" {
-        val playlistHierarchy = DefaultPlaylistHierarchy()
+        val playlistHierarchy = wiredHierarchy()
 
         val rock = playlistHierarchy.createPlaylist("Rock")
         playlistHierarchy.findByName(rock.name) shouldBePresent { it shouldBe rock }
@@ -287,7 +296,7 @@ internal class DefaultPlaylistHierarchyTest : StringSpec({
     }
 
     "Removing playlist directory from it is recursive and changes reflects on playlists" {
-        val playlistHierarchy = DefaultPlaylistHierarchy()
+        val playlistHierarchy = wiredHierarchy()
 
         val pop = playlistHierarchy.createPlaylist("Pop")
         val fifties = playlistHierarchy.createPlaylistDirectory("50s").also { it.addPlaylist(pop) }
@@ -329,7 +338,7 @@ internal class DefaultPlaylistHierarchyTest : StringSpec({
     }
 
     "Throws Exception when creating playlists with an existing name" {
-        val playlistHierarchy = DefaultPlaylistHierarchy()
+        val playlistHierarchy = wiredHierarchy()
 
         playlistHierarchy.createPlaylistDirectory("New playlist")
         playlistHierarchy.size() shouldBe 1
@@ -344,7 +353,7 @@ internal class DefaultPlaylistHierarchyTest : StringSpec({
     }
 
     "Removing child playlist directly from one, does not remove them from the repository" {
-        val playlistHierarchy = DefaultPlaylistHierarchy()
+        val playlistHierarchy = wiredHierarchy()
 
         val fifties = playlistHierarchy.createPlaylistDirectory("50s")
         val rock = playlistHierarchy.createPlaylistDirectory("Rock")
@@ -385,7 +394,7 @@ internal class DefaultPlaylistHierarchyTest : StringSpec({
     }
 
     "Deleting playlist from the repository removes it from any parent one" {
-        val playlistHierarchy = DefaultPlaylistHierarchy()
+        val playlistHierarchy = wiredHierarchy()
 
         val rock = playlistHierarchy.createPlaylist("Rock")
         val fifties = playlistHierarchy.createPlaylistDirectory("50s")
@@ -404,7 +413,7 @@ internal class DefaultPlaylistHierarchyTest : StringSpec({
 
     "MutablePlaylistBase.name assignment throws WindowsPathException on Windows when name contains forbidden char" {
         OsDetector.withOverriddenIsWindows(false) {
-            DefaultPlaylistHierarchy().use { playlistHierarchy ->
+            wiredHierarchy().use { playlistHierarchy ->
                 val playlist = playlistHierarchy.createPlaylist("ok")
                 OsDetector.withOverriddenIsWindows(true) {
                     val beforeName = playlist.name
@@ -417,7 +426,7 @@ internal class DefaultPlaylistHierarchyTest : StringSpec({
 
     "MutablePlaylistBase.name assignment with forbidden chars on Linux succeeds (pass-through)" {
         OsDetector.withOverriddenIsWindows(false) {
-            DefaultPlaylistHierarchy().use { playlistHierarchy ->
+            wiredHierarchy().use { playlistHierarchy ->
                 val playlist = playlistHierarchy.createPlaylist("ok")
                 playlist.name = "bad|name"
                 playlist.name shouldBe "bad|name"

--- a/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/playlist/MutablePlaylistTest.kt
+++ b/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/playlist/MutablePlaylistTest.kt
@@ -43,7 +43,7 @@ internal class MutablePlaylistTest : StringSpec({
         val jsonFile = tempfile("mutablePlaylist-test", ".json").also { it.deleteOnExit() }
 
         jsonFileRepository = JsonFileRepository(jsonFile, AudioPlaylistMapSerializer)
-        playlistHierarchy = DefaultPlaylistHierarchy(jsonFileRepository)
+        playlistHierarchy = DefaultPlaylistHierarchy(jsonFileRepository).also { it.markDeleteSubscriberWired() }
     }
 
     afterEach {

--- a/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/playlist/TestPlaylistHierarchy.kt
+++ b/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/playlist/TestPlaylistHierarchy.kt
@@ -28,6 +28,9 @@ internal class TestPlaylistHierarchy(
     init {
         RegistryBase.deregisterRepository(MutableAudioPlaylist::class.java)
         RegistryBase.registerRepository(MutableAudioPlaylist::class.java, repository)
+        // Test double: mark as wired so the first-use subscription guard does not block
+        // tests that exercise base class behavior directly without wiring to an audio library.
+        markDeleteSubscriberWired()
     }
 
     override fun createPlaylist(name: String): MutableAudioPlaylist {

--- a/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/playlist/event/AudioPlaylistEventSubscriberTest.kt
+++ b/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/playlist/event/AudioPlaylistEventSubscriberTest.kt
@@ -4,6 +4,7 @@ import net.transgressoft.commons.music.audio.AudioItem
 import net.transgressoft.commons.music.playlist.DefaultPlaylistHierarchy
 import net.transgressoft.commons.music.playlist.MutableAudioPlaylist
 import net.transgressoft.commons.music.testing.reactiveScope
+import net.transgressoft.commons.music.testing.registryIsolation
 import net.transgressoft.lirp.event.CrudEvent
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.datatest.withData
@@ -17,11 +18,12 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 @ExperimentalCoroutinesApi
 internal class AudioPlaylistEventSubscriberTest : StringSpec({
 
+    registryIsolation()
     val reactive = reactiveScope()
     lateinit var hierarchy: DefaultPlaylistHierarchy
 
     beforeEach {
-        hierarchy = DefaultPlaylistHierarchy()
+        hierarchy = DefaultPlaylistHierarchy().also { it.markDeleteSubscriberWired() }
     }
 
     afterEach {

--- a/music-commons-fx/build.gradle
+++ b/music-commons-fx/build.gradle
@@ -79,6 +79,7 @@ dependencies {
     implementation libs.javafx.controls.get()
 
     testImplementation project(path: ':music-commons-fx-test')
+    testImplementation project(path: ':music-commons-persistence-fx')
     testImplementation(testFixtures(project(':music-commons-media')))
     testImplementation(platform(libs.junit.bom.get()))
     testImplementation(libs.junit.jupiter.get())

--- a/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/FXMusicLibrary.kt
+++ b/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/FXMusicLibrary.kt
@@ -45,9 +45,11 @@ import net.transgressoft.lirp.persistence.VolatileRepository
 import javafx.beans.property.ReadOnlyBooleanProperty
 import javafx.beans.property.ReadOnlyListProperty
 import javafx.beans.property.ReadOnlySetProperty
+import mu.withLoggingContext
 import java.nio.file.Path
 import java.util.Optional
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * JavaFX-compatible entry point for managing an observable audio library, playlist hierarchy,
@@ -69,7 +71,9 @@ class FXMusicLibrary private constructor(
     private val _audioLibrary: FXAudioLibrary,
     private val _playlistHierarchy: FXPlaylistHierarchy,
     private val _waveformRepository: AudioWaveformRepository<AudioWaveform, ObservableAudioItem>,
-    private val _metadataIO: AudioMetadataIO
+    private val _metadataIO: AudioMetadataIO,
+    /** Diagnostic label for this library instance, used in MDC logging context. */
+    val instanceName: String
 ) : MusicLibrary<ObservableAudioItem, ObservablePlaylist> {
 
     private val closed = AtomicBoolean(false)
@@ -95,7 +99,7 @@ class FXMusicLibrary private constructor(
         get() =
             synchronized(importLock) {
                 check(!closed.get()) { "This music library has been closed and can no longer be used." }
-                _itunesImport ?: ItunesImportService(this, _metadataIO).also { _itunesImport = it }
+                _itunesImport ?: ItunesImportService(this, _metadataIO, instanceName = instanceName).also { _itunesImport = it }
             }
 
     private var _m3uImport: M3uImportService<ObservableAudioItem, ObservablePlaylist>? = null
@@ -109,7 +113,7 @@ class FXMusicLibrary private constructor(
         get() =
             synchronized(importLock) {
                 check(!closed.get()) { "This music library has been closed and can no longer be used." }
-                _m3uImport ?: M3uImportService(this).also { _m3uImport = it }
+                _m3uImport ?: M3uImportService(this, instanceName = instanceName).also { _m3uImport = it }
             }
 
     /** Observable list of all audio items in the library, suitable for direct JavaFX binding. */
@@ -153,10 +157,11 @@ class FXMusicLibrary private constructor(
      * @param path the path to the audio file
      * @return the created [ObservableAudioItem]
      */
-    override fun audioItemFromFile(path: Path): ObservableAudioItem {
-        WindowsPathValidator.validatePath(path)
-        return _audioLibrary.createFromFile(path)
-    }
+    override fun audioItemFromFile(path: Path): ObservableAudioItem =
+        withLoggingContext("libraryInstance" to instanceName) {
+            WindowsPathValidator.validatePath(path)
+            _audioLibrary.createFromFile(path)
+        }
 
     override fun createPlaylist(name: String): ObservablePlaylist = _playlistHierarchy.createPlaylist(name)
 
@@ -214,6 +219,7 @@ class FXMusicLibrary private constructor(
         private var playlistRepository: Repository<Int, ObservablePlaylist> = VolatileRepository("FXPlaylistHierarchy")
         private var waveformRepository: Repository<Int, AudioWaveform> = VolatileRepository("FXWaveformRepository")
         private var metadataIO: AudioMetadataIO = JAudioTaggerMetadataIO()
+        private var instanceName: String? = null
 
         /**
          * Injects the [repository] backing the observable audio library.
@@ -261,8 +267,30 @@ class FXMusicLibrary private constructor(
          */
         fun metadataIO(utils: AudioMetadataIO): Builder = apply { metadataIO = utils }
 
+        /**
+         * Sets a human-readable diagnostic label for this library instance.
+         *
+         * The name is surfaced as the `libraryInstance` MDC key around library operations and
+         * import-service scopes, making logs attributable when multiple library instances are
+         * active across time (e.g., sequential open/close cycles or concurrent imports).
+         *
+         * When not set, a short stable default is auto-generated from a per-JVM monotonic
+         * counter (e.g., `music-library-1`, `music-library-2`). The name is the caller's
+         * responsibility when set explicitly — it is a diagnostic label, not a trust boundary.
+         *
+         * @param name the label to assign; must be non-blank
+         * @return this builder, for chaining
+         */
+        fun instanceName(name: String): Builder =
+            apply {
+                require(name.isNotBlank()) { "instanceName must be non-blank" }
+                instanceName = name
+            }
+
         /** Builds the [FXMusicLibrary], wiring all event subscriptions between components. */
         fun build(): FXMusicLibrary {
+            val resolvedName = instanceName ?: "fx-music-library-${instanceCounter.incrementAndGet()}"
+
             val audioLibrary = FXAudioLibrary(audioRepository, metadataIO)
             var playlistRepoRegistered = false
             var waveformRepo: AudioWaveformRepository<AudioWaveform, ObservableAudioItem>? = null
@@ -291,7 +319,7 @@ class FXMusicLibrary private constructor(
                 audioLibrary.subscribe(waveformRepo)
                 audioLibrary.subscribe(playlistHierarchy)
 
-                return FXMusicLibrary(audioLibrary, playlistHierarchy, waveformRepo, metadataIO)
+                return FXMusicLibrary(audioLibrary, playlistHierarchy, waveformRepo, metadataIO, resolvedName)
             } catch (ex: Exception) {
                 if (playlistRepoRegistered) {
                     conditionalDeregister(ObservablePlaylist::class.java, playlistRepository)
@@ -305,6 +333,8 @@ class FXMusicLibrary private constructor(
     }
 
     companion object {
+
+        private val instanceCounter = AtomicInteger(0)
 
         /**
          * Returns a new [Builder] for constructing an [FXMusicLibrary].

--- a/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/audio/FXAudioItem.kt
+++ b/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/audio/FXAudioItem.kt
@@ -144,7 +144,6 @@ class FXAudioItem
             get() =
                 buildString {
                     append(path.fileName.toString().replace(' ', '_'))
-                    append("-$title")
                     append("-${duration.toSeconds()}")
                     append("-$bitRate")
                 }

--- a/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/audio/FXAudioLibrary.kt
+++ b/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/audio/FXAudioLibrary.kt
@@ -175,12 +175,14 @@ internal class FXAudioLibrary
         init {
             guardedRegister(ObservableAudioItem::class.java, repository)
 
-            // Populate fxAggregateList from existing items
+            // Populate fxAggregateList from existing items. Wire metadataIO back-refs first so that
+            // any mutation event fired during the subscription pass (subscribeExistingItems) finds a
+            // non-null delegate on every rehydrated item.
             val initialAudioItems = toList()
-            // Wire the library back-ref on items rehydrated from JSON so coverImageBytes can lazy-load.
             initialAudioItems.forEach { item ->
                 if (item is FXAudioItem) item.metadataIO = metadataIO
             }
+            subscribeExistingItems()
             audioItemIds.addAll(initialAudioItems.map { it.id })
             if (initialAudioItems.isNotEmpty()) {
                 Platform.runLater {
@@ -359,6 +361,16 @@ internal class FXAudioLibrary
                 throw InvalidAudioFilePathException("File '${audioItemPath.toAbsolutePath()}' is not readable")
             }
             val metadata = metadataIO.readMetadata(audioItemPath)
+            // Dedup by physical identity: if an item with the same fileName-duration-bitRate key
+            // already exists, return it without allocating a new id or adding a duplicate.
+            val candidateUniqueId =
+                buildString {
+                    append(audioItemPath.fileName.toString().replace(' ', '_'))
+                    append("-${metadata.duration.toSeconds()}")
+                    append("-${metadata.bitRate}")
+                }
+            val existing = findByUniqueId(candidateUniqueId)
+            if (existing.isPresent) return existing.get() as FXAudioItem
             return FXAudioItem(audioItemPath, newId(), metadata).also { fxAudioItem ->
                 add(fxAudioItem)
                 logger.trace { "New ObservableAudioItem was created from file $audioItemPath with id ${fxAudioItem.id}" }
@@ -367,7 +379,16 @@ internal class FXAudioLibrary
 
         override fun add(entity: ObservableAudioItem): Boolean {
             checkOpen()
-            if (entity is FXAudioItem) entity.metadataIO = metadataIO
+            if (entity is FXAudioItem) {
+                val existingMetadataIO = entity.metadataIO
+                if (existingMetadataIO != null && existingMetadataIO !== metadataIO) {
+                    logger.warn {
+                        "Audio item ${entity.id} was created by a different library instance. " +
+                            "Re-wiring its metadata delegate to this library."
+                    }
+                }
+                entity.metadataIO = metadataIO
+            }
             return super.add(entity)
         }
 

--- a/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/playlist/FXPlaylistHierarchy.kt
+++ b/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/playlist/FXPlaylistHierarchy.kt
@@ -20,6 +20,7 @@ package net.transgressoft.commons.fx.music.playlist
 import net.transgressoft.commons.fx.music.audio.ObservableAudioItem
 import net.transgressoft.commons.fx.music.conditionalDeregister
 import net.transgressoft.commons.fx.music.guardedRegister
+import net.transgressoft.commons.music.audio.UNASSIGNED_ID
 import net.transgressoft.commons.music.playlist.PlaylistHierarchyBase
 import net.transgressoft.commons.music.playlist.event.AudioPlaylistEventSubscriber
 import net.transgressoft.lirp.entity.toIds
@@ -60,6 +61,14 @@ internal class FXPlaylistHierarchy(
     private val logger = KotlinLogging.logger {}
 
     override val playlistElementType = ObservablePlaylist::class
+
+    /**
+     * Module-internal test hook that clears the first-use delete-subscriber guard for standalone
+     * hierarchies constructed outside the library builder. Delegates to the base protected bridge.
+     */
+    internal fun markDeleteSubscriberWiredForTest() {
+        markDeleteSubscriberWiredForTesting()
+    }
 
     private val observablePlaylistsSet: ObservableSet<ObservablePlaylist> = FXCollections.observableSet()
 
@@ -141,6 +150,9 @@ internal class FXPlaylistHierarchy(
         audioItemIds: List<Int>
     ): ObservablePlaylist {
         require(findByName(name).isEmpty) { "Playlist with name '$name' already exists" }
+        require(audioItemIds.none { it == UNASSIGNED_ID }) {
+            "audioItemIds must not contain unassigned (zero) ids — resolve each audio item to a persisted id before adding it to a playlist"
+        }
         return FXPlaylist(newId(), name, false, audioItemIds).also {
             withLoggingContext("playlistId" to it.id.toString()) { logger.trace { "Created playlist $it" } }
             add(it)
@@ -159,7 +171,11 @@ internal class FXPlaylistHierarchy(
         audioItems: List<ObservableAudioItem>
     ): ObservablePlaylist {
         require(findByName(name).isEmpty) { "Playlist with name '$name' already exists" }
-        return FXPlaylist(newId(), name, true, audioItems.toIds()).also {
+        val audioItemIds = audioItems.toIds()
+        require(audioItemIds.none { it == UNASSIGNED_ID }) {
+            "audioItemIds must not contain unassigned (zero) ids — resolve each audio item to a persisted id before adding it to a playlist"
+        }
+        return FXPlaylist(newId(), name, true, audioItemIds).also {
             withLoggingContext("playlistId" to it.id.toString()) { logger.trace { "Created playlist $it" } }
             add(it)
             it.triggerCoverHydration()

--- a/music-commons-fx/src/test/kotlin/net/transgressoft/commons/fx/music/audio/CrossLibraryMatrixFXTest.kt
+++ b/music-commons-fx/src/test/kotlin/net/transgressoft/commons/fx/music/audio/CrossLibraryMatrixFXTest.kt
@@ -1,0 +1,254 @@
+/******************************************************************************
+ * Copyright (C) 2026  Octavio Calleya Garcia                                 *
+ *                                                                            *
+ * This program is free software: you can redistribute it and/or modify       *
+ * it under the terms of the GNU General Public License as published by       *
+ * the Free Software Foundation, either version 3 of the License, or          *
+ * (at your option) any later version.                                        *
+ *                                                                            *
+ * This program is distributed in the hope that it will be useful,            *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
+ * GNU General Public License for more details.                               *
+ *                                                                            *
+ * You should have received a copy of the GNU General Public License          *
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.     *
+ ******************************************************************************/
+
+package net.transgressoft.commons.fx.music.audio
+
+import net.transgressoft.commons.fx.music.FXMusicLibrary
+import net.transgressoft.commons.fx.music.TwoFXMusicLibraries
+import net.transgressoft.commons.fx.music.audio.ObservableAudioItem
+import net.transgressoft.commons.fx.music.buildTwoFXLibrariesWithoutClosing
+import net.transgressoft.commons.fx.music.eventuallyAfterFxEvents
+import net.transgressoft.commons.media.persistence.waveform.AudioWaveformMapSerializer
+import net.transgressoft.commons.music.audio.virtualFiles
+import net.transgressoft.commons.music.testing.reactiveScope
+import net.transgressoft.commons.music.testing.registryIsolation
+import net.transgressoft.commons.persistence.fx.music.audio.ObservableAudioItemMapSerializer
+import net.transgressoft.commons.persistence.fx.music.playlist.ObservablePlaylistMapSerializer
+import net.transgressoft.lirp.persistence.json.JsonFileRepository
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.engine.spec.tempfile
+import io.kotest.matchers.optional.shouldBePresent
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.property.arbitrary.next
+import org.testfx.api.FxToolkit
+import org.testfx.util.WaitForAsyncUtils
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.asExecutor
+
+/**
+ * JavaFX mirror of the Core cross-library matrix: exercises the same three axes (baseline,
+ * foreign-object, sequential-lifecycle) on [FXMusicLibrary] with [eventuallyAfterFxEvents]
+ * settling for observable-property assertions.
+ *
+ * All three axes are covered under the single-live-instance contract (Option B):
+ *
+ * - **Baseline row:** constructing a second live [FXMusicLibrary] while one is still live throws
+ *   [IllegalStateException], both via direct construction and via loading a JSON repository into
+ *   a new library while the first is alive.
+ * - **Foreign-object axis:** unlike Core's [MutableAudioItem] (which supports re-homing), an
+ *   [ObservableAudioItem]'s FX scalar delegates are single-bound at creation and cannot be re-bound
+ *   to a second library's registry. Attempting to add an A-origin FX item to B while B is live
+ *   throws [IllegalStateException]; B's library remains empty.
+ * - **Sequential-lifecycle axis:** building A, populating audio items, a playlist, and a waveform,
+ *   closing A, then building B against the same JSON repositories yields the same entity ids and the
+ *   same playlist and waveform associations — no silent corruption on the FX facade.
+ */
+@DisplayName("CrossLibraryMatrixFXTest")
+@ExperimentalCoroutinesApi
+internal class CrossLibraryMatrixFXTest : StringSpec({
+
+    registryIsolation()
+    val reactive = reactiveScope()
+    val files = virtualFiles()
+
+    lateinit var libraries: TwoFXMusicLibraries
+
+    beforeSpec {
+        FxToolkit.registerPrimaryStage()
+    }
+
+    afterSpec {
+        FxToolkit.cleanupStages()
+    }
+
+    beforeEach {
+        libraries = buildTwoFXLibrariesWithoutClosing(files.metadataIO)
+    }
+
+    afterEach {
+        libraries.close()
+    }
+
+    // --- Baseline row ---
+
+    "FXMusicLibrary baseline — second live construction throws IllegalStateException" {
+        shouldThrow<IllegalStateException> {
+            libraries.attemptSecondConstruction()
+        }
+    }
+
+    "FXMusicLibrary baseline — loading the same JSON repository while library A is live throws IllegalStateException" {
+        val audioFile = tempfile("crossFxBaseline-audio", ".json").also { it.deleteOnExit() }
+        val playlistsFile = tempfile("crossFxBaseline-playlists", ".json").also { it.deleteOnExit() }
+        val waveformsFile = tempfile("crossFxBaseline-waveforms", ".json").also { it.deleteOnExit() }
+
+        // Close the fixture library so this test owns the registry slot exclusively.
+        libraries.close()
+
+        val libraryA =
+            FXMusicLibrary.builder()
+                .metadataIO(files.metadataIO)
+                .audioRepository(JsonFileRepository(audioFile, ObservableAudioItemMapSerializer))
+                // loadOnInit=false: FXMusicLibrary.Builder.build() calls load() itself for playlist repos
+                .playlistRepository(JsonFileRepository(playlistsFile, ObservablePlaylistMapSerializer, loadOnInit = false))
+                .waveformRepository(JsonFileRepository(waveformsFile, AudioWaveformMapSerializer))
+                .build()
+
+        try {
+            shouldThrow<IllegalStateException> {
+                // A second live library — even wired to the same files — must be rejected because the
+                // registry slot is already occupied by libraryA.
+                FXMusicLibrary.builder()
+                    .metadataIO(files.metadataIO)
+                    .audioRepository(JsonFileRepository(audioFile, ObservableAudioItemMapSerializer))
+                    .playlistRepository(JsonFileRepository(playlistsFile, ObservablePlaylistMapSerializer, loadOnInit = false))
+                    .waveformRepository(JsonFileRepository(waveformsFile, AudioWaveformMapSerializer))
+                    .build()
+            }
+        } finally {
+            libraryA.close()
+        }
+    }
+
+    // --- Foreign-object axis ---
+
+    "FXMusicLibrary foreign-object — FX item created in A cannot be re-homed into B (FX delegates are single-bound)" {
+        // Close the fixture library; this test manages the library lifecycle explicitly.
+        libraries.close()
+
+        val libraryA = FXMusicLibrary.builder().metadataIO(files.metadataIO).build()
+        val itemA: ObservableAudioItem = libraryA.audioItemFromFile(files.virtualAudioFile().next())
+        reactive.advance()
+        WaitForAsyncUtils.waitForFxEvents()
+
+        libraryA.close()
+
+        // Unlike Core's MutableAudioItem (which supports re-homing), an ObservableAudioItem's
+        // FX scalar delegates are single-bound at creation and cannot be re-bound to a second
+        // library's registry. Attempting to add an A-origin FX item to B throws IllegalStateException.
+        val libraryB = FXMusicLibrary.builder().metadataIO(files.metadataIO).build()
+        try {
+            // The FX delegate binding fails and surfaces as IllegalStateException — the re-home
+            // is rejected before the item is fully registered.
+            shouldThrow<IllegalStateException> {
+                libraryB.audioLibrary().add(itemA)
+            }
+        } finally {
+            libraryB.close()
+        }
+    }
+
+    // --- Sequential-lifecycle axis ---
+
+    "FXMusicLibrary sequential-lifecycle — items, playlist, and waveform round-trip through close-reopen with identity contract" {
+        val audioFile = tempfile("crossFxSeq-audio", ".json").also { it.deleteOnExit() }
+        val playlistsFile = tempfile("crossFxSeq-playlists", ".json").also { it.deleteOnExit() }
+        val waveformsFile = tempfile("crossFxSeq-waveforms", ".json").also { it.deleteOnExit() }
+
+        // Close the fixture library so this test owns the registry slot exclusively.
+        libraries.close()
+
+        // Build A and populate it.
+        val libraryA =
+            FXMusicLibrary.builder()
+                .metadataIO(files.metadataIO)
+                .audioRepository(JsonFileRepository(audioFile, ObservableAudioItemMapSerializer))
+                // loadOnInit=false: FXMusicLibrary.Builder.build() calls load() itself for playlist repos
+                .playlistRepository(JsonFileRepository(playlistsFile, ObservablePlaylistMapSerializer, loadOnInit = false))
+                .waveformRepository(JsonFileRepository(waveformsFile, AudioWaveformMapSerializer))
+                .build()
+
+        val item1 = libraryA.audioItemFromFile(files.virtualAudioFile().next())
+        val item2 = libraryA.audioItemFromFile(files.virtualAudioFile().next())
+        reactive.advance()
+        WaitForAsyncUtils.waitForFxEvents()
+
+        val playlist = libraryA.createPlaylist("FX Sequential Playlist")
+        playlist.addAudioItem(item1)
+        reactive.advance()
+        WaitForAsyncUtils.waitForFxEvents()
+
+        val waveform = libraryA.waveformRepository().getOrCreateWaveformAsync(item1, 780, 335, reactive.dispatcher.asExecutor())
+        reactive.advance()
+        val waveformId = waveform.get().id
+        val waveformAudioFilePath = item1.path.fileName.toString()
+
+        // Capture identity before close.
+        val item1Id = item1.id
+        val item2Id = item2.id
+        val item1UniqueId = item1.uniqueId
+        val item2UniqueId = item2.uniqueId
+        val playlistId = playlist.id
+
+        libraryA.close()
+
+        // Build B against the same backing stores — sequential construction is permitted.
+        val libraryB =
+            FXMusicLibrary.builder()
+                .metadataIO(files.metadataIO)
+                .audioRepository(JsonFileRepository(audioFile, ObservableAudioItemMapSerializer))
+                // loadOnInit=false: FXMusicLibrary.Builder.build() calls load() itself for playlist repos
+                .playlistRepository(JsonFileRepository(playlistsFile, ObservablePlaylistMapSerializer, loadOnInit = false))
+                .waveformRepository(JsonFileRepository(waveformsFile, AudioWaveformMapSerializer))
+                .build()
+        reactive.advance()
+        WaitForAsyncUtils.waitForFxEvents()
+
+        try {
+            // Items resolve with the same ids and stable uniqueIds.
+            // The path changes from jimfs to the default filesystem on deserialization, but the
+            // physical-identity key (fileName-duration-bitRate) remains stable because only the
+            // path segment names participate, not the filesystem URI scheme.
+            libraryB.audioLibrary().findById(item1Id).shouldBePresent { loaded ->
+                loaded.id shouldBe item1Id
+                loaded.uniqueId shouldBe item1UniqueId
+            }
+            libraryB.audioLibrary().findById(item2Id).shouldBePresent { loaded ->
+                loaded.id shouldBe item2Id
+                loaded.uniqueId shouldBe item2UniqueId
+            }
+
+            // Items do NOT resolve to the wrong entity (no cross-resolution corruption).
+            libraryB.audioLibrary().findById(item1Id).shouldBePresent { it.uniqueId shouldNotBe item2UniqueId }
+            libraryB.audioLibrary().findById(item2Id).shouldBePresent { it.uniqueId shouldNotBe item1UniqueId }
+
+            // The observable property settles with both re-loaded items.
+            eventuallyAfterFxEvents(2.seconds) {
+                libraryB.audioItemsProperty.size shouldBe 2
+            }
+
+            // Playlist round-trips with same id.
+            libraryB.findPlaylistByName("FX Sequential Playlist").shouldBePresent { restoredPlaylist ->
+                restoredPlaylist.id shouldBe playlistId
+            }
+
+            // Waveform round-trips with the same id and its audio-file association is preserved.
+            libraryB.waveformRepository().findById(waveformId).shouldBePresent { restoredWaveform ->
+                restoredWaveform.id shouldBe waveformId
+                // The waveform links back to the audio file by its path's filename — stable across
+                // the jimfs-to-default-filesystem deserialization boundary.
+                restoredWaveform.audioFilePath.fileName.toString() shouldBe waveformAudioFilePath
+            }
+        } finally {
+            libraryB.close()
+        }
+    }
+})

--- a/music-commons-fx/src/test/kotlin/net/transgressoft/commons/fx/music/audio/FXAudioLibraryCloseRefreshTest.kt
+++ b/music-commons-fx/src/test/kotlin/net/transgressoft/commons/fx/music/audio/FXAudioLibraryCloseRefreshTest.kt
@@ -1,0 +1,112 @@
+/******************************************************************************
+ * Copyright (C) 2026  Octavio Calleya Garcia                                 *
+ *                                                                            *
+ * This program is free software: you can redistribute it and/or modify       *
+ * it under the terms of the GNU General Public License as published by       *
+ * the Free Software Foundation, either version 3 of the License, or          *
+ * (at your option) any later version.                                        *
+ *                                                                            *
+ * This program is distributed in the hope that it will be useful,            *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
+ * GNU General Public License for more details.                               *
+ *                                                                            *
+ * You should have received a copy of the GNU General Public License          *
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.     *
+ ******************************************************************************/
+
+package net.transgressoft.commons.fx.music.audio
+
+import net.transgressoft.commons.fx.music.FXMusicLibrary
+import net.transgressoft.commons.fx.music.eventuallyAfterFxEvents
+import net.transgressoft.commons.music.audio.virtualFiles
+import net.transgressoft.commons.music.testing.ReactiveScopeSerialization
+import net.transgressoft.commons.music.testing.registryIsolation
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.property.arbitrary.next
+import org.testfx.api.FxToolkit
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+
+/**
+ * Regression test for the closed-flag guard in [FXAudioLibrary]: queued
+ * `drainAudioItemChanges` and `refreshCatalogProperties` dispatches are no-ops after
+ * [FXMusicLibrary.close]. A freshly-constructed replacement library must expose only its own
+ * items — never stale items from a closed predecessor that fired a pending [Platform.runLater]
+ * after closure.
+ */
+@DisplayName("FXAudioLibrary close-refresh regression — queued refresh is no-op after close")
+@ExperimentalCoroutinesApi
+internal class FXAudioLibraryCloseRefreshTest : StringSpec({
+
+    registryIsolation()
+    extension(ReactiveScopeSerialization)
+    val files = virtualFiles()
+
+    beforeSpec {
+        FxToolkit.registerPrimaryStage()
+    }
+
+    afterSpec {
+        FxToolkit.cleanupStages()
+    }
+
+    "#13 queued audio-items refresh is a no-op after close: no stale items in a fresh library" {
+        // Add an item and then immediately close before the debounced refresh drains.
+        // The closed-flag guard (closed.get() inside Platform.runLater) must absorb the pending
+        // refresh so the observable collections are never mutated post-close.
+        val library = FXMusicLibrary.builder().metadataIO(files.metadataIO).build()
+        library.audioItemFromFile(files.virtualAudioFile().next())
+        // Close immediately — the debounced refresh may not have fired yet
+        library.close()
+
+        // A fresh library must see an empty audioItemsProperty:
+        // the closed predecessor's pending runLater must not inject any items into it.
+        val fresh = FXMusicLibrary.builder().metadataIO(files.metadataIO).build()
+        try {
+            eventuallyAfterFxEvents(2.seconds) {
+                fresh.audioItemsProperty.isEmpty() shouldBe true
+            }
+        } finally {
+            fresh.close()
+        }
+    }
+
+    "#13 queued catalog refresh is a no-op after close: no stale catalogs in a fresh library" {
+        val library = FXMusicLibrary.builder().metadataIO(files.metadataIO).build()
+        library.audioItemFromFile(files.virtualAudioFile().next())
+        library.close()
+
+        val fresh = FXMusicLibrary.builder().metadataIO(files.metadataIO).build()
+        try {
+            eventuallyAfterFxEvents(2.seconds) {
+                fresh.artistCatalogsProperty.isEmpty() shouldBe true
+            }
+        } finally {
+            fresh.close()
+        }
+    }
+
+    "#13 rapid create-close cycles leave no residue in the final library" {
+        repeat(5) {
+            val lib = FXMusicLibrary.builder().metadataIO(files.metadataIO).build()
+            lib.audioItemFromFile(files.virtualAudioFile().next())
+            eventuallyAfterFxEvents(500.milliseconds) {
+                lib.audioItemsProperty.isEmpty() shouldBe false
+            }
+            lib.close()
+        }
+
+        val last = FXMusicLibrary.builder().metadataIO(files.metadataIO).build()
+        try {
+            eventuallyAfterFxEvents(2.seconds) {
+                last.audioItemsProperty.isEmpty() shouldBe true
+            }
+        } finally {
+            last.close()
+        }
+    }
+})

--- a/music-commons-fx/src/test/kotlin/net/transgressoft/commons/fx/music/playlist/ObservablePlaylistHierarchyTest.kt
+++ b/music-commons-fx/src/test/kotlin/net/transgressoft/commons/fx/music/playlist/ObservablePlaylistHierarchyTest.kt
@@ -45,7 +45,7 @@ internal class ObservablePlaylistHierarchyTest : StringSpec({
 
     /** Runs [block] against a fresh [FXPlaylistHierarchy], closing it afterward (mirrors `.use`). */
     suspend fun withFxHierarchy(block: suspend (FXPlaylistHierarchy) -> Unit) {
-        val hierarchy = FXPlaylistHierarchy()
+        val hierarchy = FXPlaylistHierarchy().also { it.markDeleteSubscriberWiredForTest() }
         hierarchy.use { hierarchy ->
             block(hierarchy)
         }

--- a/music-commons-media/src/test/kotlin/net/transgressoft/commons/media/persistence/waveform/AudioWaveformSerializerRoundTripTest.kt
+++ b/music-commons-media/src/test/kotlin/net/transgressoft/commons/media/persistence/waveform/AudioWaveformSerializerRoundTripTest.kt
@@ -57,6 +57,7 @@ internal class AudioWaveformSerializerRoundTripTest : StringSpec({
 
         decodedWaveform.id shouldBe id
         decodedWaveform.audioFilePath shouldBe waveform.audioFilePath
+        decodedWaveform.uniqueId shouldBe waveform.uniqueId
 
         val reEncoded = json.encodeToString(AudioWaveformMapSerializer, mapOf(id to decodedWaveform))
         reEncoded shouldBe encoded

--- a/music-commons-persistence-fx/src/test/kotlin/net/transgressoft/commons/persistence/fx/music/audio/ObservableAudioItemSerializerRoundTripTest.kt
+++ b/music-commons-persistence-fx/src/test/kotlin/net/transgressoft/commons/persistence/fx/music/audio/ObservableAudioItemSerializerRoundTripTest.kt
@@ -88,6 +88,7 @@ internal class ObservableAudioItemSerializerRoundTripTest : StringSpec({
 
         assertSoftly {
             loaded.id shouldBe original.id
+            loaded.uniqueId shouldBe original.uniqueId
             loaded.path shouldBe original.path
             loaded.title shouldBe original.title
             loaded.duration shouldBe original.duration

--- a/music-commons-persistence/src/test/kotlin/net/transgressoft/commons/persistence/music/SqliteRoundTripSmokeTest.kt
+++ b/music-commons-persistence/src/test/kotlin/net/transgressoft/commons/persistence/music/SqliteRoundTripSmokeTest.kt
@@ -1,0 +1,122 @@
+/******************************************************************************
+ * Copyright (C) 2026  Octavio Calleya Garcia                                 *
+ *                                                                            *
+ * This program is free software: you can redistribute it and/or modify       *
+ * it under the terms of the GNU General Public License as published by       *
+ * the Free Software Foundation, either version 3 of the License, or          *
+ * (at your option) any later version.                                        *
+ *                                                                            *
+ * This program is distributed in the hope that it will be useful,            *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
+ * GNU General Public License for more details.                               *
+ *                                                                            *
+ * You should have received a copy of the GNU General Public License          *
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.     *
+ ******************************************************************************/
+
+package net.transgressoft.commons.persistence.music
+
+import net.transgressoft.commons.music.CoreMusicLibrary
+import net.transgressoft.commons.music.audio.ArbitraryAudioFile.realAudioFile
+import net.transgressoft.commons.music.audio.AudioFileTagType.ID3_V_24
+import net.transgressoft.commons.music.audio.AudioItem
+import net.transgressoft.commons.music.testing.reactiveScope
+import net.transgressoft.commons.music.testing.registryIsolation
+import net.transgressoft.commons.persistence.music.audio.AudioItemMapSerializer
+import net.transgressoft.commons.persistence.music.audio.MutableAudioItemSqlTableDef
+import net.transgressoft.commons.persistence.music.playlist.AudioPlaylistMapSerializer
+import net.transgressoft.commons.persistence.music.playlist.AudioPlaylistSqlTableDef
+import net.transgressoft.lirp.persistence.json.JsonFileRepository
+import net.transgressoft.lirp.persistence.sql.SqliteRepository
+import io.kotest.assertions.assertSoftly
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.next
+import java.io.File
+
+/**
+ * Focused smoke test confirming that the Core audio-item/playlist round-trip through a
+ * [SqliteRepository] preserves the id and [AudioItem.uniqueId] identity contract.
+ *
+ * This is a targeted smoke test, not a full field-fidelity matrix — detailed field coverage lives
+ * in [net.transgressoft.commons.persistence.music.audio.MutableAudioItemSqlTableDefTest] and
+ * [net.transgressoft.commons.persistence.music.playlist.AudioPlaylistSqlTableDefTest].
+ */
+@DisplayName("SQLite round-trip smoke test — id and uniqueId identity")
+internal class SqliteRoundTripSmokeTest : StringSpec({
+
+    registryIsolation()
+    val reactive = reactiveScope()
+
+    "SqliteRepository audio-item round-trip preserves id and uniqueId identity" {
+        val dbFile = File.createTempFile("smoke-audio-sql", ".db").apply { deleteOnExit() }
+        val playlistsFile = File.createTempFile("smoke-playlists-sql", ".json").apply { deleteOnExit() }
+
+        val library =
+            CoreMusicLibrary.builder()
+                .audioRepository(SqliteRepository.fileBacked(dbFile.toPath(), MutableAudioItemSqlTableDef))
+                .playlistRepository(JsonFileRepository(playlistsFile, AudioPlaylistMapSerializer))
+                .build()
+
+        val original = library.audioItemFromFile(Arb.realAudioFile(ID3_V_24).next())
+        val originalId = original.id
+        val originalUniqueId = original.uniqueId
+        reactive.advance()
+
+        library.close()
+
+        val reloaded =
+            CoreMusicLibrary.builder()
+                .audioRepository(SqliteRepository.fileBacked(dbFile.toPath(), MutableAudioItemSqlTableDef))
+                .playlistRepository(JsonFileRepository(playlistsFile, AudioPlaylistMapSerializer))
+                .build()
+
+        val loaded = reloaded.audioLibrary().findById(originalId).orElse(null)
+        loaded.shouldNotBeNull()
+        assertSoftly {
+            loaded.id shouldBe originalId
+            loaded.uniqueId shouldBe originalUniqueId
+        }
+
+        reloaded.close()
+    }
+
+    "SqliteRepository playlist round-trip preserves id and uniqueId identity" {
+        val audioFile = File.createTempFile("smoke-audio-json", ".json").apply { deleteOnExit() }
+        val dbFile = File.createTempFile("smoke-playlists-db", ".db").apply { deleteOnExit() }
+
+        val library =
+            CoreMusicLibrary.builder()
+                .audioRepository(JsonFileRepository(audioFile, AudioItemMapSerializer))
+                .playlistRepository(SqliteRepository.fileBacked(dbFile.toPath(), AudioPlaylistSqlTableDef))
+                .build()
+
+        val audioItem = library.audioItemFromFile(Arb.realAudioFile(ID3_V_24).next())
+        val playlist = library.createPlaylist("SmokeTest", listOf(audioItem))
+        val originalPlaylistId = playlist.id
+        val originalPlaylistUniqueId = playlist.uniqueId
+        reactive.advance()
+
+        library.close()
+
+        val reloaded =
+            CoreMusicLibrary.builder()
+                .audioRepository(JsonFileRepository(audioFile, AudioItemMapSerializer))
+                .playlistRepository(SqliteRepository.fileBacked(dbFile.toPath(), AudioPlaylistSqlTableDef))
+                .build()
+        reactive.advance()
+
+        val restoredPlaylist = reloaded.findPlaylistByName("SmokeTest").orElse(null)
+        restoredPlaylist.shouldNotBeNull()
+        assertSoftly {
+            restoredPlaylist.id shouldBe originalPlaylistId
+            restoredPlaylist.uniqueId shouldBe originalPlaylistUniqueId
+        }
+
+        reloaded.close()
+    }
+})

--- a/music-commons-persistence/src/test/kotlin/net/transgressoft/commons/persistence/music/audio/AudioItemSerializerRoundTripTest.kt
+++ b/music-commons-persistence/src/test/kotlin/net/transgressoft/commons/persistence/music/audio/AudioItemSerializerRoundTripTest.kt
@@ -85,6 +85,7 @@ internal class AudioItemSerializerRoundTripTest : StringSpec({
 
         assertSoftly {
             loaded.id shouldBe original.id
+            loaded.uniqueId shouldBe original.uniqueId
             loaded.path shouldBe original.path
             loaded.title shouldBe original.title
             loaded.duration shouldBe original.duration

--- a/music-commons-test/src/main/kotlin/net/transgressoft/commons/music/audio/AudioItemAssertions.kt
+++ b/music-commons-test/src/main/kotlin/net/transgressoft/commons/music/audio/AudioItemAssertions.kt
@@ -44,8 +44,6 @@ infix fun AudioItem.shouldMatch(attributes: AudioItemTestAttributes) {
             buildString {
                 append(path.fileName.toString().replace(' ', '_'))
                 append('-')
-                append(title)
-                append('-')
                 append(duration.toSeconds())
                 append('-')
                 append(bitRate)


### PR DESCRIPTION
Closes #201

## Summary

Hardens the library against corner cases and locks down documented behavior ahead of the 1.0 release, backed by a broad new test matrix. Verified end to end; the default test suite is green (878 tests, 0 failures) and the opt-in concurrency stress test passes.

## Changes

### Source hardening
- **Physical-identity `uniqueId`** — now `fileName` + duration (whole seconds) + bit rate, dropping the mutable title term, so re-tagging a file keeps its identity stable.
- **Bounded `newId()`** — the audio-library and playlist bases fail fast both when the id space is densely populated and when the `AtomicInteger` counter overflows `Int.MAX_VALUE` (previously it silently handed out negative ids).
- **Foreign-origin entities** log a warning and are re-wired on add.
- **Album cover reload** — the no-cover sentinel resets when a `SoftReference` cover is GC-evicted, so a later access can reload instead of returning `null` permanently.
- **Metadata-IO init window** closed structurally, before any catalog subscription can observe items.
- **Playlist guards** — `createPlaylist` rejects the unassigned id, and the audio-item delete subscriber is made non-bypassable via a first-use guard applied to every playlist mutation entry point.
- **Duplicate file-path policy** — adding the same physical file twice returns the existing item (dedup by `uniqueId`).
- **Per-library instance name** — an optional builder setter with an auto-generated stable default, surfaced as a `libraryInstance` logging MDC key across library operations and import-service scopes.

### Tests
- Cross-library operation matrix (Core + FX) over baseline, foreign-object, and sequential-lifecycle axes, exercised through the reactive base modules and the opt-in persistence-mapping modules.
- Subscriber-isolation test: a throwing `onNext` does not cancel peer subscribers.
- JSON round-trip across all three persistence-mapping modules plus a SQLite smoke test; a degenerate/empty-input sweep; regression tests pinning the source fixes and the post-close refresh no-op.
- Quarantined concurrent-import stress test (opt-in via `-PincludeStress=true`) asserting no lost or duplicate writes and no leaked scopes over a 10k-item in-memory corpus.

### Housekeeping
- Added the missing GPL license header to the iTunes import service.

## Testing

- `gradle compileKotlin compileTestKotlin ktlintCheck test` — green (878 tests, 0 failures).
- `gradle :music-commons-core:test -PincludeStress=true --tests "*ConcurrentImportStressTest*"` — passes (final repository size 10000, no duplicate ids, no leaked library reference).

## Notes

- The `uniqueId` string format changed (title term removed). Persistence keys entities by their integer repository id, not by `uniqueId`, so no stored-data migration is required; only consumers that parse or persist the raw `uniqueId` string are affected. Breaking changes to the public API are permitted in this pre-1.0 line.
