### PR TITLE
Fix FXAudioLibrary artist-catalog projection lost-update race

### DIFF
--- a/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/audio/FXAudioLibrary.kt
+++ b/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/audio/FXAudioLibrary.kt
@@ -258,14 +258,18 @@ internal class FXAudioLibrary
                 delay(FX_REFRESH_DEBOUNCE_MILLIS.milliseconds)
                 Platform.runLater {
                     if (closed.get()) return@runLater
-                    try {
-                        catalogRefreshRequested.set(false)
-                        refreshCatalogProperties()
-                    } finally {
-                        catalogRefreshQueued.set(false)
-                        if (catalogRefreshRequested.get()) {
-                            queueCatalogRefresh()
-                        }
+                    // Close the check-then-act gap that could otherwise drop a catalog update permanently
+                    // under concurrent producers on the multi-threaded reactive scope. Releasing the queued
+                    // gate before reading the backing set lets a producer that mutates during the reconcile
+                    // re-arm the debounce itself, and clearing the "work arrived" flag immediately before the
+                    // read (rather than at the start of the runnable) guarantees any producer that runs after
+                    // this point is caught by the post-reconcile re-check. Either path re-triggers a refresh,
+                    // so no producer's signal is consumed separately from the state it guards.
+                    catalogRefreshQueued.set(false)
+                    catalogRefreshRequested.set(false)
+                    refreshCatalogProperties()
+                    if (catalogRefreshRequested.get()) {
+                        queueCatalogRefresh()
                     }
                 }
             }
@@ -280,8 +284,13 @@ internal class FXAudioLibrary
             // per tick), but emits only the add/remove changes that actually occurred, so bound
             // ListView/TableView consumers do O(delta) work per tick and keep selection/scroll state.
             // That frees the FX thread for the catalog projections' own builds so they converge in time.
-            observableArtistCatalogSet.retainAll(artistCatalogBacking)
-            observableArtistCatalogSet.addAll(artistCatalogBacking)
+            //
+            // Read the backing set into a single snapshot so the retain and add reconcile against one
+            // consistent view. Reading it twice would let a concurrent producer mutate between the two
+            // operations, leaving the observable set transiently inconsistent with any single backing state.
+            val backingSnapshot = artistCatalogBacking.toSet()
+            observableArtistCatalogSet.retainAll(backingSnapshot)
+            observableArtistCatalogSet.addAll(backingSnapshot)
             syncOrderedList(observableAlbumList, observableAlbumRegistry.orderedValues())
             syncOrderedList(observableGenreIndexList, observableGenreIndexRegistry.orderedValues())
         }

--- a/music-commons-fx/src/test/kotlin/net/transgressoft/commons/fx/music/audio/FXAudioLibraryCatalogConvergenceTest.kt
+++ b/music-commons-fx/src/test/kotlin/net/transgressoft/commons/fx/music/audio/FXAudioLibraryCatalogConvergenceTest.kt
@@ -1,0 +1,118 @@
+/******************************************************************************
+ * Copyright (C) 2025  Octavio Calleya Garcia                                 *
+ *                                                                            *
+ * This program is free software: you can redistribute it and/or modify       *
+ * it under the terms of the GNU General Public License as published by       *
+ * the Free Software Foundation, either version 3 of the License, or          *
+ * (at your option) any later version.                                        *
+ *                                                                            *
+ * This program is distributed in the hope that it will be useful,            *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
+ * GNU General Public License for more details.                               *
+ *                                                                            *
+ * You should have received a copy of the GNU General Public License          *
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.     *
+ ******************************************************************************/
+
+package net.transgressoft.commons.fx.music.audio
+
+import net.transgressoft.commons.music.audio.AlbumDetails
+import net.transgressoft.commons.music.audio.Artist
+import net.transgressoft.commons.music.audio.virtualFiles
+import net.transgressoft.commons.music.testing.ReactiveScopeSerialization
+import net.transgressoft.commons.music.testing.registryIsolation
+import net.transgressoft.lirp.persistence.VolatileRepository
+import io.kotest.assertions.nondeterministic.eventually
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.property.arbitrary.next
+import org.testfx.api.FxToolkit
+import org.testfx.util.WaitForAsyncUtils
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+
+/**
+ * Convergence regression test for the JavaFX artist-catalog projection under a compilation-style,
+ * involved-artist-heavy import on the real reactive dispatcher.
+ *
+ * A shared "Various Artists" album artist is re-projected once per track, so its catalog is
+ * update-churned as many times as there are tracks, each churn producing a fresh, content-unequal
+ * `FXArtistCatalog`. Combined with the debounced `Platform.runLater` reconcile running against the
+ * production `Dispatchers.Default` scope, this is the scenario in which a lost catalog-refresh re-arm
+ * would leave `artistCatalogsProperty` permanently missing the final track(s) of the churned catalog.
+ *
+ * The spec keeps `ReactiveScope`'s production dispatchers via [ReactiveScopeSerialization] (rather
+ * than swapping in a deterministic test dispatcher, which would collapse producer and consumer onto
+ * one thread and hide the interleaving) and asserts that the public property converges to the same
+ * per-artist coverage as the registry projection.
+ */
+@ExperimentalCoroutinesApi
+internal class FXAudioLibraryCatalogConvergenceTest : StringSpec({
+
+    registryIsolation()
+    extension(ReactiveScopeSerialization)
+    val files = virtualFiles()
+
+    var nextId = 1
+
+    beforeSpec {
+        FxToolkit.registerPrimaryStage()
+    }
+
+    afterSpec {
+        FxToolkit.cleanupStages()
+    }
+
+    fun FXAudioLibrary.addItem(artist: Artist, album: AlbumDetails, trackTitle: String, track: Short): FXAudioItem {
+        val path =
+            files.virtualAudioFile {
+                this.artist = artist
+                this.album = album
+                title = trackTitle
+                trackNumber = track
+                discNumber = 1
+            }.next()
+        return FXAudioItemTestBridge.createFxAudioItem(path, nextId++, files.metadataIO).also { add(it) }
+    }
+
+    fun ObservableArtistCatalog.itemIds(): Set<Int> = albums.flatMap { it.tracks }.map { it.id }.toSet()
+
+    "artistCatalogsProperty converges to full per-artist coverage under a compilation-style involved-artist import" {
+        val trackCount = 40
+
+        repeat(6) { iteration ->
+            FXAudioLibrary(VolatileRepository("CatalogConvergenceFx-$iteration")).use { library ->
+                val variousArtists = Artist.of("Various Artists")
+                val compilation = AlbumDetails("Compilations", variousArtists)
+
+                // Each track has a distinct primary artist plus the shared "Various Artists" album artist,
+                // so every track lands in two catalogs and the shared catalog is churned once per track.
+                val expectedByArtist = linkedMapOf<Artist, MutableSet<Int>>()
+                for (index in 1..trackCount) {
+                    val trackArtist = Artist.of("Artist $index")
+                    val item = library.addItem(trackArtist, compilation, "Track $index", index.toShort())
+                    expectedByArtist.getOrPut(trackArtist) { mutableSetOf() }.add(item.id)
+                    expectedByArtist.getOrPut(variousArtists) { mutableSetOf() }.add(item.id)
+                }
+
+                eventually(5.seconds) {
+                    WaitForAsyncUtils.waitForFxEvents()
+
+                    val catalogs: Set<ObservableArtistCatalog> = library.artistCatalogsProperty
+                    val catalogsByArtist = catalogs.associateBy { it.artist }
+
+                    // The public property exposes exactly one catalog per involved artist...
+                    catalogsByArtist.keys shouldContainExactlyInAnyOrder expectedByArtist.keys
+
+                    expectedByArtist.forEach { (artist, expectedIds) ->
+                        // ...the churned "Various Artists" catalog is not left missing its last track(s)...
+                        catalogsByArtist.getValue(artist).itemIds() shouldContainExactlyInAnyOrder expectedIds
+                        // ...and the public property agrees with the registry projection.
+                        library.getArtistCatalog(artist).get().itemIds() shouldContainExactlyInAnyOrder expectedIds
+                    }
+                }
+            }
+        }
+    }
+})


### PR DESCRIPTION
Closes #195

## Problem

`FXAudioLibrary.queueCatalogRefresh()` coalesces artist-catalog updates into a debounced 16 ms `Platform.runLater` reconcile using two flags (`catalogRefreshRequested` / `catalogRefreshQueued`). The "work arrived" flag was cleared at the *start* of the reconcile runnable — separately from where `refreshCatalogProperties()` reads the `artistCatalogBacking` snapshot — while the `catalogRefreshQueued` gate was held for the entire reconcile.

Under the production multi-threaded reactive scope (`Dispatchers.Default.limitedParallelism(4)`), a producer that mutated the backing set and re-armed the debounce in that gap could have its re-arm swallowed: the post-reconcile re-check read a stale flag and scheduled no follow-up refresh. Because `FXArtistCatalog` equality is content-based, the public `artistCatalogsProperty` was then left holding a stale or absent catalog with nothing to repair it — a classic check-then-act lost update. It surfaced as intermittent non-convergence of the artist catalogs during large, involved-artist-heavy imports (e.g. a "Compilations" library), reliable on Linux but nondeterministic on Windows/macOS.

## Fix

`FXAudioLibrary.kt`

- `queueCatalogRefresh()` — close the check-then-act gap:
  - release the `catalogRefreshQueued` gate **first**, so a concurrent producer can re-arm the debounce itself (a second, independent re-arm path);
  - clear `catalogRefreshRequested` **immediately before** the backing read rather than at the start of the runnable;
  - re-check the flag **after** the reconcile so any producer that ran during the refresh re-triggers one.
  - The reconcile no longer wraps in try/finally: with the queued gate released up front the debounce can no longer wedge, matching the existing contract that these FX dispatches omit error handling.
- `refreshCatalogProperties()` — read the backing set into a single snapshot so the `retainAll`/`addAll` reconcile against one consistent view instead of two independent reads a concurrent producer can mutate between.

Both methods are private members of an internal class, so the public API surface is unchanged.

## Regression test

Adds `FXAudioLibraryCatalogConvergenceTest`, a convergence guard on the real reactive dispatcher (production `Dispatchers.Default`, not a collapsed test dispatcher). It imports a compilation-style, involved-artist-heavy set — a shared "Various Artists" album artist churned once per track — and asserts, per involved artist, that `artistCatalogsProperty` coverage equals the registry projection.

Note: the underlying failure is memory-model / scheduler dependent (reliable-passing on Linux, nondeterministic on Windows/macOS). The two-flag protocol is sequentially-consistent-safe, so this test cannot force a deterministic failure on Linux/x86 — it exercises the exact production dispatcher and worst-case scenario and guards the invariant on the Windows/macOS CI legs.

## Testing

- `gradle :music-commons-fx:compileTestKotlin` — success
- `gradle ktlintCheck` — success
- `gradle :music-commons-fx:test` (full module suite, including the new test) — success