### PR TITLE
#206 Build imported audio items with final metadata to avoid dropped artist catalogs

### DIFF
--- a/music-commons-api/api/music-commons-api.api
+++ b/music-commons-api/api/music-commons-api.api
@@ -3,6 +3,7 @@ public abstract interface annotation class net/transgressoft/commons/music/Music
 
 public abstract interface class net/transgressoft/commons/music/MusicLibrary : java/lang/AutoCloseable {
 	public abstract fun audioItemFromFile (Ljava/nio/file/Path;)Lnet/transgressoft/commons/music/audio/ReactiveAudioItem;
+	public abstract fun audioItemFromFile (Ljava/nio/file/Path;Lkotlin/jvm/functions/Function1;)Lnet/transgressoft/commons/music/audio/ReactiveAudioItem;
 	public abstract fun audioLibrary ()Lnet/transgressoft/commons/music/audio/ReactiveAudioLibrary;
 	public abstract fun createPlaylist (Ljava/lang/String;)Lnet/transgressoft/commons/music/playlist/ReactiveAudioPlaylist;
 	public abstract fun createPlaylistDirectory (Ljava/lang/String;)Lnet/transgressoft/commons/music/playlist/ReactiveAudioPlaylist;
@@ -2488,6 +2489,7 @@ public abstract interface class net/transgressoft/commons/music/audio/ReactiveAu
 	public abstract fun containsAudioItemWithGenre (Ljava/lang/String;)Z
 	public abstract fun createAudioItem (Lkotlin/jvm/functions/Function1;)Lnet/transgressoft/commons/music/audio/ReactiveAudioItem;
 	public abstract fun createFromFile (Ljava/nio/file/Path;)Lnet/transgressoft/commons/music/audio/ReactiveAudioItem;
+	public abstract fun createFromFile (Ljava/nio/file/Path;Lkotlin/jvm/functions/Function1;)Lnet/transgressoft/commons/music/audio/ReactiveAudioItem;
 	public fun createFromFileBatchAsync (Ljava/util/Collection;I)Ljava/util/concurrent/CompletableFuture;
 	public fun createFromFileBatchAsync (Ljava/util/Collection;Ljava/util/concurrent/Executor;I)Ljava/util/concurrent/CompletableFuture;
 	public fun createFromFileBatchAsync (Ljava/util/Collection;Lkotlinx/coroutines/CoroutineDispatcher;I)Ljava/util/concurrent/CompletableFuture;

--- a/music-commons-api/src/main/kotlin/net/transgressoft/commons/music/MusicLibrary.kt
+++ b/music-commons-api/src/main/kotlin/net/transgressoft/commons/music/MusicLibrary.kt
@@ -17,6 +17,7 @@
 
 package net.transgressoft.commons.music
 
+import net.transgressoft.commons.music.audio.AudioItemMetadata
 import net.transgressoft.commons.music.audio.ReactiveAudioItem
 import net.transgressoft.commons.music.audio.ReactiveAudioLibrary
 import net.transgressoft.commons.music.playlist.ReactiveAudioPlaylist
@@ -91,6 +92,24 @@ public interface MusicLibrary<I : ReactiveAudioItem<I>, P : ReactiveAudioPlaylis
      * @since 1.0
      */
     public fun audioItemFromFile(path: Path): I
+
+    /**
+     * Creates an audio item from the audio file at [path], transforming the metadata read from the
+     * file before the item is constructed, and adds it to the audio library in a single step.
+     *
+     * Importers that enrich file metadata from an external source use this so the item enters the
+     * library already carrying its final metadata, avoiding a register-then-update sequence. See
+     * [ReactiveAudioLibrary.createFromFile] for the transform semantics (applied only to newly
+     * constructed items; an already-present item with the same physical identity is returned
+     * unchanged).
+     *
+     * @param path the path to the audio file
+     * @param metadataTransform maps the metadata read from the file to the metadata the new item is
+     *   built with
+     * @return the created (or already-present) audio item
+     * @since 1.0
+     */
+    public fun audioItemFromFile(path: Path, metadataTransform: (AudioItemMetadata) -> AudioItemMetadata): I
 
     /**
      * Creates a new playlist with [name].

--- a/music-commons-api/src/main/kotlin/net/transgressoft/commons/music/audio/ReactiveAudioLibrary.kt
+++ b/music-commons-api/src/main/kotlin/net/transgressoft/commons/music/audio/ReactiveAudioLibrary.kt
@@ -86,6 +86,27 @@ public interface ReactiveAudioLibrary<
     public fun createFromFile(audioItemPath: Path): I
 
     /**
+     * Creates an audio item from the file at the specified path, transforming the metadata read from
+     * the file before the item is constructed.
+     *
+     * Unlike [createFromFile], the item is registered in a single step already carrying its final
+     * metadata — no post-registration mutation is required. Importers that enrich file metadata from
+     * an external source (for example iTunes) use this so the item enters the library complete: a
+     * register-then-update sequence would otherwise force grouped projections to re-key the entity
+     * while it is already live, and a projection reading the entity mid-update can miss a key.
+     *
+     * [metadataTransform] is applied only when a new item is constructed. When an item with the same
+     * physical identity already exists, it is returned unchanged and the transform is not applied.
+     *
+     * @param audioItemPath Path to the audio file
+     * @param metadataTransform maps the metadata read from the file to the metadata the new item is
+     *   built with
+     * @return The created audio item, or the already-present item with the same physical identity
+     * @since 1.0
+     */
+    public fun createFromFile(audioItemPath: Path, metadataTransform: (AudioItemMetadata) -> AudioItemMetadata): I
+
+    /**
      * Finds all audio items for a specific album by an artist.
      *
      * @param artist The artist to search for

--- a/music-commons-core/api/music-commons-core.api
+++ b/music-commons-core/api/music-commons-core.api
@@ -3,6 +3,8 @@ public final class net/transgressoft/commons/music/CoreMusicLibrary : net/transg
 	public synthetic fun <init> (Lnet/transgressoft/commons/music/audio/AudioLibrary;Lnet/transgressoft/commons/music/playlist/PlaylistHierarchy;Lnet/transgressoft/commons/music/waveform/AudioWaveformRepository;Lnet/transgressoft/commons/music/audio/AudioMetadataIO;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun audioItemFromFile (Ljava/nio/file/Path;)Lnet/transgressoft/commons/music/audio/AudioItem;
 	public synthetic fun audioItemFromFile (Ljava/nio/file/Path;)Lnet/transgressoft/commons/music/audio/ReactiveAudioItem;
+	public fun audioItemFromFile (Ljava/nio/file/Path;Lkotlin/jvm/functions/Function1;)Lnet/transgressoft/commons/music/audio/AudioItem;
+	public synthetic fun audioItemFromFile (Ljava/nio/file/Path;Lkotlin/jvm/functions/Function1;)Lnet/transgressoft/commons/music/audio/ReactiveAudioItem;
 	public fun audioLibrary ()Lnet/transgressoft/commons/music/audio/AudioLibrary;
 	public synthetic fun audioLibrary ()Lnet/transgressoft/commons/music/audio/ReactiveAudioLibrary;
 	public static final fun builder ()Lnet/transgressoft/commons/music/CoreMusicLibrary$Builder;

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/CoreMusicLibrary.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/CoreMusicLibrary.kt
@@ -21,6 +21,7 @@ import net.transgressoft.commons.media.waveform.audioWaveformRepository
 import net.transgressoft.commons.music.audio.Artist
 import net.transgressoft.commons.music.audio.ArtistCatalog
 import net.transgressoft.commons.music.audio.AudioItem
+import net.transgressoft.commons.music.audio.AudioItemMetadata
 import net.transgressoft.commons.music.audio.AudioLibrary
 import net.transgressoft.commons.music.audio.AudioMetadataIO
 import net.transgressoft.commons.music.audio.DefaultAudioLibrary
@@ -151,6 +152,12 @@ public class CoreMusicLibrary private constructor(
             // again, but failing here surfaces the exception before the audio item construction kicks off.
             WindowsPathValidator.validatePath(path)
             _audioLibrary.createFromFile(path)
+        }
+
+    override fun audioItemFromFile(path: Path, metadataTransform: (AudioItemMetadata) -> AudioItemMetadata): AudioItem =
+        withLoggingContext("libraryInstance" to instanceName) {
+            WindowsPathValidator.validatePath(path)
+            _audioLibrary.createFromFile(path, metadataTransform)
         }
 
     override fun createPlaylist(name: String): MutableAudioPlaylist = _playlistHierarchy.createPlaylist(name)

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/DefaultAudioLibrary.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/audio/DefaultAudioLibrary.kt
@@ -90,7 +90,9 @@ internal class DefaultAudioLibrary
             return super.add(entity)
         }
 
-        override fun createFromFile(audioItemPath: Path): AudioItem {
+        override fun createFromFile(audioItemPath: Path): AudioItem = createFromFile(audioItemPath) { it }
+
+        override fun createFromFile(audioItemPath: Path, metadataTransform: (AudioItemMetadata) -> AudioItemMetadata): AudioItem {
             if (!Files.exists(audioItemPath)) {
                 throw InvalidAudioFilePathException("File '${audioItemPath.toAbsolutePath()}' does not exist")
             }
@@ -102,7 +104,9 @@ internal class DefaultAudioLibrary
             }
             val tag = metadataIO.readMetadata(audioItemPath)
             // Dedup by physical identity: if an item with the same fileName-duration-bitRate key
-            // already exists, return it without allocating a new id or adding a duplicate.
+            // already exists, return it without allocating a new id or adding a duplicate. The key is
+            // derived from the raw file tag; metadataTransform only enriches user-facing fields, never
+            // the technical fields the identity is built from.
             val candidateUniqueId =
                 buildString {
                     append(audioItemPath.fileName.toString().replace(' ', '_'))
@@ -111,7 +115,7 @@ internal class DefaultAudioLibrary
                 }
             val existing = findByUniqueId(candidateUniqueId)
             if (existing.isPresent) return existing.get()
-            return MutableAudioItem(audioItemPath, newId(), tag).also { audioItem ->
+            return MutableAudioItem(audioItemPath, newId(), metadataTransform(tag)).also { audioItem ->
                 add(audioItem)
                 logger.trace { "New AudioItem was created from file $audioItemPath with id ${audioItem.id}" }
             }

--- a/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/itunes/ItunesImportService.kt
+++ b/music-commons-core/src/main/kotlin/net/transgressoft/commons/music/itunes/ItunesImportService.kt
@@ -20,6 +20,7 @@ package net.transgressoft.commons.music.itunes
 import net.transgressoft.commons.music.MusicLibrary
 import net.transgressoft.commons.music.audio.AlbumDetails
 import net.transgressoft.commons.music.audio.Artist
+import net.transgressoft.commons.music.audio.AudioItemMetadata
 import net.transgressoft.commons.music.audio.AudioMetadataIO
 import net.transgressoft.commons.music.audio.Genre
 import net.transgressoft.commons.music.audio.JAudioTaggerMetadataIO
@@ -207,11 +208,17 @@ public class ItunesImportService<I, P>
     }
 
     private fun importTrack(track: ItunesTrack, path: Path, policy: ItunesImportPolicy): I {
-        val audioItem = musicLibrary.audioItemFromFile(path)
-
-        if (!policy.useFileMetadata) {
-            applyItunesMetadata(audioItem, track)
-        }
+        // When enriching with iTunes metadata, build the item complete via the metadata transform so
+        // it is registered in a single step. A register-then-mutate sequence changes the item's
+        // involved-artist key set while it is already live in the library, forcing its grouped
+        // projections (artist catalogs) to re-key; a projection reading the entity mid-mutation can
+        // miss a title-derived artist and permanently drop that catalog.
+        val audioItem =
+            if (policy.useFileMetadata) {
+                musicLibrary.audioItemFromFile(path)
+            } else {
+                musicLibrary.audioItemFromFile(path, itunesMetadataTransform(track))
+            }
 
         if (policy.holdPlayCount && track.playCount > 0) {
             audioItem.setPlayCount(track.playCount)
@@ -224,17 +231,19 @@ public class ItunesImportService<I, P>
         return audioItem
     }
 
-    private fun applyItunesMetadata(audioItem: I, track: ItunesTrack) {
+    private fun itunesMetadataTransform(track: ItunesTrack): (AudioItemMetadata) -> AudioItemMetadata {
         val (artist, album, genres) = resolveItunesMetadata(track)
-        audioItem.mutate {
-            title = track.title
-            this.artist = artist
-            this.album = album
-            this.genres = genres
-            comments = track.comments
-            trackNumber = track.trackNumber
-            discNumber = track.discNumber
-            bpm = track.bpm
+        return { fileMetadata ->
+            fileMetadata.copy(
+                title = track.title,
+                artist = artist,
+                album = album,
+                genres = genres,
+                comments = track.comments,
+                trackNumber = track.trackNumber,
+                discNumber = track.discNumber,
+                bpm = track.bpm
+            )
         }
     }
 

--- a/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/audio/TestAudioLibrary.kt
+++ b/music-commons-core/src/test/kotlin/net/transgressoft/commons/music/audio/TestAudioLibrary.kt
@@ -20,10 +20,12 @@ internal class TestAudioLibrary(
         metadataIO
     ) {
 
-    override fun createFromFile(audioItemPath: Path): AudioItem {
+    override fun createFromFile(audioItemPath: Path): AudioItem = createFromFile(audioItemPath) { it }
+
+    override fun createFromFile(audioItemPath: Path, metadataTransform: (AudioItemMetadata) -> AudioItemMetadata): AudioItem {
         val tag = metadataIO.readMetadata(audioItemPath)
         val cover = metadataIO.loadCover(audioItemPath)
-        return MutableAudioItem(audioItemPath, newId(), tag.copy(coverBytes = cover)).also { add(it) }
+        return MutableAudioItem(audioItemPath, newId(), metadataTransform(tag.copy(coverBytes = cover))).also { add(it) }
     }
 
     /** Exposes the artist catalog registry for test assertions on post-close catalog state. */

--- a/music-commons-fx/api/music-commons-fx.api
+++ b/music-commons-fx/api/music-commons-fx.api
@@ -3,6 +3,8 @@ public final class net/transgressoft/commons/fx/music/FXMusicLibrary : net/trans
 	public synthetic fun <init> (Lnet/transgressoft/commons/fx/music/audio/FXAudioLibrary;Lnet/transgressoft/commons/fx/music/playlist/FXPlaylistHierarchy;Lnet/transgressoft/commons/music/waveform/AudioWaveformRepository;Lnet/transgressoft/commons/music/audio/AudioMetadataIO;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun audioItemFromFile (Ljava/nio/file/Path;)Lnet/transgressoft/commons/fx/music/audio/ObservableAudioItem;
 	public synthetic fun audioItemFromFile (Ljava/nio/file/Path;)Lnet/transgressoft/commons/music/audio/ReactiveAudioItem;
+	public fun audioItemFromFile (Ljava/nio/file/Path;Lkotlin/jvm/functions/Function1;)Lnet/transgressoft/commons/fx/music/audio/ObservableAudioItem;
+	public synthetic fun audioItemFromFile (Ljava/nio/file/Path;Lkotlin/jvm/functions/Function1;)Lnet/transgressoft/commons/music/audio/ReactiveAudioItem;
 	public fun audioLibrary ()Lnet/transgressoft/commons/fx/music/audio/ObservableAudioLibrary;
 	public synthetic fun audioLibrary ()Lnet/transgressoft/commons/music/audio/ReactiveAudioLibrary;
 	public static final fun builder ()Lnet/transgressoft/commons/fx/music/FXMusicLibrary$Builder;

--- a/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/FXMusicLibrary.kt
+++ b/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/FXMusicLibrary.kt
@@ -29,6 +29,7 @@ import net.transgressoft.commons.fx.music.playlist.ObservablePlaylistHierarchy
 import net.transgressoft.commons.media.waveform.audioWaveformRepository
 import net.transgressoft.commons.music.MusicLibrary
 import net.transgressoft.commons.music.audio.Artist
+import net.transgressoft.commons.music.audio.AudioItemMetadata
 import net.transgressoft.commons.music.audio.AudioMetadataIO
 import net.transgressoft.commons.music.audio.JAudioTaggerMetadataIO
 import net.transgressoft.commons.music.audio.event.AudioItemEventSubscriber
@@ -224,6 +225,12 @@ public class FXMusicLibrary private constructor(
         withLoggingContext("libraryInstance" to instanceName) {
             WindowsPathValidator.validatePath(path)
             _audioLibrary.createFromFile(path)
+        }
+
+    override fun audioItemFromFile(path: Path, metadataTransform: (AudioItemMetadata) -> AudioItemMetadata): ObservableAudioItem =
+        withLoggingContext("libraryInstance" to instanceName) {
+            WindowsPathValidator.validatePath(path)
+            _audioLibrary.createFromFile(path, metadataTransform)
         }
 
     override fun createPlaylist(name: String): ObservablePlaylist = _playlistHierarchy.createPlaylist(name)

--- a/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/audio/FXAudioItem.kt
+++ b/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/audio/FXAudioItem.kt
@@ -445,8 +445,12 @@ public class FXAudioItem
                 getArtistsNamesInvolved(
                     title, artist.name, album.albumArtist.name
                 ).map { Artist.of(it) }.toSet()
-            artistsInvolvedProperty.clear()
+            // Add-before-remove: populate the new artists first, then drop the stale ones, so a
+            // concurrent reader (e.g. a grouped projection re-keying off this set) never observes the
+            // set momentarily missing an artist it still involves. A clear()+addAll() would expose an
+            // empty window, from which such a reader can drop a still-valid catalog key.
             artistsInvolvedProperty.addAll(involved)
+            artistsInvolvedProperty.retainAll(involved)
         }
 
         override fun setPlayCount(count: Short) {

--- a/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/audio/FXAudioLibrary.kt
+++ b/music-commons-fx/src/main/kotlin/net/transgressoft/commons/fx/music/audio/FXAudioLibrary.kt
@@ -19,6 +19,7 @@ package net.transgressoft.commons.fx.music.audio
 
 import net.transgressoft.commons.fx.music.conditionalDeregister
 import net.transgressoft.commons.fx.music.guardedRegister
+import net.transgressoft.commons.music.audio.AudioItemMetadata
 import net.transgressoft.commons.music.audio.AudioLibraryBase
 import net.transgressoft.commons.music.audio.AudioMetadataIO
 import net.transgressoft.commons.music.audio.JAudioTaggerMetadataIO
@@ -358,7 +359,9 @@ internal class FXAudioLibrary
             queueCatalogRefresh()
         }
 
-        override fun createFromFile(audioItemPath: Path): FXAudioItem {
+        override fun createFromFile(audioItemPath: Path): FXAudioItem = createFromFile(audioItemPath) { it }
+
+        override fun createFromFile(audioItemPath: Path, metadataTransform: (AudioItemMetadata) -> AudioItemMetadata): FXAudioItem {
             checkOpen()
             if (!Files.exists(audioItemPath)) {
                 throw InvalidAudioFilePathException("File '${audioItemPath.toAbsolutePath()}' does not exist")
@@ -371,7 +374,9 @@ internal class FXAudioLibrary
             }
             val metadata = metadataIO.readMetadata(audioItemPath)
             // Dedup by physical identity: if an item with the same fileName-duration-bitRate key
-            // already exists, return it without allocating a new id or adding a duplicate.
+            // already exists, return it without allocating a new id or adding a duplicate. The key is
+            // derived from the raw file tag; metadataTransform only enriches user-facing fields, never
+            // the technical fields the identity is built from.
             val candidateUniqueId =
                 buildString {
                     append(audioItemPath.fileName.toString().replace(' ', '_'))
@@ -380,7 +385,7 @@ internal class FXAudioLibrary
                 }
             val existing = findByUniqueId(candidateUniqueId)
             if (existing.isPresent) return existing.get() as FXAudioItem
-            return FXAudioItem(audioItemPath, newId(), metadata).also { fxAudioItem ->
+            return FXAudioItem(audioItemPath, newId(), metadataTransform(metadata)).also { fxAudioItem ->
                 add(fxAudioItem)
                 logger.trace { "New ObservableAudioItem was created from file $audioItemPath with id ${fxAudioItem.id}" }
             }

--- a/music-commons-fx/src/test/kotlin/net/transgressoft/commons/fx/music/audio/FXAudioLibraryCatalogConvergenceTest.kt
+++ b/music-commons-fx/src/test/kotlin/net/transgressoft/commons/fx/music/audio/FXAudioLibraryCatalogConvergenceTest.kt
@@ -25,7 +25,9 @@ import net.transgressoft.commons.music.testing.registryIsolation
 import net.transgressoft.lirp.persistence.VolatileRepository
 import io.kotest.assertions.nondeterministic.eventually
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.optional.shouldBePresent
 import io.kotest.property.arbitrary.next
 import org.testfx.api.FxToolkit
 import org.testfx.util.WaitForAsyncUtils
@@ -110,6 +112,84 @@ internal class FXAudioLibraryCatalogConvergenceTest : StringSpec({
                         catalogsByArtist.getValue(artist).itemIds() shouldContainExactlyInAnyOrder expectedIds
                         // ...and the public property agrees with the registry projection.
                         library.getArtistCatalog(artist).get().itemIds() shouldContainExactlyInAnyOrder expectedIds
+                    }
+                }
+            }
+        }
+    }
+
+    "getArtistCatalog resolves an artist that appears only as a title-parsed guest" {
+        FXAudioLibrary(VolatileRepository("TitleGuestFx")).use { library ->
+            val primary = Artist.of("Primary One")
+            val album = AlbumDetails("Solo Album", primary)
+            val guest = Artist.of("Guest Deejay")
+
+            val item = library.addItem(primary, album, "Night Drive feat Guest Deejay", 1)
+
+            // The guest is parsed only from the title and is nobody's primary or album artist. Since the
+            // registry keys every artist in artistsInvolved, the guest must expose a retrievable catalog.
+            item.artistsInvolved shouldContain guest
+
+            eventually(5.seconds) {
+                WaitForAsyncUtils.waitForFxEvents()
+                library.getArtistCatalog(guest).shouldBePresent { it.itemIds() shouldContainExactlyInAnyOrder setOf(item.id) }
+            }
+        }
+    }
+
+    "getArtistCatalog resolves every title-parsed guest under a compilation-style import at scale" {
+        val trackCount = 80
+
+        repeat(4) { iteration ->
+            FXAudioLibrary(VolatileRepository("TitleGuestScaleFx-$iteration")).use { library ->
+                val variousArtists = Artist.of("Various Artists")
+                val compilation = AlbumDetails("Compilations", variousArtists)
+
+                // Each track has a distinct primary artist, the shared (churned) "Various Artists" album
+                // artist, and a unique guest that appears only in the title. Every guest must resolve.
+                val expectedGuestIds = linkedMapOf<Artist, Int>()
+                for (index in 1..trackCount) {
+                    val primary = Artist.of("Primary $index")
+                    val guest = Artist.of("Guest $index")
+                    val item = library.addItem(primary, compilation, "Song $index feat Guest $index", index.toShort())
+                    expectedGuestIds[guest] = item.id
+                }
+
+                eventually(10.seconds) {
+                    WaitForAsyncUtils.waitForFxEvents()
+                    expectedGuestIds.forEach { (guest, id) ->
+                        library.getArtistCatalog(guest).shouldBePresent { it.itemIds() shouldContain id }
+                    }
+                }
+            }
+        }
+    }
+
+    "getArtistCatalog resolves every title-guest introduced by mutating in-repository items at scale" {
+        val trackCount = 120
+
+        repeat(4) { iteration ->
+            FXAudioLibrary(VolatileRepository("TitleGuestMutateScaleFx-$iteration")).use { library ->
+                val variousArtists = Artist.of("Various Artists")
+                val compilation = AlbumDetails("Compilations", variousArtists)
+
+                // Mirror the iTunes import: add each item with a plain title (from its file tag), then
+                // mutate it in place to apply the richer metadata whose title introduces a unique guest.
+                // The shared "Various Artists" album artist is churned once per mutation.
+                val expectedGuestIds = linkedMapOf<Artist, Int>()
+                val items = mutableListOf<FXAudioItem>()
+                for (index in 1..trackCount) {
+                    val primary = Artist.of("Primary $index")
+                    val item = library.addItem(primary, compilation, "Song $index", index.toShort())
+                    items += item
+                    expectedGuestIds[Artist.of("Guest ${item.id}")] = item.id
+                }
+                items.forEach { item -> item.mutate { title = "Song ${item.id} feat Guest ${item.id}" } }
+
+                eventually(10.seconds) {
+                    WaitForAsyncUtils.waitForFxEvents()
+                    expectedGuestIds.forEach { (guest, id) ->
+                        library.getArtistCatalog(guest).shouldBePresent { it.itemIds() shouldContain id }
                     }
                 }
             }

--- a/music-commons-persistence-fx/src/test/kotlin/net/transgressoft/commons/persistence/fx/music/audio/FXArtistCatalogSqliteConvergenceTest.kt
+++ b/music-commons-persistence-fx/src/test/kotlin/net/transgressoft/commons/persistence/fx/music/audio/FXArtistCatalogSqliteConvergenceTest.kt
@@ -1,0 +1,113 @@
+/******************************************************************************
+ * Copyright (C) 2026  Octavio Calleya Garcia                                 *
+ *                                                                            *
+ * This program is free software: you can redistribute it and/or modify       *
+ * it under the terms of the GNU General Public License as published by       *
+ * the Free Software Foundation, either version 3 of the License, or          *
+ * (at your option) any later version.                                        *
+ *                                                                            *
+ * This program is distributed in the hope that it will be useful,            *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
+ * GNU General Public License for more details.                               *
+ *                                                                            *
+ * You should have received a copy of the GNU General Public License          *
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.     *
+ ******************************************************************************/
+
+package net.transgressoft.commons.persistence.fx.music.audio
+
+import net.transgressoft.commons.fx.music.FXMusicLibrary
+import net.transgressoft.commons.fx.music.audio.ObservableArtistCatalog
+import net.transgressoft.commons.music.audio.AlbumDetails
+import net.transgressoft.commons.music.audio.Artist
+import net.transgressoft.commons.music.audio.Artist.Companion.of
+import net.transgressoft.commons.music.audio.virtualFiles
+import net.transgressoft.commons.music.testing.ReactiveScopeSerialization
+import net.transgressoft.lirp.persistence.sql.SqliteRepository
+import io.kotest.assertions.nondeterministic.eventually
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.optional.shouldBePresent
+import io.kotest.property.arbitrary.next
+import org.testfx.api.FxToolkit
+import org.testfx.util.WaitForAsyncUtils
+import java.io.File
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+
+/**
+ * Convergence regression for the SQLite-backed JavaFX artist-catalog projection under the iTunes
+ * import's add-then-mutate flow.
+ *
+ * The import adds each item to the repository from its file tag and only afterward mutates it in
+ * place with the richer metadata whose title contributes additional involved artists. On the
+ * SQLite-backed repository, under the production reactive dispatcher, the re-keying update stream
+ * must not drop the newly involved artists: every artist an item ends up involved with — including
+ * one that exists only in the mutated title — must expose a retrievable catalog.
+ */
+@ExperimentalCoroutinesApi
+internal class FXArtistCatalogSqliteConvergenceTest : StringSpec({
+
+    extension(ReactiveScopeSerialization)
+    val files = virtualFiles()
+
+    beforeSpec {
+        FxToolkit.registerPrimaryStage()
+    }
+
+    afterSpec {
+        FxToolkit.cleanupStages()
+    }
+
+    fun ObservableArtistCatalog.itemIds(): Set<Int> = albums.flatMap { it.tracks }.map { it.id }.toSet()
+
+    "getArtistCatalog resolves every title-guest after an add-then-mutate SQLite import at scale" {
+        val trackCount = 120
+        val dbFile = File.createTempFile("fxArtistCatalogSql", ".db").apply { deleteOnExit() }
+
+        val library =
+            FXMusicLibrary.builder()
+                .audioRepository(SqliteRepository.fileBacked(dbFile.toPath(), FXAudioItemSqlTableDef))
+                .metadataIO(files.metadataIO)
+                .build()
+        val repository = library.audioLibrary()
+        try {
+            val variousArtists = of("Various Artists")
+            val compilation = AlbumDetails("Compilations", variousArtists)
+
+            val expectedGuestIds = linkedMapOf<Artist, Int>()
+            for (index in 1..trackCount) {
+                val path =
+                    files.virtualAudioFile {
+                        this.artist = of("Primary $index")
+                        this.album = compilation
+                        title = "Song $index"
+                        trackNumber = index.toShort()
+                        discNumber = 1
+                    }.next()
+                // Add from the plain-title file, then mutate in place to introduce a unique title-only
+                // guest, exactly as the iTunes import applies its metadata after the initial add.
+                val item = repository.createFromFile(path)
+                // Mirror applyItunesMetadata: title, artist and album are all set within one mutate, so
+                // each setter re-runs syncArtistsInvolved (clear + repopulate) and the projection must
+                // absorb several key-set churns per item before settling on the final involved set.
+                item.mutate {
+                    title = "Song ${item.id} feat Guest ${item.id}"
+                    artist = of("Primary ${item.id}")
+                    album = compilation
+                }
+                expectedGuestIds[of("Guest ${item.id}")] = item.id
+            }
+
+            eventually(15.seconds) {
+                WaitForAsyncUtils.waitForFxEvents()
+                expectedGuestIds.forEach { (guest, id) ->
+                    repository.getArtistCatalog(guest).shouldBePresent { it.itemIds() shouldContain id }
+                }
+            }
+        } finally {
+            library.close()
+        }
+    }
+})


### PR DESCRIPTION
Fixes #206.

## Problem

After importing a large, involved-artist-heavy iTunes library, artists that appear **only** inside a track's title (featured / remix credits) have no retrievable artist catalog — `getArtistCatalog(artist)` and `getArtistCatalog(name)` both return empty — even though the repository still contains items with that artist in their `artistsInvolved` set. Primary and album artists converge correctly; only title-only guest artists are dropped.

## Root cause

`ItunesImportService` created each item via `audioItemFromFile(path)` (which reads the file tag and **registers the item immediately**) and then mutated it in place to apply the iTunes metadata. Setting the title changes the item's `artistsInvolved` key set while it is already live in the library, forcing the artist-catalog projection to re-key the entity. The projection extracts keys from the live, shared entity at event-processing time, so a read that races the in-place mutation can observe a transient involved-artist set and permanently drop the bucket for an artist introduced by the new title.

## Change

- Add a `metadataTransform` seam to `ReactiveAudioLibrary.createFromFile(path, transform)` and `MusicLibrary.audioItemFromFile(path, transform)`. The transform is applied to the metadata read from the file when a **new** item is constructed, so the item is registered complete in a single step; an already-present item with the same physical identity is returned unchanged.
- `ItunesImportService` now enriches file metadata through this transform instead of registering-then-mutating, eliminating the post-registration re-key.
- Harden `FXAudioItem.syncArtistsInvolved()` to update its involved-artist set **add-before-remove** (instead of `clear()` + `addAll()`), so a concurrent reader never observes the set momentarily missing an artist it still involves.

## Testing

- New JavaFX and SQLite-backed convergence tests assert `getArtistCatalog` resolves every involved artist — including one that exists only in a title-parsed guest credit — under compilation-style, add-then-mutate imports at scale.
- Existing iTunes import, concurrent-import stress, and M3U import suites pass unchanged.
- Verified end-to-end against the downstream Musicott compilations import, which now passes with a strict per-involved-artist catalog assertion restored.

## Notes

- Public API additions; `.api` dumps updated.
- Minor behavior refinement: re-importing an already-present file no longer overwrites its stored metadata from the external source (the transform seeds construction only). No test relied on the previous overwrite behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)